### PR TITLE
Add trtllm::cublas_scaled_mm to torch_op_mapping

### DIFF
--- a/TraceLens/PerfModel/torch_op_mapping.py
+++ b/TraceLens/PerfModel/torch_op_mapping.py
@@ -27,6 +27,7 @@ op_to_perf_model_class_map = {
     'aten::mm': perf_model.aten_mm,
     'aten::addmm': perf_model.aten_addmm,
     'aten::_scaled_mm': perf_model.aten_scaled_mm,
+    'trtllm::cublas_scaled_mm': perf_model.aten_scaled_mm,
 
     # TEv2 pseudo ops
     '_Linear_yfwd_mm': perf_model.tev2_pseudo_gemm,


### PR DESCRIPTION
Simplified addition of `trtllm::cublas_scaled_mm` to torch_op_mapping.  

As discussed here:  https://github.com/AMD-AGI/TraceLens/pull/295#discussion_r2391640805

Before:
<img width="531" height="497" alt="image" src="https://github.com/user-attachments/assets/2cd1574d-72a3-46de-b790-e26c778f8eff" />

After:
<img width="535" height="539" alt="image" src="https://github.com/user-attachments/assets/61515d34-b42f-440c-807d-89d7eafa6e8f" />
