### PR TITLE
Alternative subtract_intervals function optimized for scalability

### DIFF
--- a/TraceLens/TreePerf/gpu_event_analyser.py
+++ b/TraceLens/TreePerf/gpu_event_analyser.py
@@ -26,40 +26,35 @@ class GPUEventAnalyser:
                 merged.append((start, end))
         return merged
 
-    @staticmethod
-    def subtract_intervals(interval, intervals_to_subtract):
-        """
-        Subtract a list of intervals (assumed non-overlapping and sorted) from a given interval.
-        Returns a list of intervals (as (start, end) tuples) that represent the parts of 'interval'
-        not covered by any of the intervals_to_subtract.
-        """
-        result = []
-        current_start, current_end = interval
-        for sub_start, sub_end in intervals_to_subtract:
-            # Skip if there is no overlap.
-            if sub_end <= current_start or sub_start >= current_end:
-                continue
-            # Add gap before the subtracting interval if any.
-            if sub_start > current_start:
-                result.append((current_start, sub_start))
-            current_start = max(current_start, sub_end)
-            if current_start >= current_end:
-                break
-        if current_start < current_end:
-            result.append((current_start, current_end))
-        return result
 
     @staticmethod
-    def subtract_intervalsA_from_B(merged_intervalA, merged_intervalB):
-        """
-        Subtract a set of non-overlapping, sorted intervals from another set of non-overlapping, sorted intervals.
-        Returns a list of intervals (as (start, end) tuples) that represent the parts of 'merged_intervalB'
+    def subtract_intervalsA_from_B(intervals_to_subtract, intervals):
+        """Subtract set of intervals from another set of intervals.
+
+        Intervals in sets are expected to be non-overlapping and sorted.
+
+        Returns a list of intervals as (start, end) tuples.
         """
         result = []
-        for b_interval in merged_intervalB:
-            # Subtract the entire set of merged_A from the current interval b_interval.
-            remaining_parts = GPUEventAnalyser.subtract_intervals(b_interval, merged_intervalA)
-            result.extend(remaining_parts)
+        a_idx = 0
+        a_len = len(intervals_to_subtract)
+
+        for b_start, b_end in intervals:
+            current = b_start
+            while a_idx < a_len and intervals_to_subtract[a_idx][1] <= b_start:
+                a_idx += 1
+
+            temp_idx = a_idx
+            while temp_idx < a_len and intervals_to_subtract[temp_idx][0] < b_end:
+                a_start, a_end = intervals_to_subtract[temp_idx]
+                if a_start > current:
+                    result.append((current, min(b_end, a_start)))
+                current = max(current, a_end)
+                if current >= b_end:
+                    break
+                temp_idx += 1
+            if current < b_end:
+                result.append((current, b_end))
 
         return result
 

--- a/tests/test_subtract_intervals.py
+++ b/tests/test_subtract_intervals.py
@@ -1,0 +1,109 @@
+from TraceLens.TreePerf import GPUEventAnalyser as GPUEA
+
+
+def test_empty_intervals_to_subtract():
+    intervals = [(10, 20)]
+    intervals_to_subtract = []
+    expected_result = [(10, 20)]
+
+    result = GPUEA.subtract_intervalsA_from_B(intervals_to_subtract, intervals)
+    assert result == expected_result
+
+
+def test_subtract_from_empty_intervals():
+    intervals = []
+    intervals_to_subtract = [(5, 15)]
+    expected_result = []
+
+    result = GPUEA.subtract_intervalsA_from_B(intervals_to_subtract, intervals)
+    assert result == expected_result
+
+
+def test_subtract_empty_from_empty():
+    intervals = []
+    intervals_to_subtract = []
+    expected_result = []
+
+    result = GPUEA.subtract_intervalsA_from_B(intervals_to_subtract, intervals)
+    assert result == expected_result
+
+
+def test_one_interval_to_subtract():
+    intervals = [(10, 20)]
+    intervals_to_subtract = [(15, 16)]
+    expected_result = [(10, 15), (16, 20)]
+
+    result = GPUEA.subtract_intervalsA_from_B(intervals_to_subtract, intervals)
+    assert result == expected_result
+
+
+def test_two_intervals_to_subtract():
+    intervals = [(10, 20)]
+    intervals_to_subtract = [(15, 16), (17, 18)]
+    expected_result = [(10, 15), (16, 17), (18, 20)]
+
+    result = GPUEA.subtract_intervalsA_from_B(intervals_to_subtract, intervals)
+    assert result == expected_result
+
+
+def test_consecutive_intervals():
+    intervals = [(10, 20)]
+    intervals_to_subtract = [(15, 16), (16, 18)]
+    expected_result = [(10, 15), (18, 20)]
+
+    result = GPUEA.subtract_intervalsA_from_B(intervals_to_subtract, intervals)
+    assert result == expected_result
+
+
+def test_subtraction_before_interval():
+    intervals = [(10, 20)]
+    intervals_to_subtract = [(9, 12)]
+    expected_result = [(12, 20)]
+
+    result = GPUEA.subtract_intervalsA_from_B(intervals_to_subtract, intervals)
+    assert result == expected_result
+
+
+def test_subtraction_after_interval():
+    intervals = [(10, 20)]
+    intervals_to_subtract = [(15, 22)]
+    expected_result = [(10, 15)]
+
+    result = GPUEA.subtract_intervalsA_from_B(intervals_to_subtract, intervals)
+    assert result == expected_result
+
+
+def test_overlapping_subtraction():
+    intervals = [(10, 20)]
+    intervals_to_subtract = [(15, 17), (16, 18)]
+    expected_result = [(10, 15), (18, 20)]
+
+    result = GPUEA.subtract_intervalsA_from_B(intervals_to_subtract, intervals)
+    assert result == expected_result
+
+
+def test_perfectly_overlapping_subtraction():
+    intervals = [(10, 20)]
+    intervals_to_subtract = [(10, 20)]
+    expected_result = []
+
+    result = GPUEA.subtract_intervalsA_from_B(intervals_to_subtract, intervals)
+    assert result == expected_result
+
+
+def test_subtracting_long_interval():
+    intervals = [(10, 20)]
+    intervals_to_subtract = [(0, 30)]
+    expected_result = []
+
+    result = GPUEA.subtract_intervalsA_from_B(intervals_to_subtract, intervals)
+    assert result == expected_result
+
+
+def test_subtracting_from_two_intervals():
+    intervals = [(10, 20), (30, 40)]
+    intervals_to_subtract = [(15, 35)]
+    expected_result = [(10, 15), (35, 40)]
+
+    result = GPUEA.subtract_intervalsA_from_B(intervals_to_subtract, intervals)
+    assert result == expected_result


### PR DESCRIPTION
With trace files about 2 GB in size building the GPU timeline with "generate_perf_report.py" becomes slow (20 mins or longer). This PR adds an alternative function with unit tests than scales better to large file sizes.

## Performance

With Stagingv0.3 "25f44cf86139ee192e0a7efd7565e9ae02b0490e":

```
$ python test_intervals_perf.py 10000 10000
Performance Test Results:
  Intervals to subtract (A): 10000
  Intervals (B): 10000
  Iterations: 5
  Total time: 9.125103 seconds
  Average time per iteration: 1.825021 seconds

$ python test_intervals_perf.py 100000 100000
Performance Test Results:
  Intervals to subtract (A): 100000
  Intervals (B): 100000
  Iterations: 5
  Total time: 1084.892391 seconds
  Average time per iteration: 216.978478 seconds
```

With this PR:

```
$ python test_intervals_perf.py 10000 10000
Performance Test Results:
  Intervals to subtract (A): 10000
  Intervals (B): 10000
  Iterations: 5
  Total time: 0.015661 seconds
  Average time per iteration: 0.003132 seconds

$ python test_intervals_perf.py 100000 100000
Performance Test Results:
  Intervals to subtract (A): 100000
  Intervals (B): 100000
  Iterations: 5
  Total time: 0.237157 seconds
  Average time per iteration: 0.047431 seconds

$ python test_intervals_perf.py 1000000 1000000
Performance Test Results:
  Intervals to subtract (A): 1000000
  Intervals (B): 1000000
  Iterations: 5
  Total time: 1.476847 seconds
  Average time per iteration: 0.295369 seconds
```

## Script to test performance

```python
import argparse
from time import perf_counter

from TraceLens.TreePerf.gpu_event_analyser import GPUEventAnalyser as GPUEA


def generate_intervals(num, start=0, gap=10, length=5):
    """Generates n non-overlapping, sorted intervals."""
    intervals = []
    current = start
    for _ in range(num):
        intervals.append((current, current + length))
        current += gap
    return intervals


def test_performance(num_to_subtract, num_intervals, iterations=5):
    """Test the performance of subtract_intervalsA_from_B()."""

    intervals_to_subtract = generate_intervals(
        num_to_subtract, start=0, gap=10, length=5
    )
    intervals = generate_intervals(num_intervals, start=0, gap=20, length=10)

    start_time = perf_counter()
    for _ in range(iterations):
        _ = GPUEA.subtract_intervalsA_from_B(intervals_to_subtract, intervals)
    end_time = perf_counter()

    total_time = end_time - start_time
    avg_time = total_time / iterations
    print("Performance Test Results:")
    print(f"  Intervals to subtract (A): {num_to_subtract}")
    print(f"  Intervals (B): {num_intervals}")
    print(f"  Iterations: {iterations}")
    print(f"  Total time: {total_time:.6f} seconds")
    print(f"  Average time per iteration: {avg_time:.6f} seconds")


if __name__ == "__main__":
    parser = argparse.ArgumentParser(
        description="Test performance of subtract_intervalsA_from_B function."
    )
    parser.add_argument(
        "num_to_subtract",
        type=int,
        help="Number of intervals in the set to subtract (A intervals).",
    )
    parser.add_argument(
        "num_intervals",
        type=int,
        help="Number of intervals in the main set (B intervals).",
    )
    args = parser.parse_args()

    test_performance(args.num_to_subtract, args.num_intervals)
```

## Running unit tests

In the project root directory run:
```bash
pytest tests
```