### PR TITLE
fix(trace2tree): skip non-kernel events in gemm detection

### DIFF
--- a/TraceLens/Trace2Tree/util.py
+++ b/TraceLens/Trace2Tree/util.py
@@ -33,7 +33,8 @@ def set_bookkeeping_attr(tree, event: dict):
 
 
 def is_gemm_kernel(kernel_event: dict) -> bool:
-    assert kernel_event["cat"] == "kernel"
+    if kernel_event.get("cat") != "kernel":
+        return False # skip non-kernel events
     kernel_name = kernel_event["name"]
     pattern = r".*C.*_A.*_B.*"
     is_rocm_gemm = bool(re.match(pattern, kernel_name))


### PR DESCRIPTION
Problem:  we were seeing assertion failures on a specific platform:
```
  fwd_gemm_kernels = [e for e in fwd_gpu_events if is_gemm_kernel(e)]
                                                     ^^^^^^^^^^^^^^^^^
  File "[snip]/TraceLens/Trace2Tree/util.py", line 27, in is_gemm_kernel
    assert kernel_event['cat'] == 'kernel'
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  AssertionError
```

Solution: 
- avoid assertion in `is_gemm_kernel()` when traces include non-kernel events
- return False for non-kernel entries while preserving existing GEMM name checks

Outcome:  script completes successfully