### PR TITLE
feat(Trace2Tree): Add backward-to-forward callstack linking

### DIFF
--- a/TraceLens/Trace2Tree/trace_to_tree.py
+++ b/TraceLens/Trace2Tree/trace_to_tree.py
@@ -813,13 +813,16 @@ class TraceToTree:
             if "gpu_events" not in event:
                 event["non_gpu_path"] = True
 
-    def build_tree(self, add_python_func=False) -> None:
+    def build_tree(self, add_python_func=False, link_fwd_bwd=True) -> None:
         print(f"Building tree with add_python_func={add_python_func}")
         self.build_host_call_stack_tree(add_python_func)
         self.add_gpu_ops_to_tree()
 
         if self.prune_nongpu_paths:
             self.label_non_gpu_paths()
+
+        if link_fwd_bwd:
+            self.link_all_fwd_bwd_events()
 
     # TODO base class includes this, remove
     def get_UID2event(self, UID):
@@ -889,6 +892,7 @@ class TraceToTree:
         node: Dict[str, Any],
         prune_non_gpu: bool = True,
         cpu_op_fields: tuple[str, ...] = (),
+        include_bwd: bool = False,
     ) -> None:
         """
         Initiates traversal of a subtree of profiling events and prints them in a hierarchical call stack format.
@@ -898,12 +902,18 @@ class TraceToTree:
             prune_non_gpu (bool): If True, prunes events that do not lead to GPU events.
             cpu_op_fields (tuple[str, ...]): Optional tuple to specify printing additional details for CPU operations.
                 It will be some subset of ['Input Dims', 'Input type', 'Input Strides', 'Concrete Inputs'].
+            include_bwd (bool): If True, also prints backward events linked via bwd_events for each forward op.
 
         Prints:
             A structured representation of the subtree with details about each event.
         """
         self._traverse_subtree_recursive(
-            node, prune_non_gpu, cpu_op_fields=cpu_op_fields, _prefix="", is_last=True
+            node,
+            prune_non_gpu,
+            cpu_op_fields=cpu_op_fields,
+            include_bwd=include_bwd,
+            _prefix="",
+            is_last=True,
         )
 
     def _traverse_subtree_recursive(
@@ -911,6 +921,7 @@ class TraceToTree:
         node: Dict[str, Any],
         prune_non_gpu: bool,
         cpu_op_fields: tuple[str],
+        include_bwd: bool,
         _prefix: str,
         is_last: bool,
     ) -> None:
@@ -945,21 +956,75 @@ class TraceToTree:
         if prune_non_gpu:
             children = [child for child in children if "non_gpu_path" not in child]
 
+        # Check if we have backward events to show after children
+        has_bwd = include_bwd and "bwd_events" in node and node["bwd_events"]
+
         child_count = len(children)
         new_prefix = _prefix + ("    " if is_last else "│   ")
 
         for i, child in enumerate(children):
+            # If we have bwd events, children are never "last" (bwd comes after)
+            child_is_last = (i == child_count - 1) and not has_bwd
             self._traverse_subtree_recursive(
                 child,
                 prune_non_gpu,
                 cpu_op_fields=cpu_op_fields,
+                include_bwd=include_bwd,
                 _prefix=new_prefix,
-                is_last=(i == child_count - 1),
+                is_last=child_is_last,
             )
 
+        # Print backward events AFTER children
+        if has_bwd:
+            bwd_events = node["bwd_events"]
+            for i, bwd_uid in enumerate(bwd_events):
+                bwd_event = self.get_UID2event(bwd_uid)
+                if bwd_event:
+                    bwd_is_last = i == len(bwd_events) - 1
+                    bwd_connector = "└── " if bwd_is_last else "├── "
+                    bwd_name = bwd_event.get(
+                        TraceLens.util.TraceEventUtils.TraceKeys.Name, "Unknown"
+                    )
+                    print(
+                        f"{new_prefix}{bwd_connector}[BWD] {bwd_name} (UID: {bwd_event.get('UID')})"
+                    )
+                    # Print backward subtree with proper sibling handling
+                    bwd_subtree_prefix = new_prefix + (
+                        "    " if bwd_is_last else "│   "
+                    )
+                    bwd_children = [
+                        self.get_UID2event(uid) for uid in bwd_event.get("children", [])
+                    ]
+                    bwd_children = [c for c in bwd_children if c]  # Filter None
+                    for j, bwd_child in enumerate(bwd_children):
+                        child_is_last = j == len(bwd_children) - 1
+                        self._traverse_subtree_recursive(
+                            bwd_child,
+                            prune_non_gpu,
+                            cpu_op_fields=cpu_op_fields,
+                            include_bwd=False,  # Don't recurse bwd->fwd->bwd
+                            _prefix=bwd_subtree_prefix,
+                            is_last=child_is_last,
+                        )
+
     def traverse_parents_and_get_callstack(
-        self, node: Dict[str, Any], filter: tuple[str, ...] = ()
+        self,
+        node: Dict[str, Any],
+        filter: tuple[str, ...] = (),
+        follow_fwd_link: bool = False,
     ):
