### PR TITLE
Added Perf Model for FAv3 (fwd only)

### DIFF
--- a/TraceLens/PerfModel/perf_model.py
+++ b/TraceLens/PerfModel/perf_model.py
@@ -1371,6 +1371,22 @@ class aiter__flash_attn_backward(SDPA):
     def bytes(self, bytes_per_element=2):
         return self.bytes_bwd(bytes_per_element)
 
+class flash_attn_v3_forward(SDPA):
+    
+    @staticmethod
+    def get_param_details(event):
+        input_dims = event['args']['Input Dims']
+        concrete_inputs = event['args']['Concrete Inputs']
+        q_shape, k_shape, v_shape = input_dims[0], input_dims[1], input_dims[2]
+        bhnd_idx = 0, 2, 1, 3
+        sdpa_cfg = extract_sdpa_cfg(q_shape, k_shape, v_shape, bhnd_idx)
+        B, N_Q, H_Q, N_KV, H_KV, d_h_qk, d_h_v = (sdpa_cfg[key] for key in ['B', 'N_Q', 'H_Q', 'N_KV', 'H_KV', 'd_h_qk', 'd_h_v'])
+        dropout_p = 0.0 # dropout currently not implemented
+        is_causal = concrete_inputs[24].lower() == 'true' if concrete_inputs[24] not in ('', 'None') else False
+
+        return {"B": B, "N_Q": N_Q, "H_Q": H_Q, "N_KV": N_KV, "H_KV": H_KV, "d_h_qk": d_h_qk, "d_h_v": d_h_v,
+                "dropout": dropout_p, "causal": is_causal, "flash_impl": True}
+
 class aiter__fmha_v3_forward(SDPA):
     
     @staticmethod

--- a/TraceLens/PerfModel/torch_op_mapping.py
+++ b/TraceLens/PerfModel/torch_op_mapping.py
@@ -49,6 +49,7 @@ op_to_perf_model_class_map = {
     "aiter::_flash_attn_backward": perf_model.aiter__flash_attn_backward,
     "aiter::wrapper_fmha_v3_fwd": perf_model.aiter__fmha_v3_forward,
     "aiter::wrapper_fmha_v3_bwd": perf_model.aiter__fmha_v3_backward,
+    "flash_attn_3::fwd": perf_model.flash_attn_v3_forward,
 }
 
 unary_elemwise_ops = [


### PR DESCRIPTION
Added perf model for [Hopper FAv3](https://github.com/Dao-AILab/flash-attention/blob/main/hopper/flash_attn_interface.py#L507-L568) for only the forward operator. 

(Closes #276)