### PR TITLE
Update lint rule to only run black on changed files

### DIFF
--- a/TraceLens/TreePerf/gpu_event_analyser.py
+++ b/TraceLens/TreePerf/gpu_event_analyser.py
@@ -115,7 +115,8 @@ class GPUEventAnalyser:
                 else:
                     raise ValueError(f"Unknown event category: {category}")
         return {
-            GPUEventAnalyser.all_gpu_key: gpu_events, GPUEventAnalyser.computation_key: comp_events,
+            GPUEventAnalyser.all_gpu_key: gpu_events,
+            GPUEventAnalyser.computation_key: comp_events,
             GPUEventAnalyser.communication_key: comm_events,
             GPUEventAnalyser.memcpy_key: memcpy_events,
         }


### PR DESCRIPTION
This prevents failures due to existing files that don't match the linting rule