+        """
+        Traverses the parent nodes and returns a string representation of the call stack.
+
+        Args:
+            node (Dict[str, Any]): The event node from which to start traversing upwards.
+            filter (tuple[str, ...]): Optional tuple of strings to filter which nodes to include in output.
+            follow_fwd_link (bool): If True, when reaching the root of a backward event chain,
+                follow the fwd_event link to continue traversing the forward call stack.
+
+        Returns:
+            str: The call stack as a string with " => " separators.
+        """
         depth = 0
         print_str = node["name"] + " => "
         while True:
@@ -975,12 +1040,25 @@ class TraceToTree:
             # Move to the parent node
             parent_node = self.get_parent_event(node)
             if parent_node is None:
+                # Check if we should follow the fwd_event link for backward events
+                if follow_fwd_link and "fwd_event" in node:
+                    fwd_uid = node["fwd_event"]
+                    fwd_node = self.get_UID2event(fwd_uid)
+                    print_str += "[FWD] => "
+                    # Continue traversing the forward event's parent chain
+                    fwd_callstack = self.traverse_parents_and_get_callstack(
+                        fwd_node, filter, follow_fwd_link=False
+                    )
+                    return print_str + fwd_callstack
                 return print_str.strip(" => ").strip(" ")
             node = parent_node
             depth += 1
 
     def traverse_parents_and_print(
-        self, node: Dict[str, Any], cpu_op_fields: tuple[str, ...] = ()
+        self,
+        node: Dict[str, Any],
+        cpu_op_fields: tuple[str, ...] = (),
+        follow_fwd_link: bool = False,
     ) -> None:
         """
         Traverses the parent nodes of a given event node and prints their details
@@ -990,6 +1068,8 @@ class TraceToTree:
             node (Dict[str, Any]): The event node from which to start traversing upwards.
             cpu_op_fields (tuple[str, ...]): Optional tuple to specify printing additional details for CPU operations.
                 It will be some subset of ['Input Dims', 'Input type', 'Input Strides', 'Concrete Inputs'].
+            follow_fwd_link (bool): If True, when reaching the root of a backward event chain,
+                follow the fwd_event link to continue traversing the forward call stack.
         """
 
         depth = 0
@@ -1025,6 +1105,19 @@ class TraceToTree:
             # Move to the parent node
             parent_node = self.get_parent_event(node)
             if parent_node is None:
+                # Check if we should follow the fwd_event link for backward events
+                if follow_fwd_link and "fwd_event" in node:
+                    fwd_uid = node["fwd_event"]
+                    fwd_node = self.get_UID2event(fwd_uid)
+                    print(f"\n{'='*60}")
+                    print(
+                        f"Following fwd_event link to forward call stack (UID: {fwd_uid})"
+                    )
+                    print(f"{'='*60}")
+                    # Recursively traverse the forward event's parent chain
+                    return self.traverse_parents_and_print(
+                        fwd_node, cpu_op_fields, follow_fwd_link=False
+                    )
                 return node
             node = parent_node
             depth += 1
@@ -1046,23 +1139,96 @@ class TraceToTree:
                 seq_nums.update(self.get_seq_nums_for_node_subtree(child_UID))
         return seq_nums
 
-    def link_bwd_events(self, event_UID):
+    def get_subtree_bwd_events(self, event_UID):
+        """
+        Returns all backward event UIDs from this event and all its descendants.
+
+        Does NOT modify any event - just aggregates and returns.
+        Uses the 1:1 bwd_events links established by link_all_fwd_bwd_events().
+
+        Args:
+            event_UID: The UID of the forward event to get backward events for.
+
+        Returns:
+            list: List of backward event UIDs from this subtree.
+        """
         fwd_event = self.events_by_uid[event_UID]
