### PR TITLE
Add roofline support for aiter::mha  ops

### DIFF
--- a/TraceLens/PerfModel/perf_model.py
+++ b/TraceLens/PerfModel/perf_model.py
@@ -2782,89 +2782,68 @@ class aiter__fmha_v3_backward(SDPA):
         return self.bytes_bwd(bytes_per_element)
 
 
-class aiter_mha_fwd(SDPA):
+def _parse_aiter_mha_fwd_args(event):
+    """Shared parser for aiter::mha_fwd and aiter::fmha_v3_fwd.
+
+    Both ops share the same argument layout:
+      q[0], k[1], v[2] — raw shape (B, N, H, d_h) in bnhd order;
+      bhnd_idx=(0,2,1,3) extracts B, H, N, d_h from the bnhd tuple.
+      dropout_p[3], softmax_scale[4], is_causal[5].
+    """
+    input_dims = event["args"]["Input Dims"]
+    concrete_inputs = event["args"]["Concrete Inputs"]
+    q_shape, k_shape, v_shape = input_dims[0], input_dims[1], input_dims[2]
+    bhnd_idx = 0, 2, 1, 3
+    sdpa_cfg = extract_sdpa_cfg(q_shape, k_shape, v_shape, bhnd_idx)
+    B, N_Q, H_Q, N_KV, H_KV, d_h_qk, d_h_v = (
+        sdpa_cfg[key] for key in ["B", "N_Q", "H_Q", "N_KV", "H_KV", "d_h_qk", "d_h_v"]
+    )
+    dropout_p = 0.0
+    if concrete_inputs[3] not in ("", "None"):
+        try:
+            dropout_p = float(concrete_inputs[3])
+        except (ValueError, TypeError):
+            pass
+    is_causal = (
+        concrete_inputs[5].lower() == "true"
+        if concrete_inputs[5] not in ("", "None")
+        else False
+    )
+    return {
+        "B": B,
+        "N_Q": N_Q,
+        "H_Q": H_Q,
+        "N_KV": N_KV,
+        "H_KV": H_KV,
+        "d_h_qk": d_h_qk,
+        "d_h_v": d_h_v,
+        "dropout": dropout_p,
+        "causal": is_causal,
+        "flash_impl": True,
+    }
+
+
+class aiter__mha_fwd(SDPA):
     # aiter::mha_fwd(q, k, v, dropout_p, softmax_scale, is_causal, ...)
-    # Tensor args: q[0], k[1], v[2] — shape (B, N, H, d_h), bhnd layout
+    # Raw tensor shape (B, N, H, d_h) in bnhd order; bhnd_idx=(0,2,1,3) extracts B,H,N,d_h.
 
     @staticmethod
     def get_param_details(event):
-        input_dims = event["args"]["Input Dims"]
-        concrete_inputs = event["args"]["Concrete Inputs"]
-        q_shape, k_shape, v_shape = input_dims[0], input_dims[1], input_dims[2]
-        bhnd_idx = 0, 2, 1, 3
-        sdpa_cfg = extract_sdpa_cfg(q_shape, k_shape, v_shape, bhnd_idx)
-        B, N_Q, H_Q, N_KV, H_KV, d_h_qk, d_h_v = (
-            sdpa_cfg[key]
-            for key in ["B", "N_Q", "H_Q", "N_KV", "H_KV", "d_h_qk", "d_h_v"]
-        )
-        dropout_p = 0.0
-        if concrete_inputs[3] not in ("", "None"):
-            try:
-                dropout_p = float(concrete_inputs[3])
-            except (ValueError, TypeError):
-                pass
-        is_causal = (
-            concrete_inputs[5].lower() == "true"
-            if concrete_inputs[5] not in ("", "None")
-            else False
-        )
-        return {
-            "B": B,
-            "N_Q": N_Q,
-            "H_Q": H_Q,
-            "N_KV": N_KV,
-            "H_KV": H_KV,
-            "d_h_qk": d_h_qk,
-            "d_h_v": d_h_v,
-            "dropout": dropout_p,
-            "causal": is_causal,
-            "flash_impl": True,
-        }
+        return _parse_aiter_mha_fwd_args(event)
 
 
-class aiter_fmha_v3_fwd(SDPA):
+class aiter__fmha_v3_fwd(SDPA):
     # aiter::fmha_v3_fwd(q, k, v, dropout_p, softmax_scale, is_causal, ...)
-    # Tensor args: q[0], k[1], v[2] — shape (B, N, H, d_h), bhnd layout
+    # Same argument layout as aiter::mha_fwd — raw shape (B, N, H, d_h) in bnhd order.
 
     @staticmethod
     def get_param_details(event):
