### PR TITLE
docs: add Trace2Tree example notebook and simplify docs

### DIFF
--- a/TraceLens/Trace2Tree/trace_to_tree.py
+++ b/TraceLens/Trace2Tree/trace_to_tree.py
@@ -804,6 +804,20 @@ class TraceToTree:
             return []
         return [self.get_UID2event(child_UID) for child_UID in event["children"]]
 
+    def get_gpu_events(self, event):
+        """
+        Get GPU events (kernels, memcpy, memset) launched by this event.
+
+        Args:
+            event: The event to get GPU events for
+
+        Returns:
+            List of GPU event dictionaries
+        """
+        if "gpu_events" not in event:
+            return []
+        return [self.get_UID2event(gpu_uid) for gpu_uid in event["gpu_events"]]
+
     def get_node_by_ext_id_pid_tid(self, ext_id, pid, tid):
         for event in self.events:
             if (

--- a/docs/Trace2Tree.md
+++ b/docs/Trace2Tree.md
@@ -6,9 +6,9 @@ See LICENSE for license information.
 
 # Trace2Tree
 
-In GPU applications performance analysis, understanding the relationship between host CPU operations and correspondng GPU kernel executions is crucial for analysing bottlenecks. The PyTorch profiler provides a JSON trace file containing events with timestamps and durations but lacks explicit call stack dependency information.
+In GPU applications performance analysis, understanding the relationship between host CPU operations and corresponding GPU kernel executions is crucial for analyzing bottlenecks. The PyTorch profiler provides a JSON trace file containing events with timestamps and durations but lacks explicit call stack dependency information.
 
-Trace2Tree is a Python SDK designed to parse these trace files and build a hierarchical tree structure that represents the dependency relationships from host CPU operations to GPU kernels. This enables users to analyze and extract insights, such as the total GPU kernel time for a high-level host function (e.g., aten::linear), and perform many other advanced analyses leveraging the tree structure.
+Trace2Tree is the underlying tree structure component used by TraceLens to parse trace files and build hierarchical dependency relationships from host CPU operations to GPU kernels. **It is recommended to access this functionality through the `TreePerfAnalyzer` interface** rather than using Trace2Tree directly.
 
 ---
 
@@ -23,99 +23,87 @@ Trace2Tree is a Python SDK designed to parse these trace files and build a hiera
 
 ## Quick Start
 
-### Example 1: Build and traverse tree
+> **💡 Tip:** See [`examples/trace2tree_example.ipynb`](../examples/trace2tree_example.ipynb) for a complete interactive tutorial.
 
-#### 1. Load the Trace data
+### Example: Build and traverse tree
+
+#### 1. Load the Trace data via TreePerfAnalyzer
 ```python
+from TraceLens.TreePerf import TreePerfAnalyzer
 
-import json
-from pprint import pprint
-from TraceLens import TraceToTree
-
-# Load trace data
+# Load trace data using TreePerfAnalyzer
+# Set add_python_func=True to include Python function call stack in the tree
+# This allows you to trace GPU kernels all the way back to your Python code
 trace_file = '/path/to/trace.json'
-with open(trace_file, 'r') as f:
-    trace_data = json.load(f)
+analyzer = TreePerfAnalyzer.from_file(trace_file, add_python_func=True)
 
-events = data['traceEvents']
-tree = TraceToTree(events)
-tree.build_tree()
+# Access the underlying tree structure
+tree = analyzer.tree
 ```
-#### 2. Locate node from Perfetto UI  
-Note External Id, Process Id and Thread Id
-![locate_node](./locate_node.PNG)
 
-#### 3. Get the Node by Its Identifiers
+#### 2. Find an Operation to Analyze
 
 ```python
-node = tree.get_node_by_ext_id_pid_tid(14990986, 937116, 937116)
-pprint(node)
+# Find an operation of interest
+event_interest = next(
+    evt for evt in tree.events 
+    if evt.get('name') == 'aten::convolution' and evt.get('cat') == 'cpu_op'
+)
 ```
 
-```
-{'UID': 103700,
- 'args': {'Ev Idx': 95372,
-          'External id': 14990986,
-          'Fwd thread id': 0,
-          'Record function id': 0,
-          'Sequence number': 556085},
- 'cat': 'cpu_op',
- 'children': [103701],
- 'cpu_op_root': True,
- 'dur': 33.21,
- 'name': 'aten::layer_norm',
- 'parent': None,
- 'ph': 'X',
- 'pid': 937116,
- 't_end': 3962902441202.784,
- 'tid': 937116,
- 'tree': True,
- 'ts': 3962902441169.574}
-```
+#### 3. Traverse Subtree
 
-#### 4. Recursively Traverse the Tree
+Visualize the entire subtree rooted at this operation:
 
 ```python
-
-tree.traverse_and_print(node)
+tree.traverse_subtree_and_print(event_interest)
 ```
 
 ```
-└── Category: cpu_op, Name: aten::layer_norm
-    └── Category: cpu_op, Name: aten::layer_norm
-        └── Category: cpu_op, Name: aten::native_layer_norm
-            ├── Category: cpu_op, Name: aten::empty
-            ├── Category: cpu_op, Name: aten::empty
-            ├── Category: cpu_op, Name: aten::empty
-            ├── Category: cuda_runtime, Name: hipLaunchKernel
-            │   └── Category: kernel, Name: void at::native::(anonymous namespace)::vectorized_layer_norm_ke...
-            ├── Category: cpu_op, Name: aten::view
-            └── Category: cpu_op, Name: aten::view
-
+└── UID: 41, Category: cpu_op, Name: aten::convolution
+    └── UID: 42, Category: cpu_op, Name: aten::_convolution
+        └── UID: 43, Category: cpu_op, Name: aten::miopen_convolution
+            ├── UID: 104314, Category: cuda_runtime, Name: hipExtModuleLaunchKernel
+            │   └── UID: 107846, Category: kernel, Name: Im2d2Col_v2, Duration: 45.063
+            └── UID: 104318, Category: cuda_runtime, Name: hipExtModuleLaunchKernel
+                └── UID: 107848, Category: kernel, Name: Cijk_Ailk_Bljk_BBS_BH...
 ```
-#### 5. Traverse Upwards to Analyze Parent Nodes
+
+#### 4. Traverse Parent Chain
+
+Trace back through all parent events to see the full call stack. You can optionally include CPU operation details like input dimensions, types, and strides using the `cpu_op_fields` parameter:
+
+Available fields: `'Input Dims'`, `'Input type'`, `'Input Strides'`, `'Concrete Inputs'`
 
 ```python
-node = tree.get_node_by_ext_id_pid_tid(14990988, 9, 0)
-parent = node
-depth = 0
-
-tree.traverse_parents_and_print(node)
+root = tree.traverse_parents_and_print(
+    event_interest, 
+    cpu_op_fields=('Input Dims', 'Input type')
+)
 ```
+
 ```
 Node:
-  cat: kernel
-  name: void at::native::(anonymous namespace)::vectorized_layer_norm_ke...
+  UID: 41, Category: cpu_op, Name: aten::convolution
+    Input Dims: [[1, 768, 24, 24], [768, 768, 3, 3], []]
+    Input type: [float, float, float]
 1-up:
-  cat: cuda_runtime
-  name: hipLaunchKernel
+  UID: 40, Category: cpu_op, Name: aten::conv2d
+    Input Dims: [[1, 768, 24, 24], [768, 768, 3, 3], [1], [2, 2], [1, 1], [1, 1], [1]]
+    Input type: [float, float, int, int, int, int, int]
 2-up:
-  cat: cpu_op
-  name: aten::native_layer_norm
+  UID: 40139, Category: python_function, Name: <built-in method conv2d of type object at 0x...>
 3-up:
-  cat: cpu_op
-  name: aten::layer_norm
+  UID: 40138, Category: python_function, Name: torch/utils/_device.py(100): __torch_function__
 4-up:
-  cat: cpu_op
-  name: aten::layer_norm
+  UID: 40137, Category: python_function, Name: torch/nn/modules/conv.py(554): _conv_forward
+5-up:
+  UID: 40136, Category: python_function, Name: torch/nn/modules/conv.py(558): forward
+6-up:
+  UID: 40135, Category: python_function, Name: torch/nn/modules/module.py(1736): _wrapped_call_impl
+7-up:
+  UID: 40134, Category: python_function, Name: torch/nn/modules/module.py(1747): _call_impl
+8-up:
+  UID: 40133, Category: python_function, Name: transformers/models/owlv2/modeling_owlv2.py(395): forward
+...
 ```

--- a/examples/trace2tree_example.ipynb
+++ b/examples/trace2tree_example.ipynb
@@ -1,0 +1,213 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<!--\n",
+    "Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.\n",
+    "\n",
+    "See LICENSE for license information.\n",
+    "-->"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Trace2Tree Example Notebook\n",
+    "\n",
+    "This notebook demonstrates how to navigate the tree structure created by TraceLens.\n",
+    "\n",
+    "**What you'll learn:**\n",
+    "- Load traces using `TreePerfAnalyzer.from_file()`\n",
+    "- Traverse subtrees to see operation hierarchies\n",
+    "- Navigate parent chains to understand call stacks\n",
+    "- Access parent/child relationships and GPU events using tree methods"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Load Trace and Build Tree"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pprint import pprint\n",
+    "from TraceLens.TreePerf import TreePerfAnalyzer\n",
+    "\n",
+    "# Load trace data using TreePerfAnalyzer\n",
+    "# Set add_python_func=True to include Python function call stack\n",
+    "# This allows you to trace GPU kernels all the way back to your Python code\n",
+    "trace_file = 'tests/traces/mi300/google_owlv2-large-patch14-ensemble__1016001.json.gz'\n",
+    "analyzer = TreePerfAnalyzer.from_file(trace_file, add_python_func=True)\n",
+    "\n",
+    "# Access the underlying tree structure\n",
+    "tree = analyzer.tree\n",
+    "\n",
+    "print(f'Loaded {len(tree.events)} events')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Find an Operation to Analyze\n",
+    "\n",
+    "Let's find an operation of interest. You can change the filter to find different operations (e.g., `aten::matmul`, `aten::addmm`, `aten::layer_norm`, etc.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Find an operation (feel free to change this to any operation)\n",
+    "event_interest = next(\n",
+    "    evt for evt in tree.events \n",
+    "    if evt.get('name') == 'aten::convolution' and evt.get('cat') == 'cpu_op'\n",
+    ")\n",
+    "\n",
+    "print(f\"Found operation: {event_interest['name']}\")\n",
+    "print(f\"Duration: {event_interest.get('dur', 0):.2f} \u00b5s\")\n",
+    "print(f\"UID: {event_interest['UID']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Traverse Subtree\n",
+    "\n",
+    "Visualize the entire subtree rooted at this operation to see what happens beneath it. You can optionally include CPU operation details."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Subtree for {event_interest['name']}:\\n\")\n",
+    "tree.traverse_subtree_and_print(event_interest)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Traverse Parent Chain\n",
+    "\n",
+    "Trace back through all parent events to see the full call stack that led to this operation. You can optionally include CPU operation details like input dimensions and types."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Parent chain for {event_interest['name']}:\\n\")\n",
+    "root = tree.traverse_parents_and_print(\n",
+    "    event_interest,\n",
+    "    cpu_op_fields=('Input Dims', 'Input type')\n",
+    ")\n",
+    "print(f\"\\nRoot event: {root['name']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Navigating Parent-Child Relationships\n",
+    "\n",
+    "Use tree methods to directly access parent and children."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get parent using tree method\n",
+    "parent_evt = tree.get_parent_event(event_interest)\n",
+    "if parent_evt:\n",
+    "    print(f\"Parent: {parent_evt['name']} (cat: {parent_evt['cat']})\\n\")\n",
+    "\n",
+    "# Get children using tree method\n",
+    "children = tree.get_children_events(event_interest)\n",
+    "print(f\"Children ({len(children)}):\")\n",
+    "for child in children[:5]:  # Show first 5\n",
+    "    print(f\"  - {child['name']} (cat: {child['cat']})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Exploring GPU Events\n",
+    "\n",
+    "Use the `get_gpu_events()` method to see which GPU kernels this operation launches."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gpu_events = tree.get_gpu_events(event_interest)\n",
+    "print(f\"GPU kernels launched by {event_interest['name']} (total: {len(gpu_events)}):\\n\")\n",
+    "for gpu_evt in gpu_events[:5]:  # Show first 5\n",
+    "    print(f\"  Kernel: {gpu_evt['name'][:60]}...\")\n",
+    "    print(f\"  Duration: {gpu_evt.get('dur', 0):.2f} \u00b5s\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "This notebook demonstrated:\n",
+    "- Loading traces via `TreePerfAnalyzer.from_file()` with Python stack\n",
+    "- `traverse_subtree_and_print()` and `traverse_parents_and_print()` to explore call hierarchies\n",
+    "- Using `cpu_op_fields` parameter to display input dimensions and types for CPU operations\n",
+    "- Using tree methods: `get_parent_event()`, `get_children_events()`, `get_gpu_events()`\n",
+    "\n",
+    "For more advanced analysis, see:\n",
+    "- `tree_perf_example.ipynb` - Performance metrics and roofline analysis\n",
+    "- `trace_diff_example.ipynb` - Comparing two traces"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
- Add trace2tree_example.ipynb showing tree traversal via TreePerfAnalyzer
- Add get_gpu_events() method to TraceToTree
- Simplify Trace2Tree.md examples and remove outdated pid/tid lookup section
