### PR TITLE
Add script to filter trace to range of given user annotation

### DIFF
--- a/examples/custom_workflows/filter_trace.py
+++ b/examples/custom_workflows/filter_trace.py
@@ -38,7 +38,7 @@ def find_user_annotation(event_iter: Iterable[dict[str, Any]], user_annotation_n
     return None
 
 def find_user_annotation_in_trace_file(json_file: Path, user_annotation_name: str) -> Optional[dict[str, Any]]:
-    with gzip.open(json_file, 'rt') if json_file.suffix == ".gz" else open(json_file, "rb") as f:
+    with gzip.open(json_file, 'rt') if json_file.suffix == ".gz" else open(json_file, "r", encoding="UTF-8") as f:
         return find_user_annotation(ijson.items(f, "traceEvents.item"), user_annotation_name=user_annotation_name)
 
 def filter_trace_events_to_range(events: Iterable[dict[str, Any]], start: Decimal, end: Decimal) -> list[dict[str, Any]]:


### PR DESCRIPTION
A common pattern is to use the PyTorch profiler like so:
```
x = torch.randn((1, 1), requires_grad=True)
with torch.autograd.profiler.profile() as prof:
    y = x ** 2
    with torch.autograd.profiler.record_function("label-z"): # label the block
        z = y ** 3
```
The labels can indicate regions of interest, e.g., particular stages of model inference or training. It is often interesting to analyze such labeled sections independently rather than in the context of the entire profile trace.

This PR provides a standalone script where a user can filter their trace file first to a specific label and then proceed with TraceLens analysis on the filtered file instead.

A related feature was requested in #90 to add analysis of labeled regions to TraceLens. This PR does _not_ provide that functionality, as it seems to require quite a bit more work and modifying the internals.