### PR TITLE
Add support for trtllm::cublas_scaled_mm

### DIFF
--- a/TraceLens/PerfModel/perf_model.py
+++ b/TraceLens/PerfModel/perf_model.py
@@ -345,9 +345,9 @@ class aten_addmm(GEMM):
     def bytes_bwd(self, bytes_per_element):
         raise NotImplementedError("Backward pass for aten::addmm is not defined.")
 
-class aten_scaled_mm(GEMM):
+class ScaledMM(GEMM):
     """
-    aten::scaled_mm is the scale_result(scale_a*A.matmul(scale_b*B) + bias)
+    Common scaled_mm is the scale_result(scale_a*A.matmul(scale_b*B) + bias)
     """
     @staticmethod
     def get_param_details(event):
@@ -378,7 +378,7 @@ class aten_scaled_mm(GEMM):
             f"Data types of A and B are not supported: {dtype_A_B}"
         if bpeA != bpeB:
             # raise ValueError(f"Data types of A and B are different: {dtype_A_B}")
-            warnings.warn(f"Data sizes of A and B are different: {dtype_A_B} for aten_scaled_mm. ")
+            warnings.warn(f"Data sizes of A and B are different: {dtype_A_B} for scaled_mm. ")
         self.bpe = bpeA  # or bpeB, they are the same
         # assumption:
         # for fp8 the output dtype is fp16
@@ -394,9 +394,21 @@ class aten_scaled_mm(GEMM):
                              bpe_output=out_bpe)
 
     def flops_bwd(self):
-        raise NotImplementedError("Backward pass for aten::addmm is not defined.")
+        raise NotImplementedError("Backward pass for scaled_mm is not defined.")
     def bytes_bwd(self, bytes_per_element):
-        raise NotImplementedError("Backward pass for aten::addmm is not defined.")
+        raise NotImplementedError("Backward pass for scaled_mm is not defined.")
+
+class aten_scaled_mm(ScaledMM):
+    """
+    aten::_scaled_mm — uses ScaledMM semantics.
+    """
+    pass
+
+class trtllm_cublas_scaled_mm(ScaledMM):
+    """
+    trtllm::cublas_scaled_mm — uses ScaledMM semantics.
+    """
+    pass
 
 class aten_bmm(GEMM):
     """

--- a/TraceLens/PerfModel/torch_op_mapping.py
+++ b/TraceLens/PerfModel/torch_op_mapping.py
@@ -27,6 +27,7 @@ op_to_perf_model_class_map = {
     'aten::mm': perf_model.aten_mm,
     'aten::addmm': perf_model.aten_addmm,
     'aten::_scaled_mm': perf_model.aten_scaled_mm,
+    'trtllm::cublas_scaled_mm': perf_model.trtllm_cublas_scaled_mm,
 
     # TEv2 pseudo ops
     '_Linear_yfwd_mm': perf_model.tev2_pseudo_gemm,
@@ -77,6 +78,7 @@ for op in binary_elemwise_ops:
 
 dict_base_class2category = {
     perf_model.GEMM: 'GEMM',
+    perf_model.ScaledMM: 'GEMM',
     perf_model.CONV: 'CONV',
     perf_model.SDPA: 'SDPA',
     perf_model.UnaryElementwise: 'UnaryElementwise',


### PR DESCRIPTION
TRT-LLM’s trtllm::cublas_scaled_mm was not appearing under GEMMs in ops_summary_by_category nor in the GEMM tab. This PR introduces a GEMM-derived ScaledMM base and maps both aten::_scaled_mm and trtllm::cublas_scaled_mm to it, preserving GEMM classification while keeping identical FLOPs/bytes semantics.

Here are screenshots (left - before commit, right - after commit):

<img width="2495" height="755" alt="tracelens-trtllm-scaledmm-GEMM" src="https://github.com/user-attachments/assets/aa83ca14-de44-4911-827d-bde4cfe60629" />
<img width="2495" height="750" alt="tracelens-trtllm-scaledmm-ops_summary_by_category" src="https://github.com/user-attachments/assets/ceed5290-1730-4112-ad37-da8c3fbe6e5e" />
