### PR TITLE
Add ridge point column to tracelens perf report roofline metrics

### DIFF
--- a/TraceLens/TreePerf/tree_perf.py
+++ b/TraceLens/TreePerf/tree_perf.py
@@ -395,13 +395,12 @@ class TreePerfAnalyzer:
                 # Memory time: bytes / (bandwidth_gbps * 1e9) gives seconds, convert to µs
                 memory_time_us = (bytes_moved / (mem_bw_gbps * 1e9)) * 1e6
                 roofline_time_us = max(compute_time_us, memory_time_us)
-                # Add ridge point column
                 if compute_time_us >= memory_time_us:
-                    ridge_point = "COMPUTE_BOUND"
+                    roofline_bound = "COMPUTE_BOUND"
                 else:
-                    ridge_point = "MEMORY_BOUND"
+                    roofline_bound = "MEMORY_BOUND"
                 dict_metrics["Roofline Time (µs)"] = roofline_time_us
-                dict_metrics["Roofline Ridge Point"] = ridge_point
+                dict_metrics["Roofline Bound"] = roofline_bound
                 dict_metrics["Pct Roofline"] = (
                     (roofline_time_us / busy_kernel_time) * 100
                     if busy_kernel_time > 0
@@ -594,6 +593,8 @@ class TreePerfAnalyzer:
         # Roofline metrics - first since they should be same for the group
         if "Roofline Time (µs)" in df_perf_metrics.columns:
             dict_agg["Roofline Time (µs)"] = "first"
+        if "Roofline Bound" in df_perf_metrics.columns:
+            dict_agg["Roofline Bound"] = "first"
         if "Pct Roofline" in df_perf_metrics.columns:
             dict_agg["Pct Roofline"] = agg_metrics
         if "Simulated Time (µs)" in df_perf_metrics.columns:
@@ -1576,6 +1577,7 @@ class TreePerfAnalyzer:
                 "TB/s",
                 "Compute Spec",
                 "Roofline Time (µs)",
+                "Roofline Bound",
                 "Pct Roofline",
             ]
 
@@ -1760,6 +1762,8 @@ class TreePerfAnalyzer:
         # Roofline metrics
         if "Roofline Time (µs)" in df_temp.columns:
             agg_dict["Roofline Time (µs)"] = "first"  # Static for same args
+        if "Roofline Bound" in df_temp.columns:
+            agg_dict["Roofline Bound"] = "first"  # Static for same args
         if "Pct Roofline" in df_temp.columns:
             agg_dict["Pct Roofline"] = agg_metrics  # Varies per instance
 

--- a/tests/test_roofline_bound.py
+++ b/tests/test_roofline_bound.py
@@ -1,0 +1,111 @@
+###############################################################################
+# Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Test that the Roofline Bound column appears in the unified_perf_summary
+and per-category sheets when a GPU arch config is provided.
+"""
+
+import json
+import os
+import tempfile
+
+import pandas as pd
+import pytest
+
+from TraceLens.Reporting.generate_perf_report_pytorch import (
+    generate_perf_report_pytorch,
+)
+
+MI300X_ARCH = {
+    "name": "MI300X",
+    "mem_bw_gbps": 5300,
+    "max_achievable_tflops": {
+        "matrix_fp16": 654,
+        "matrix_bf16": 708,
+        "matrix_fp32": 163,
+        "matrix_fp64": 81,
+        "matrix_fp8": 1273,
+        "matrix_int8": 2600,
+        "vector_fp16": 163,
+        "vector_bf16": 163,
+        "vector_fp32": 81,
+        "vector_fp64": 40,
+    },
+    "_reference": "https://rocm.blogs.amd.com/software-tools-optimization/measuring-max-achievable-flops-part2/README.html#amd-maf-results",
+}
+
+TRACE_PATH = os.path.join(
+    "tests",
+    "traces",
+    "mi300",
+    "Falconsai_nsfw_image_detection__1016002.json.gz",
+)
+
+VALID_BOUND_VALUES = {"COMPUTE_BOUND", "MEMORY_BOUND"}
+
+
+@pytest.fixture(scope="module")
+def perf_report(tmp_path_factory):
+    """Generate a perf report with GPU arch config once for the module."""
+    output_dir = tmp_path_factory.mktemp("roofline_bound")
+    arch_path = str(output_dir / "mi300x.json")
+    report_path = str(output_dir / "perf_report.xlsx")
+
+    with open(arch_path, "w") as f:
+        json.dump(MI300X_ARCH, f)
+
+    generate_perf_report_pytorch(
+        profile_json_path=TRACE_PATH,
+        output_xlsx_path=report_path,
+        gpu_arch_json_path=arch_path,
+    )
+
+    return report_path
+
+
+def _find_roofline_bound_col(df):
+    """Find the Roofline Bound column, which may have an aggregation suffix."""
+    for col in df.columns:
+        if col == "Roofline Bound" or col.startswith("Roofline Bound"):
+            return col
+    return None
+
+
+def test_roofline_bound_in_unified_perf_summary(perf_report):
+    """Roofline Bound column must appear in unified_perf_summary."""
+    df = pd.read_excel(perf_report, sheet_name="unified_perf_summary")
+    bound_col = _find_roofline_bound_col(df)
+    assert bound_col is not None, (
+        f"'Roofline Bound' missing from unified_perf_summary. "
+        f"Columns: {list(df.columns)}"
+    )
+    bound_vals = set(df[bound_col].dropna().unique())
+    assert bound_vals <= VALID_BOUND_VALUES, f"Unexpected values: {bound_vals}"
+
+
+def test_roofline_bound_in_category_sheets(perf_report):
+    """Roofline Bound column must appear in per-category sheets that have roofline data."""
+    xls = pd.ExcelFile(perf_report)
+    sheets_with_roofline = []
+    for sheet in xls.sheet_names:
+        df = pd.read_excel(xls, sheet_name=sheet)
+        roofline_time_cols = [c for c in df.columns if c.startswith("Roofline Time")]
+        if roofline_time_cols:
+            sheets_with_roofline.append(sheet)
+            bound_col = _find_roofline_bound_col(df)
+            assert bound_col is not None, (
+                f"Sheet '{sheet}' has roofline time but missing "
+                f"'Roofline Bound'. Columns: {list(df.columns)}"
+            )
+            bound_vals = set(df[bound_col].dropna().unique())
+            assert (
+                bound_vals <= VALID_BOUND_VALUES
+            ), f"Sheet '{sheet}': unexpected Roofline Bound values: {bound_vals}"
+
+    assert (
+        sheets_with_roofline
+    ), "No sheets contain Roofline Time — arch config may not have been applied"


### PR DESCRIPTION
<!--
Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.

See LICENSE for license information.
-->

# Add roofline ridge point to tracelens perf report roofline metrics
This is a simple addition that updates the tracelens perf report; if a gpu architecture `json` is provided a roofline ridge point column featuring options `COMPUTE_BOUND` or `MEMORY_BOUND` will appear alongside columns like `roofline_time_us` to indicate to the user where the kernel of interest lies with respect to the roofline ridge. 

               if compute_time_us >= memory_time_us:
                    ridge_point = "COMPUTE_BOUND"
                else:
                    ridge_point = "MEMORY_BOUND"

> **Note to AMDers:**  
> This is a public repository. Please do **not** upload any confidential or customer data. Make sure all such data has been anonymized or removed before making this PR. If you need to attach any private files or links, please insert a Internal OneDrive Link or a Jira Ticket Link instead.
