### PR TITLE
CPU operation to kernel mapping

### DIFF
--- a/TraceLens/TraceDiff/trace_diff.py
+++ b/TraceLens/TraceDiff/trace_diff.py
@@ -1116,7 +1116,7 @@ class TraceDiff:
 
             if should_traverse_children:
                 for cid in node["children"]:
-                    traverse(cid, combined_parent_node)
+                    traverse(cid, node)
             return
 
         for root_id in merged_root_ids:


### PR DESCRIPTION
Creates a JSON mapping CPU operations to kernels.
cpu_op_map_trace1.json maps CPU operations in trace1 to their list of associated kernels
cpu_op_map_trace2.json maps CPU operations in trace2 to their list of associated kernels

cpu_op_map.json maps CPU operations in both traces to their list of associated kernels. Given two CPU operation names in trace1 and trace2 that are likely related or identical, it renames these CPU operations to a common name shared between the two traces. If the names are not similar but are have the same nn.Module parent, the CPU operations are renamed to the nn.Module parent. Otherwise, the CPU operations are not renamed.

Additionally, 
1. Removed line number from LCA name in report. 
2. Fixed LCA id in rare cases where root node is not combined