### PR TITLE
NCCLAnalyzer: add missing allgather_into_tensor_coalesced collective name

### DIFF
--- a/TraceLens/NcclAnalyser/nccl_analyser.py
+++ b/TraceLens/NcclAnalyser/nccl_analyser.py
@@ -53,7 +53,7 @@ class NcclAnalyser:
         self.collective_type2name = {
             'allreduce':     ['allreduce', 'allreduce_coalesced'],
             'reducescatter': ['reducescatter', '_reduce_scatter_base', 'reduce_scatter_tensor_coalesced'],
-            'allgather':     ['allgather', 'all_gather', '_allgather_base', 'all_gather_into_tensor_coalesced'],
+            'allgather':     ['allgather', 'all_gather', '_allgather_base', 'all_gather_into_tensor_coalesced', 'allgather_into_tensor_coalesced'],
             'alltoall':      ['all_to_all'],
             'alltoallv':     ['all_to_allv'],
         }


### PR DESCRIPTION
While analyzing the Flux-1 dev model communication, NCCLAnalyzer was crashing with the following backtrace:
```
Traceback (most recent call last):
  File "/home/miklauri@amd.com/sandbox/TraceLens/examples/custom_workflows/generate_perf_report.py", line 259, in <module>
    main()
  File "/home/miklauri@amd.com/sandbox/TraceLens/examples/custom_workflows/generate_perf_report.py", line 256, in main
    analyze_traces(args.b, args.p, args.e, args.f, args.r, args.d, args.a, args.o)
  File "/home/miklauri@amd.com/sandbox/TraceLens/examples/custom_workflows/generate_perf_report.py", line 225, in analyze_traces
    nccl_analyser.build_df_summary_nccl_implicit_sync_cat(agg_metrics=["mean"]).to_excel(writer, sheet_name="summary_nccl_implicit_sync_cat", index=False)
  File "/home/miklauri@amd.com/sandbox/TraceLens/TraceLens/NcclAnalyser/nccl_analyser.py", line 255, in build_df_summary_nccl_implicit_sync_cat
    self.df_implicit_sync_cat = self.build_df_nccl_implicit_sync_cat()
  File "/home/miklauri@amd.com/sandbox/TraceLens/TraceLens/NcclAnalyser/nccl_analyser.py", line 240, in build_df_nccl_implicit_sync_cat
    df = df[ordered_cols]
  File "/home/miklauri@amd.com/sandbox/TraceLens/.venv/lib/python3.10/site-packages/pandas/core/frame.py", line 4108, in __getitem__
    indexer = self.columns._get_indexer_strict(key, "columns")[1]
  File "/home/miklauri@amd.com/sandbox/TraceLens/.venv/lib/python3.10/site-packages/pandas/core/indexes/base.py", line 6200, in _get_indexer_strict
    self._raise_if_missing(keyarr, indexer, axis_name)
  File "/home/miklauri@amd.com/sandbox/TraceLens/.venv/lib/python3.10/site-packages/pandas/core/indexes/base.py", line 6249, in _raise_if_missing
    raise KeyError(f"None of [{key}] are in the [{axis_name}]")
KeyError: "None of [Index(['collective_id', 'Process Group Name', 'Process Group Ranks',\n       'Collective name', 'Group size', 'dtype', 'In msg nelems',\n       'Out msg nelems', 'In msg size (MB)', 'Out msg size (MB)',\n       'Full msg size (MB)', 'comm_latency', 'skew in start time',\n       'earliest arrival rank', 'avg_wait_time', 'skew in end time',\n       'algo bw (GB/s)', 'bus bw (GB/s)'],\n      dtype='object')] are in the [columns]"
```


The reason is an empty dataframe, due to mismatch in collective names. The Flux-1 dev model uses collectives with a name `allgather_into_tensor_coalesced`, whereas NCCLAnalyzer only recognizes `all_gather_into_tensor_coalesced` (note, with extra underscore).

This PR adds the collective name without the underscore.