-        input_dims = event["args"]["Input Dims"]
-        concrete_inputs = event["args"]["Concrete Inputs"]
-        q_shape, k_shape, v_shape = input_dims[0], input_dims[1], input_dims[2]
-        bhnd_idx = 0, 2, 1, 3
-        sdpa_cfg = extract_sdpa_cfg(q_shape, k_shape, v_shape, bhnd_idx)
-        B, N_Q, H_Q, N_KV, H_KV, d_h_qk, d_h_v = (
-            sdpa_cfg[key]
-            for key in ["B", "N_Q", "H_Q", "N_KV", "H_KV", "d_h_qk", "d_h_v"]
-        )
-        dropout_p = 0.0
-        if concrete_inputs[3] not in ("", "None"):
-            try:
-                dropout_p = float(concrete_inputs[3])
-            except (ValueError, TypeError):
-                pass
-        is_causal = (
-            concrete_inputs[5].lower() == "true"
-            if concrete_inputs[5] not in ("", "None")
-            else False
-        )
-        return {
-            "B": B,
-            "N_Q": N_Q,
-            "H_Q": H_Q,
-            "N_KV": N_KV,
-            "H_KV": H_KV,
-            "d_h_qk": d_h_qk,
-            "d_h_v": d_h_v,
-            "dropout": dropout_p,
-            "causal": is_causal,
-            "flash_impl": True,
-        }
+        return _parse_aiter_mha_fwd_args(event)
 
 
-class aiter_mha_bwd(SDPA):
+class aiter__mha_bwd(SDPA):
     # aiter::mha_bwd(dout, q, k, v, out, softmax_lse, dropout_p, softmax_scale, is_causal, ...)
-    # Tensor args: q[1], k[2], v[3] — shape (B, N, H, d_h), bhnd layout
+    # q[1], k[2], v[3] — raw shape (B, N, H, d_h) in bnhd order; bhnd_idx=(0,2,1,3) extracts B,H,N,d_h.
 
     @staticmethod
     def get_param_details(event):

