### PR TITLE
Improve Trace2Tree runtime

### DIFF
--- a/TraceLens/Trace2Tree/trace_to_tree.py
+++ b/TraceLens/Trace2Tree/trace_to_tree.py
@@ -638,7 +638,9 @@ class TraceToTree:
         self.ac2g_event_map = {"start": {}, "end": {}}
         self.pid_tid_event_map = {}
         self.seq_num2event_uids_map = {}  # from seq id to list uids
-        self.runtime_event_uids = []  # UIDs of cuda_runtime/cuda_driver events for fast add_gpu_ops_to_tree
+        self.runtime_event_uids = (
+            []
+        )  # UIDs of cuda_runtime/cuda_driver events for fast add_gpu_ops_to_tree
         # Index: linking_key value -> list of GPU events (for _get_graph_gpu_events, avoids O(N) scan per graph launch)
         self.linking_id_to_gpu_events = defaultdict(list)
         # self.dict_pythonID2UID = {}  # Commented out: never read, only written

--- a/TraceLens/util.py
+++ b/TraceLens/util.py
@@ -37,12 +37,19 @@ class DataLoader:
             data = data.decode("utf-8")  # we get bytes back from the call above
         elif filename_path.endswith("json.gz"):
             import gzip
+            import time
 
+            t0 = time.time()
             with gzip.open(filename_path, "r") as fin:
                 data = fin.read()  # Keep as bytes for orjson
+            print(f"[timing] load_data: file read (gzip) {time.time() - t0:.3f}s")
         elif filename_path.endswith("json"):
+            import time
+
+            t0 = time.time()
             with open(filename_path, "rb") as fin:  # Read as bytes for orjson
                 data = fin.read()
+            print(f"[timing] load_data: file read (json) {time.time() - t0:.3f}s")
         else:
             raise ValueError("Unknown file type", filename_path)
         if save_preprocessed:
@@ -52,10 +59,15 @@ class DataLoader:
 
         # Use orjson for faster parsing (23% faster than stdlib json)
         # Falls back to json if orjson not available
+        import time
+
+        t0 = time.time()
         try:
             import orjson
 
-            return orjson.loads(data)
+            result = orjson.loads(data)
+            print(f"[timing] load_data: JSON parse {time.time() - t0:.3f}s")
+            return result
         except ImportError:
             logger.warning(
                 "orjson not available, falling back to standard json. "
@@ -63,7 +75,9 @@ class DataLoader:
             )
             if isinstance(data, bytes):
                 data = data.decode("utf-8")
-            return json.loads(data)
+            result = json.loads(data)
+            print(f"[timing] load_data: JSON parse (stdlib) {time.time() - t0:.3f}s")
+            return result
 
 
 class JaxProfileProcessor:


### PR DESCRIPTION
Each invocation of `_get_graph_gpu_events` searches for the GPU events associated with a graph launch. This was done by searching through every event in the trace and finding the events with the same linking key. This was where a bulk of the runtime was coming from.
`add_gpu_ops_to_tree` was traversing through all events as well, even if they weren't GPU events.

In the initial tree traversal in `_preprocess_and_index_events`, the GPU event uids are cached in an array and the CPU op to GPU kernel links are cached in a dict.

This improves runtime significantly. A trace that previously took 40 minutes to process now only takes around 1 minute.