-        seq_nums = self.get_seq_nums_for_node_subtree(event_UID)
-        bwd_event_UIDs = []
-        for seq_num in seq_nums:
-            for seq_num_match_UID in self.seq_num2event_uids_map.get(seq_num, []):
-                if (
-                    not self.events_by_uid[seq_num_match_UID]
-                    .get(TraceLens.util.TraceEventUtils.TraceKeys.Name)
-                    .startswith("autograd::engine::evaluate_function:")
-                ):
+
+        # Collect all bwd_events from this event and all descendants
+        all_bwd_uids = set()
+
+        def collect_bwd(event):
+            if "bwd_events" in event:
+                all_bwd_uids.update(event["bwd_events"])
+            for child_uid in event.get("children", []):
+                child = self.get_UID2event(child_uid)
+                if child:
+                    collect_bwd(child)
+
+        collect_bwd(fwd_event)
+        return list(all_bwd_uids)
+
+    def link_all_fwd_bwd_events(self):
+        """
+        Automatically link all forward events to their corresponding backward events
+        using 1:1 mapping. For each backward autograd event, finds the leaf forward op
+        that matches the sequence number.
+
+        This populates:
+          - fwd_event["bwd_events"] = [backward event UID]  (1:1 mapping)
+          - bwd_event["fwd_event"] = forward event UID
+        """
+        linked_count = 0
+
+        # Iterate through all autograd backward events
+        for seq_num, uids in self.seq_num2event_uids_map.items():
+            # Find the autograd::engine::evaluate_function event for this seq_num
+            bwd_autograd_event = None
+            for uid in uids:
+                event = self.events_by_uid[uid]
+                name = event.get(TraceLens.util.TraceEventUtils.TraceKeys.Name, "")
+                if name.startswith("autograd::engine::evaluate_function:"):
+                    bwd_autograd_event = event
+                    break
+
+            if not bwd_autograd_event:
+                continue
+
+            # Find the leaf forward op with this sequence number
+            # (the one with the latest timestamp = most specific/deepest op)
+            # Skip backward events by checking pid/tid - backward ops run on autograd thread
+            bwd_pid = bwd_autograd_event.get("pid")
+            bwd_tid = bwd_autograd_event.get("tid")
+            leaf_fwd_event = None
+            leaf_fwd_ts = -1
+            for uid in uids:
+                event = self.events_by_uid[uid]
+                # Skip events on the same thread as the backward autograd event
+                if event.get("pid") == bwd_pid and event.get("tid") == bwd_tid:
                     continue
