### PR TITLE
fix(TreePerf): Restore execute pass-through in kernel launcher detection

### DIFF
--- a/TraceLens/TreePerf/tree_perf.py
+++ b/TraceLens/TreePerf/tree_perf.py
@@ -658,6 +658,12 @@ class TreePerfAnalyzer:
             while current is not None:
                 cat = self.event_to_category(current)
                 if cat == "cpu_op":
+                    # Special case: 'execute' is a pass-through cpu_op
+                    # (e.g. conv_bn_fused -> execute -> cuda launch -> kernel)
+                    # Skip it and use its parent as the launcher instead.
+                    if current.get("name") == "execute":
+                        current = self.tree.get_parent_event(current)
+                        continue
                     leaf_cpu_op = current
                     break
                 elif cat == "python_function":


### PR DESCRIPTION
The refactor in b183198 replaced forward-traversal with backward-traversal for get_kernel_launchers but dropped the special-case handling for 'execute' cpu_ops. This caused conv_bn_fused -> execute -> cuda launch -> kernel to incorrectly pick 'execute' as the launcher instead of conv_bn_fused.

Restore the skip for 'execute' in the backward walk and update tests to assert the parent cpu_op is used as the launcher.
