### PR TITLE
only include linked kernels in gpu timeline

### DIFF
--- a/TraceLens/TreePerf/tree_perf.py
+++ b/TraceLens/TreePerf/tree_perf.py
@@ -358,7 +358,7 @@ class TreePerfAnalyzer:
         return df_agg
 
     def get_df_gpu_timeline(self):
-        kernel_events =  [event for event in self.tree.events if event.get('cat') in {'kernel', 'gpu_memcpy', 'gpu_memset'}]
+        kernel_events =  [event for event in self.tree.events if event.get('cat') in {'kernel', 'gpu_memcpy', 'gpu_memset'} and event.get('tree')]
         gpu_event_analyser = GPUEventAnalyser(kernel_events)
         df = gpu_event_analyser.get_breakdown_df()
         return df


### PR DESCRIPTION
Only include linked kernels in the GPU timeline df.
Context: profiles sometimes contain kernels (gpu events) from previous steps, which are not linked to host ops. It is better to exclude these from the gpu timeline df as its not part of the "tree"