### PR TITLE
fix: JaxAnalyses.default_gpu_event_filter to allow tid>100 for actual streams

### DIFF
--- a/TraceLens/TreePerf/jax_analyses.py
+++ b/TraceLens/TreePerf/jax_analyses.py
@@ -90,6 +90,9 @@ class JaxAnalyses:
         # Keep events from actual GPU streams, filter out supplemental metadata threads
         thread_info = event.get("thread", {})
         thread_name = thread_info.get("thread_name", "")
+        if not thread_name:
+            # Fallback to old logic for backward compatibility
+            return event.get("tid", 200) < 100
         return thread_name.startswith("Stream #")
 
     @staticmethod


### PR DESCRIPTION
-Fix a case when actual GPU streams have tid>100 for JaxAnalyses.default_gpu_event_filter