### PR TITLE
Add unified_perf_summary sheet to perf report

### DIFF
--- a/TraceLens/Reporting/generate_perf_report_pytorch.py
+++ b/TraceLens/Reporting/generate_perf_report_pytorch.py
@@ -399,6 +399,21 @@ def generate_perf_report_pytorch(
             dict_name2df["ops_summary"] = df_kernel_launchers_summary
         if not df_kernel_launchers_unique_args.empty:
             dict_name2df["ops_unique_args"] = df_kernel_launchers_unique_args
+
+        # Add unified perf metrics table (ops with perf models + leaf ops with GPU kernels)
+        df_unified_perf = perf_analyzer.build_df_unified_perf_table()
+        if not df_unified_perf.empty:
+            df_unified_perf_summary = perf_analyzer.summarize_df_unified_perf_table(
+                df_unified_perf, agg_metrics=agg_metrics, include_pct=True
+            )
+            if not df_unified_perf_summary.empty:
+                df_unified_perf_summary = add_truncated_kernel_details(
+                    df_unified_perf_summary,
+                    source_col="kernel_details_summary",
+                    new_col_name="trunc_kernel_details",
+                )
+                dict_name2df["unified_perf_summary"] = df_unified_perf_summary
+
         # update this dict with the perf_metrics_dfs
         dict_name2df.update(perf_metrics_dfs)
 

--- a/docs/generate_perf_report.md
+++ b/docs/generate_perf_report.md
@@ -42,10 +42,11 @@ python generate_perf_report_jax.py --profile_path path/to/profile.xplane.pb
 | `gpu_timeline`             | End-to-end GPU activity summary, including compute, memory copies, communication, and idle time.                 |
 | `ops_summary_by_category`  | Summary of compute time grouped by operation category (e.g., GEMM, SDPA_fwd, elementwise).                       |
 | `ops_summary`              | Summary of compute time at the individual operation level; each row corresponds to a unique operation name.      |
-| `ops_all`                  | Detailed operation-level summary; each row corresponds to a unique (operation name, argument) combination.       |
+| `ops_unique_args`          | Detailed operation-level summary; each row corresponds to a unique (operation name, argument) combination.       |
+| `unified_perf_summary`     | Unified perf metrics for all ops with perf models OR leaf ops that launch GPU kernels. Includes GFLOPS, TFLOPS/s, Data Moved, FLOPS/Byte, TB/s metrics aggregated by unique args. |
 | `short_kernels_histogram`  | Histogram showing the distribution of kernel durations below the short-duration threshold.                   |
 | `short_kernels_all_details`| Detailed list of short-duration kernels, including count, total/mean time, runtime percentage, and parent op.   |
-| Roofline Sheets            | Roofline analysis for each operation category, including TFLOPs, TB/s, and FLOPs/byte metrics.                |
+| Roofline Sheets            | Roofline analysis for each operation category (GEMM, CONV, etc.), including TFLOPs, TB/s, and FLOPs/byte metrics. |
 
 Note: JAX outputs do not include `short_kernels_histogram` or `short_kernels_all_details`, these are for PyTorch only.
 


### PR DESCRIPTION
- Add collect_unified_perf_events() to traverse tree and collect ops with perf models or leaf ops that launch GPU kernels
- Add build_df_unified_perf_table() and summarize_df_unified_perf_table() for building detailed and summarized DataFrames
- Include GFLOPS, TFLOPS/s, Data Moved, FLOPS/Byte, TB/s metrics
- Add perf_params column with op-specific params (e.g., M/N/K for GEMM, input_shape/filter_shape for Conv, B/N_Q/H_Q for SDPA)
- Support backward ops with 1:1 forward linking for theoretical metrics
- Add kernel_details and trunc_kernel_details columns
- Add include_nccl parameter to optionally exclude NCCL collective ops
- Handle extension-injected pseudo ops by checking cpu_op children with perf models before collecting leaf ops
- Integrate unified_perf_summary as new sheet in generate_perf_report_pytorch
- Update docs with new sheet description