--- a/TraceLens/PerfModel/torch_op_mapping.py
+++ b/TraceLens/PerfModel/torch_op_mapping.py
@@ -35,9 +35,9 @@ op_to_perf_model_class_map = {
     "aiter::_flash_attn_backward": perf_model.aiter__flash_attn_backward,
     "aiter::wrapper_fmha_v3_fwd": perf_model.aiter__fmha_v3_forward,
     "aiter::wrapper_fmha_v3_bwd": perf_model.aiter__fmha_v3_backward,
-    "aiter::mha_fwd": perf_model.aiter_mha_fwd,
-    "aiter::fmha_v3_fwd": perf_model.aiter_fmha_v3_fwd,
-    "aiter::mha_bwd": perf_model.aiter_mha_bwd,
+    "aiter::mha_fwd": perf_model.aiter__mha_fwd,
+    "aiter::fmha_v3_fwd": perf_model.aiter__fmha_v3_fwd,
+    "aiter::mha_bwd": perf_model.aiter__mha_bwd,
     "flash_attn_3::fwd": perf_model.flash_attn_v3_forward,
     "vllm::unified_attention_with_output": perf_model.vllm_unified_attention_with_output,
     # TEv2 pseudo ops

--- a/tests/test_aiter_mha_ops.py
+++ b/tests/test_aiter_mha_ops.py
@@ -5,9 +5,9 @@
 ###############################################################################
 
 from TraceLens.PerfModel.perf_model import (
-    aiter_mha_fwd,
-    aiter_fmha_v3_fwd,
-    aiter_mha_bwd,
+    aiter__mha_fwd,
+    aiter__fmha_v3_fwd,
+    aiter__mha_bwd,
 )
 from TraceLens.PerfModel.torch_op_mapping import (
     categorize_torch_op,
@@ -20,9 +20,9 @@ from TraceLens.PerfModel.torch_op_mapping import (
 
 
 def test_aiter_mha_ops_are_mapped():
-    assert op_to_perf_model_class_map["aiter::mha_fwd"] is aiter_mha_fwd
-    assert op_to_perf_model_class_map["aiter::fmha_v3_fwd"] is aiter_fmha_v3_fwd
-    assert op_to_perf_model_class_map["aiter::mha_bwd"] is aiter_mha_bwd
+    assert op_to_perf_model_class_map["aiter::mha_fwd"] is aiter__mha_fwd
+    assert op_to_perf_model_class_map["aiter::fmha_v3_fwd"] is aiter__fmha_v3_fwd
+    assert op_to_perf_model_class_map["aiter::mha_bwd"] is aiter__mha_bwd
 
 
 def test_aiter_mha_fwd_categorizes_as_sdpa_fwd():
@@ -44,7 +44,7 @@ def test_aiter_mha_bwd_categorizes_as_sdpa_bwd():
 # Shared helpers
 # ---------------------------------------------------------------------------
 
-# q/k/v shape: (B=2, N=512, H=16, d_h=64) in bhnd layout → [B, N, H, d_h]
+# q/k/v shape: (B=2, N=512, H=16, d_h=64) in bnhd order; bhnd_idx=(0,2,1,3) extracts B,H,N,d_h
 _Q_SHAPE = [2, 512, 16, 64]
 _K_SHAPE = [2, 512, 16, 64]
 _V_SHAPE = [2, 512, 16, 64]
@@ -82,22 +82,22 @@ def _bwd_event():
 
 
 def test_aiter_mha_fwd_flops():
-    model = aiter_mha_fwd(_fwd_event("aiter::mha_fwd"))
+    model = aiter__mha_fwd(_fwd_event("aiter::mha_fwd"))
     # causal=True: 2 * B * H_Q * N_Q * N_KV/2 * (d_h_qk + d_h_v) = SDPA.flops_func causal
     assert model.flops() > 0
 
 
 def test_aiter_mha_fwd_causal_flag():
-    model = aiter_mha_fwd(_fwd_event("aiter::mha_fwd"))
+    model = aiter__mha_fwd(_fwd_event("aiter::mha_fwd"))
     assert model.param_details["causal"] is True
 
 
 def test_aiter_mha_fwd_non_causal():
     concrete = list(_FWD_CONCRETE)
     concrete[5] = "False"
-    model = aiter_mha_fwd(_fwd_event("aiter::mha_fwd", concrete))
+    model = aiter__mha_fwd(_fwd_event("aiter::mha_fwd", concrete))
     assert model.param_details["causal"] is False
-    causal_model = aiter_mha_fwd(_fwd_event("aiter::mha_fwd"))
+    causal_model = aiter__mha_fwd(_fwd_event("aiter::mha_fwd"))
     # non-causal attends to full KV → higher flops than causal
     assert model.flops() > causal_model.flops()
 
@@ -109,24 +109,24 @@ def test_aiter_mha_fwd_non_causal():
 
 def test_aiter_fmha_v3_fwd_flops_match_mha_fwd():
     # Same argument layout as mha_fwd — flops must be identical for same shapes
-    mha = aiter_mha_fwd(_fwd_event("aiter::mha_fwd"))
-    v3 = aiter_fmha_v3_fwd(_fwd_event("aiter::fmha_v3_fwd"))
+    mha = aiter__mha_fwd(_fwd_event("aiter::mha_fwd"))
+    v3 = aiter__fmha_v3_fwd(_fwd_event("aiter::fmha_v3_fwd"))
     assert mha.flops() == v3.flops()
     assert mha.bytes() == v3.bytes()
 
 
 # ---------------------------------------------------------------------------
-# aiter_mha_bwd
+# aiter__mha_bwd
 # ---------------------------------------------------------------------------
 
 
 def test_aiter_mha_bwd_flops():
-    model = aiter_mha_bwd(_bwd_event())
+    model = aiter__mha_bwd(_bwd_event())
     assert model.flops() > 0
 
 
 def test_aiter_mha_bwd_flops_greater_than_fwd():
-    fwd = aiter_mha_fwd(_fwd_event("aiter::mha_fwd"))
-    bwd = aiter_mha_bwd(_bwd_event())
+    fwd = aiter__mha_fwd(_fwd_event("aiter::mha_fwd"))
+    bwd = aiter__mha_bwd(_bwd_event())
     # Backward FLOPs > forward FLOPs (flash bwd is ~2.5x fwd for causal)
     assert bwd.flops() > fwd.flops()


### PR DESCRIPTION
Closes https://github.com/AMD-AGI/TraceLens/issues/517 

## Summary

When Primus training runs are profiled with PyTorch, `aiter::mha_fwd`, `aiter::fmha_v3_fwd`, and `aiter::mha_bwd` appear in traces but were uncategorized in TraceLens reports — they fell through to "other" with no SDPA roofline analysis. This PR adds perf model coverage for these ops, sourcing argument indices from [`ROCm/aiter/aiter/ops/mha.py`](https://github.com/ROCm/aiter/blob/main/aiter/ops/mha.py).

## Changes

**`perf_model.py`** — shared helper + three new classes, all inheriting `SDPA`:
- `_parse_aiter_mha_fwd_args()` — module-level helper shared by `aiter__mha_fwd` and `aiter__fmha_v3_fwd` to avoid duplicate `get_param_details`.
- `aiter__mha_fwd` — `q[0],k[1],v[2]`; `dropout_p[3]`; `is_causal[5]`. Inherits `flops()`/`bytes()`.
- `aiter__fmha_v3_fwd` — same argument layout as `aiter__mha_fwd`; delegates to shared helper.
- `aiter__mha_bwd` — `q[1],k[2],v[3]`; `dropout_p[6]`; `is_causal[8]`. Overrides `flops()`/`bytes()` to use backward formulas.

**`torch_op_mapping.py`** — 3 op-name registrations. `aiter::mha_bwd` also added to `sdpa_bwd_names` for correct `SDPA_bwd` subcategorization.

## Tests

10 unit tests in `tests/test_aiter_mha_ops.py`: mapping, categorization (fwd/bwd split), causal flag parsing, non-causal vs causal flops comparison, fwd/bwd relative magnitude.