### PR TITLE
Perform a second pass in unified table creation to find GPU events wi…

### DIFF
--- a/TraceLens/TreePerf/tree_perf.py
+++ b/TraceLens/TreePerf/tree_perf.py
@@ -1478,6 +1478,49 @@ class TreePerfAnalyzer:
         for root_uid in self.tree.cpu_root_nodes:
             traverse(root_uid)
 
+        # Collect GPU kernels that have no cpu_op in their parent hierarchy.
+        # These are missed by the cpu_root_nodes traversal above.
+        collected_gpu_uids = set()
+        for evt in collected:
+            collected_gpu_uids.update(evt.get("gpu_events", []))
+
+        orphan_kernels = []
+        for evt in self.tree.events:
+            if self.event_to_category(evt) not in {"kernel", "gpu_memcpy", "gpu_memset"}:
+                continue
+            if evt["UID"] in collected_gpu_uids:
+                continue
+            if not include_nccl and "nccl" in evt.get("name", "").lower():
+                continue
+
+            has_cpu_op = False
+            parent = self.tree.get_parent_event(evt)
+            while parent is not None:
+                if self.event_to_category(parent) == "cpu_op":
+                    has_cpu_op = True
+                    break
+                parent = self.tree.get_parent_event(parent)
+
+            if not has_cpu_op:
+                orphan_kernels.append(evt)
+
+        # Group orphan kernels by their immediate parent (typically a runtime event)
+        parent_to_orphans = defaultdict(list)
+        for kernel in orphan_kernels:
+            parent = self.tree.get_parent_event(kernel)
+            parent_uid = parent["UID"] if parent else None
+            parent_to_orphans[parent_uid].append(kernel)
+
+        for parent_uid, kernels in parent_to_orphans.items():
+            if parent_uid is None:
+                continue
+            parent_evt = self.tree.get_UID2event(parent_uid)
+            for kernel in kernels:
+                synthetic = dict(parent_evt)
+                synthetic["name"] = f"{parent_evt['name']}::{kernel['name']}"
+                synthetic["gpu_events"] = [kernel["UID"]]
+                collected.append(synthetic)
+
         return collected
 
     def build_df_unified_perf_table(


### PR DESCRIPTION
This pull request enhances the logic in the `traverse` method of `tree_perf.py` to ensure GPU kernel events that are not associated with any CPU operation in their parent hierarchy are properly included in the collected events. The update identifies "orphan" GPU kernels, groups them by their immediate parent event, and creates synthetic parent events to represent these relationships.

**Improvements to GPU kernel event handling:**

* Added logic to identify GPU kernel events (including `kernel`, `gpu_memcpy`, `gpu_memset`) that do not have a CPU operation in their parent hierarchy, ensuring these "orphan" kernels are not missed in the collection process.
* Grouped orphan GPU kernels by their immediate parent event and generated synthetic parent events to accurately represent the relationship in the collected events.

<!--
Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.

See LICENSE for license information.
-->
