### PR TITLE
add feature to optionally separate idle time into micro and macro

### DIFF
--- a/TraceLens/Reporting/generate_perf_report_pytorch.py
+++ b/TraceLens/Reporting/generate_perf_report_pytorch.py
@@ -179,6 +179,9 @@ def generate_perf_report_pytorch(profile_json_path: str,
                                 # include unlinked kernels in gpu timeline
                                 include_unlinked_kernels: bool = False,
 
+                                # threshold in microseconds for micro idle time
+                                micro_idle_thresh_us: int = None,
+
                                 # collective analysis
                                 collective_analysis: bool = True,
 
@@ -211,7 +214,7 @@ def generate_perf_report_pytorch(profile_json_path: str,
     agg_metrics = ['mean', 'median', 'std', 'min', 'max']
 
     # Generate base DataFrames
-    df_gpu_timeline = perf_analyzer.get_df_gpu_timeline()
+    df_gpu_timeline = perf_analyzer.get_df_gpu_timeline(micro_idle_thresh_us=micro_idle_thresh_us)
 
     # TODO: move this to the TreePerfAnalyzer class
     total_time_row = df_gpu_timeline[df_gpu_timeline['type'] == 'total_time']
@@ -324,6 +327,9 @@ def main():
     # Optional arguments
     parser.add_argument('--include_unlinked_kernels', action='store_true',
                         help='Include unlinked kernels in the GPU timeline analysis.')
+    parser.add_argument('--micro_idle_thresh_us', type=int, default=None,
+                        help='Threshold in microseconds to classify idle interval as micro idle in GPU timeline analysis. ' \
+                        'Default is None and all idle times are included in one category.')
     parser.add_argument('--disable_coll_analysis', action='store_false', dest='collective_analysis',
                         default=True,
                         help='Disable collective analysis section in the report. Enabled by default.')
@@ -352,6 +358,7 @@ def main():
                                  output_xlsx_path=args.output_xlsx_path,
                                  output_csvs_dir=args.output_csvs_dir,
                                  include_unlinked_kernels=args.include_unlinked_kernels,
+                                 micro_idle_thresh_us=args.micro_idle_thresh_us,
                                  collective_analysis=args.collective_analysis,
                                  short_kernel_study=args.short_kernel_study,
                                  short_kernel_threshold_us=args.short_kernel_threshold_us,

--- a/TraceLens/TreePerf/tree_perf.py
+++ b/TraceLens/TreePerf/tree_perf.py
@@ -646,12 +646,12 @@ class TreePerfAnalyzer:
 
         return df_agg
 
-    def get_df_gpu_timeline(self):
+    def get_df_gpu_timeline(self, micro_idle_thresh_us= None):
         kernel_events =  [event for event in self.tree.events if self.event_to_category(event) in {'kernel', 'gpu_memcpy', 'gpu_memset'}]
         if not self.include_unlinked_kernels:
             kernel_events = [event for event in kernel_events if event.get('tree')]
         gpu_event_analyser = self.GPUEventAnalyser(kernel_events)
-        df = gpu_event_analyser.get_breakdown_df()
+        df = gpu_event_analyser.get_breakdown_df(micro_idle_thresh_us=micro_idle_thresh_us)
         return df
 
     def get_kernel_details(self, kernel_event,

--- a/docs/generate_perf_report.md
+++ b/docs/generate_perf_report.md
@@ -46,6 +46,7 @@ The script supports several optional arguments to customize the output report. B
 | `--topk_roofline_ops N`           | `None`            | Limit the number of rows in the roofline sheet.                             |
 | `--extension_file`           | `None`            | Path to extension python file   
 | `--include_unlinked_kernels`            | `False`           | Include all kernels in the gpu timeline analysis -  including kernels not linked to host call stack. By default these unlinked kernels are excluded in the analysis. |
+`--micro_idle_thresh_us X`        | `None`            | Threshold (in microseconds) to classify idle intervals as micro idle in GPU timeline analysis. If None, all idle times are included in one category. |
 | `--short_kernel_study`            | `False`           | Include short-kernel analysis in the report.                                |
 | `--short_kernel_threshold_us X`   | `10`              | Threshold (in microseconds) to classify a kernel as "short".               |
 | `--short_kernel_histogram_bins B` | `100`             | Number of bins to use for the short-kernel duration histogram.             |


### PR DESCRIPTION
This PR adds a feature to optionally separate idle time into micro and macro categories based on a configurable threshold. The change allows users to analyze GPU idle intervals more granularly by distinguishing between short "micro" idle periods and longer "macro" idle periods.