-                bwd_event_UIDs.append(seq_num_match_UID)
-                bwd_event = self.events_by_uid[seq_num_match_UID]
-                bwd_event["fwd_event"] = event_UID
-                break
-        fwd_event["bwd_events"] = bwd_event_UIDs
+                # This is a forward event - check if it's the latest (leaf)
+                ts = event.get(TraceLens.util.TraceEventUtils.TraceKeys.TimeStamp, 0)
+                if ts > leaf_fwd_ts:
+                    leaf_fwd_ts = ts
+                    leaf_fwd_event = event
+
+            if not leaf_fwd_event:
+                continue
+
+            # 1:1 link: backward -> forward
+            bwd_autograd_event["fwd_event"] = leaf_fwd_event[
+                TraceLens.util.TraceEventUtils.TraceKeys.UID
+            ]
+
+            # 1:1 link: forward -> backward (as a list for API compatibility)
+            if "bwd_events" not in leaf_fwd_event:
+                leaf_fwd_event["bwd_events"] = []
+            leaf_fwd_event["bwd_events"].append(
+                bwd_autograd_event[TraceLens.util.TraceEventUtils.TraceKeys.UID]
+            )
+            linked_count += 1
+
+        logger.debug(f"Linked {linked_count} forward-backward event pairs (1:1)")
 
     def _get_graph_gpu_events(self, graph_launch_evt):
         corr = graph_launch_evt.get(

--- a/TraceLens/TreePerf/tree_perf.py
+++ b/TraceLens/TreePerf/tree_perf.py
@@ -251,9 +251,8 @@ class TreePerfAnalyzer:
 
         # Handle kernel aggregation
         if bwd:
-            if not event.get("bwd_events"):
-                self.tree.link_bwd_events(event["UID"])
-            cpu_op_uids = event["bwd_events"]
+            # Always use subtree aggregation for backward metrics
+            cpu_op_uids = self.tree.get_subtree_bwd_events(event["UID"])
         else:
             cpu_op_uids = [event["UID"]]
         cpu_op_list = [self.tree.get_UID2event(uid) for uid in cpu_op_uids]
@@ -1179,10 +1178,8 @@ class TreePerfAnalyzer:
         Returns:
             list: List of collected event dictionaries.
         """
-        # First, link all forward events with perf models to their backward events
-        for event in self.tree.events:
-            if self._has_perf_model(event):
-                self.tree.link_bwd_events(event["UID"])
+        # Note: 1:1 bwd_events linking is done in build_tree() via link_all_fwd_bwd_events()
+        # Use get_subtree_bwd_events() for on-demand subtree aggregation
 
         collected = []
         visited = set()
@@ -2186,10 +2183,8 @@ class JaxTreePerfAnalyzer(TreePerfAnalyzer):
                         operand_list += (_operand_dim,)
                         operand_idx += (_operand_idx,)
         except Exception as e:
-            logger.debug(
-                f"\nException occurred when parsing Event: \n\n {event} \n\
-                            Event metadata: {event['metadata']}, operands: {operands}"
-            )
+            logger.debug(f"\nException occurred when parsing Event: \n\n {event} \n\
+                            Event metadata: {event['metadata']}, operands: {operands}")
             raise ValueError(
                 f"{e} Exception occurred when parsing Event operands: \n\n {operands}"
             )

--- a/examples/custom_workflows/te_gemms.py
+++ b/examples/custom_workflows/te_gemms.py
@@ -16,11 +16,11 @@ def get_bwd_ops_for_fwd_op(
 ) -> list[dict]:
     """
     Get backward operations for a given forward operation.
+    Uses on-demand subtree aggregation to find all backward events.
     """
-    bwd_eventUIDs = fwd_op_event.get("bwd_events")
-    if not bwd_eventUIDs:
-        perf_analyzer.tree.link_bwd_events(fwd_op_event["UID"])
-        bwd_eventUIDs = fwd_op_event.get("bwd_events")
+    bwd_eventUIDs = fwd_op_event.get(
+        "bwd_events"
+    ) or perf_analyzer.tree.get_subtree_bwd_events(fwd_op_event["UID"])
     bwd_events = [perf_analyzer.tree.get_UID2event(uid) for uid in bwd_eventUIDs]
     return bwd_events
 

--- a/examples/example_megatron_extension.py
+++ b/examples/example_megatron_extension.py
@@ -59,11 +59,11 @@ def tree_postprocess_extension(trace_tree):
 def get_bwd_ops_for_fwd_op(trace_tree, fwd_op_event: dict) -> list[dict]:
     """
     Get backward operations for a given forward operation.
+    Uses on-demand subtree aggregation to find all backward events.
     """
-    bwd_eventUIDs = fwd_op_event.get("bwd_events")
-    if not bwd_eventUIDs:
-        trace_tree.link_bwd_events(fwd_op_event["UID"])
-        bwd_eventUIDs = fwd_op_event.get("bwd_events")
+    bwd_eventUIDs = fwd_op_event.get("bwd_events") or trace_tree.get_subtree_bwd_events(
+        fwd_op_event["UID"]
+    )
     bwd_events = [trace_tree.get_UID2event(uid) for uid in bwd_eventUIDs]
     return bwd_events
 


### PR DESCRIPTION
Enable tracing backward autograd events to their forward callstacks:

- Add link_all_fwd_bwd_events() to auto-link 1:1 forward-backward pairs using sequence numbers during tree building
- Add follow_fwd_link parameter to traverse_parents_and_print/get_callstack to follow bwd_event -> fwd_event links when reaching backward roots
- Add include_bwd parameter to traverse_subtree_and_print to show linked backward events inline with [BWD] markers
- Add get_subtree_bwd_events() for on-demand backward event aggregation
- Simplify compute_perf_metrics to always use subtree aggregation for backward metrics

