### PR TITLE
add flash_attn::_flash_attn_forward

### DIFF
--- a/TraceLens/PerfModel/torch_op_mapping.py
+++ b/TraceLens/PerfModel/torch_op_mapping.py
@@ -40,6 +40,7 @@ op_to_perf_model_class_map = {
     'tex_ts::te_gemm_ts': perf_model.tex_ts_te_gemm_ts,
     'aten::baddbmm': perf_model.aten_baddbmm,
     'FlashAttnFunc': perf_model.flash_attention,
+    'flash_attn::_flash_attn_forward': perf_model.flash_attention,
     'aten::_scaled_dot_product_cudnn_attention': perf_model.aten__scaled_dot_product_cudnn_attention,
     'aten::_scaled_dot_product_efficient_attention': perf_model.aten__scaled_dot_product_efficient_attention,
     'aten::convolution': perf_model.aten_conv,


### PR DESCRIPTION
`flash_attn::_flash_attn_forward` appears as FA op in some models. This PR adds it to `torch_op_mapping.py`.