### PR TITLE
ci: consolidate workflow dependencies and add pip caching

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,14 +20,15 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.x'  # Specify the Python version you need
+        python-version: '3.10'
+        cache: 'pip'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -23,38 +23,30 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.10'
+          cache: 'pip'
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .
+          pip install . pytest openpyxl tensorboard-plugin-profile==2.19.0
 
-      - name: Run pytest on function-based tests
-        run: |
-          pip install pytest
-          pytest tests/test_subtract_intervals.py tests/test_graph_mode.py tests/test_kernel_launchers.py
+      - name: Run function-based tests
+        run: pytest tests/test_subtract_intervals.py tests/test_graph_mode.py tests/test_kernel_launchers.py
 
-      - name: Run pytest on rocprof based testcases
-        run: |
-          pip install pytest openpyxl pandas
-          pytest tests/test_rocprof_perf_report.py
+      - name: Run rocprof report tests
+        run: pytest tests/test_rocprof_perf_report.py
 
-      - name: Run pytest on report regression tests
-        run: |
-          pip install pytest openpyxl pandas
-          pytest tests/test_compare_perf_report.py
+      - name: Run report regression tests
+        run: pytest tests/test_compare_perf_report.py
 
-      - name: Run pytest on collective analysis tests
-        run: |
-          pip install pytest openpyxl pandas
-          pytest tests/test_collective_analysis.py
-      
-      - name: Run pytest on JAX perf report end-to-end tests
-        run: |
-          pip install pytest openpyxl pandas tensorboard-plugin-profile==2.19.0
-          pytest tests/test_jax_perf_report.py
+      - name: Run collective analysis tests
+        run: pytest tests/test_collective_analysis.py
+
+      - name: Run JAX perf report tests
+        run: pytest tests/test_jax_perf_report.py
+
+      - name: Run detect recompute tests
+        run: pytest tests/test_detect_recompute.py
 
       - name: Run copyright header checks
-        run: |
-          pip install pytest
-          pytest tests/test_copyright_headers.py
+        run: pytest tests/test_copyright_headers.py


### PR DESCRIPTION
- Install all test deps (pytest, openpyxl, tensorboard-plugin-profile) once instead of repeating pip install in each test step
- Enable pip caching via setup-python cache: 'pip'
- Update lint.yml actions from v2 to v4/v5
- Add test_detect_recompute.py to regression test workflow

Made-with: Cursor








