### PR TITLE
add logging levels

### DIFF
--- a/TraceLens/Reporting/generate_perf_report_jax.py
+++ b/TraceLens/Reporting/generate_perf_report_jax.py
@@ -2,6 +2,13 @@ import argparse, os, sys
 import json
 from pathlib import Path
 import pandas as pd
+import logging
+
+# Configure basic logging to stdout with DEBUG level
+logging.basicConfig(stream=sys.stdout, # Output to console
+                    level=logging.DEBUG, # Set the minimum log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
+                    format='[%(asctime)s] {%(filename)s:%(lineno)d} %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
 
 from TraceLens.PerfModel import jax_op_mapping
 from TraceLens.TreePerf import TreePerfAnalyzer, JaxTreePerfAnalyzer

--- a/TraceLens/Reporting/generate_perf_report_jax.py
+++ b/TraceLens/Reporting/generate_perf_report_jax.py
@@ -8,7 +8,6 @@ import logging
 logging.basicConfig(stream=sys.stdout, # Output to console
                     level=logging.DEBUG, # Set the minimum log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
                     format='[%(asctime)s] {%(filename)s:%(lineno)d} %(levelname)s - %(message)s')
-logger = logging.getLogger(__name__)
 
 from TraceLens.PerfModel import jax_op_mapping
 from TraceLens.TreePerf import TreePerfAnalyzer, JaxTreePerfAnalyzer

--- a/TraceLens/Trace2Tree/trace_to_tree.py
+++ b/TraceLens/Trace2Tree/trace_to_tree.py
@@ -29,6 +29,8 @@ from ..util import TraceEventUtils, JaxProfileProcessor
 
 
 from abc import ABC, abstractmethod
+import logging
+logger = logging.getLogger(__name__)
 
 class BaseTraceToTree(ABC):
     def __init__(self, events_data,
@@ -483,8 +485,8 @@ class JaxTraceToTree(BaseTraceToTree):
                                     if (hlo_module in self.hlo_ops.keys()) and (hlo_op in self.hlo_ops.get(hlo_module).keys()):
                                         GPU_event['metadata'] = self.hlo_ops.get(hlo_module).get(hlo_op)
                                     else:
-                                        print('Missing hlo_op: ', hlo_op)
-                                        print('in hlo_module: ', GPU_event['args']['hlo_module'])
+                                        logger.warning(f'Missing hlo_op: {hlo_op}')
+                                        logger.warning(f'in hlo_module: {GPU_event['args']['hlo_module']}')
 
 class TraceToTree:
     def __init__(self, events_data,

--- a/TraceLens/Trace2Tree/trace_to_tree.py
+++ b/TraceLens/Trace2Tree/trace_to_tree.py
@@ -485,8 +485,8 @@ class JaxTraceToTree(BaseTraceToTree):
                                     if (hlo_module in self.hlo_ops.keys()) and (hlo_op in self.hlo_ops.get(hlo_module).keys()):
                                         GPU_event['metadata'] = self.hlo_ops.get(hlo_module).get(hlo_op)
                                     else:
-                                        logger.warning(f'Missing hlo_op: {hlo_op}')
-                                        logger.warning(f'in hlo_module: {GPU_event['args']['hlo_module']}')
+                                        logger.warning(f"Missing hlo_op: {hlo_op}")
+                                        logger.warning(f"in hlo_module: {GPU_event['args']['hlo_module']}")
 
 class TraceToTree:
     def __init__(self, events_data,

--- a/TraceLens/TreePerf/gpu_event_analyser.py
+++ b/TraceLens/TreePerf/gpu_event_analyser.py
@@ -282,7 +282,6 @@ class JaxGPUEventAnalyser(GPUEventAnalyser):
         # Default: use GPU0 (PID 1) for Jax
         dict_gpu_event_lists = self.get_gpu_event_lists(gpu_pid=gpu_pid, event_filter=event_filter)
         GPUEventAnalyser.verify_dict_gpu_event_lists(dict_gpu_event_lists)
-
         return GPUEventAnalyser.compute_metrics_dict(dict_gpu_event_lists) 
     
     def get_breakdown_df_multigpu(self, event_filter = None):
@@ -325,7 +324,6 @@ class JaxGPUEventAnalyser(GPUEventAnalyser):
 
         Similar to get_breakdown_df_multigpu but returns a dataframe for output.
         """
-        # print("Processing events by GPU")
         gpu_metrics = self.comput_metrics_multigpu(gpu_pid=gpu_pid, event_filter=event_filter)
         list_pids = [gpu_pid] if gpu_pid else range(1,9)  
         list_dfs = []

--- a/TraceLens/TreePerf/tree_perf.py
+++ b/TraceLens/TreePerf/tree_perf.py
@@ -1245,7 +1245,6 @@ class JaxTreePerfAnalyzer(TreePerfAnalyzer):
         if perf_model_class is None:
             logger.info(f"\nPerf model is not implemented. \n\nEvent: {event}")
             return dict()
-
         perf_model = perf_model_class(event, arch=self.arch, python_path=self.python_path)
 
         gflops = (perf_model.flops() if not bwd else perf_model.flops_bwd())/ 1e9

--- a/TraceLens/TreePerf/tree_perf.py
+++ b/TraceLens/TreePerf/tree_perf.py
@@ -1243,7 +1243,7 @@ class JaxTreePerfAnalyzer(TreePerfAnalyzer):
         perf_model_name = JaxTreePerfAnalyzer.get_event_perf_model_name(event)
         perf_model_class = self.jax_op_to_perf_model_class_map.get(perf_model_name , None)
         if perf_model_class is None:
-            logger.info(f"\nPerf model is not implemented. \n\nEvent: {event}")
+            logger.warning(f"\nPerf model is not implemented. \n\nEvent: {event}")
             return dict()
         perf_model = perf_model_class(event, arch=self.arch, python_path=self.python_path)
 


### PR DESCRIPTION
Use logging levels to differentiate between warnings and errors when processing jax traces.

closes [ issue 337](https://github.com/AMD-AGI/TraceLens/issues/337)