### PR TITLE
intra vs inter node in multi collective report

### DIFF
--- a/TraceLens/Reporting/generate_multi_rank_collective_report_pytorch.py
+++ b/TraceLens/Reporting/generate_multi_rank_collective_report_pytorch.py
@@ -9,9 +9,7 @@ import re
 import argparse
 import pandas as pd
 import glob
-import sys
-from typing import List, Dict, Optional, Union
-import subprocess
+from typing import Dict, List, Optional
 import warnings
 from TraceLens import NcclAnalyser
 from TraceLens.Reporting.reporting_utils import (

--- a/TraceLens/Reporting/reporting_utils.py
+++ b/TraceLens/Reporting/reporting_utils.py
@@ -164,19 +164,29 @@ def add_node_span_columns(
     if df is None or df.empty:
         return df
 
-    if world_size is None:
-        if "rank" in df.columns:
-            world_size = int(df["rank"].max()) + 1
-        else:
-            logger.warning(
-                "Cannot infer world_size for node_span labeling; "
-                "skipping node columns."
-            )
-            return df
+    if gpus_per_node <= 0:
+        raise ValueError(
+            f"gpus_per_node must be a positive integer, got {gpus_per_node}"
+        )
 
     has_rank = "rank" in df.columns
     has_pg_ranks = "Process Group Ranks" in df.columns
     if not has_rank and not has_pg_ranks:
+        return df
+
+    if world_size is None:
+        if has_rank:
+            world_size = int(df["rank"].max()) + 1
+        elif has_pg_ranks:
+            all_ranks: set = set()
+            for v in df["Process Group Ranks"].dropna().unique():
+                all_ranks.update(_parse_pg_ranks(v))
+            world_size = max(all_ranks) + 1 if all_ranks else None
+
+    if world_size is None:
+        logger.warning(
+            "Cannot infer world_size for node_span labeling; " "skipping node columns."
+        )
         return df
 
     r2n = _rank_to_node_map(world_size, gpus_per_node)
@@ -186,9 +196,10 @@ def add_node_span_columns(
         df["node_id"] = df["rank"].map(r2n)
 
     if has_pg_ranks:
-        df["node_span"] = df["Process Group Ranks"].apply(
-            lambda v: _node_span_for_pg(v, r2n, gpus_per_node)
-        )
+        pg_series = df["Process Group Ranks"]
+        unique_pgs = pg_series.unique()
+        pg_to_span = {v: _node_span_for_pg(v, r2n, gpus_per_node) for v in unique_pgs}
+        df["node_span"] = pg_series.map(pg_to_span)
 
     return df
 

--- a/docs/generate_multi_rank_collective_report_pytorch.md
+++ b/docs/generate_multi_rank_collective_report_pytorch.md
@@ -93,7 +93,7 @@ TraceLens_generate_multi_rank_collective_report_pytorch   --trace_dir /path/to/t
 
 _Notes:_
 - Summary sheets (`nccl_summary_*`) are **always** produced; detailed per-event sheets (`nccl_long`, `nccl_implicit_sync`, `nccl_all2allv`) appear when `--detailed_analysis` is set.
-- When `gpus_per_node` is known (auto-detected or set via `--gpus_per_node`), all sheets gain `node_id` and `node_span` columns. `node_span` is `intra_node` when all ranks in the process group reside on the same node, or `inter_node` otherwise. You can filter or pivot on these columns in Excel to compare intra- vs inter-node communication.
+- When `gpus_per_node` is known (auto-detected or set via `--gpus_per_node`), sheets that contain `rank` and/or `Process Group Ranks` columns gain `node_id` and `node_span` columns (fully aggregated summary sheets without these columns remain unchanged). `node_span` is `intra_node` when all ranks in the process group reside on the same node, or `inter_node` otherwise. You can filter or pivot on these columns in Excel to compare intra- vs inter-node communication.
 - Column sets can evolve; the above reflects the provided example workbook.
 ---
 


### PR DESCRIPTION
## Summary
Add `node_id` and `node_span` columns to multi-rank collective report sheets, enabling users to distinguish intra-node vs inter-node communication directly in the output.

## Details
- New reusable utility `add_node_span_columns(df, gpus_per_node)` in `reporting_utils.py` adds `node_id` (`rank // gpus_per_node`) and `node_span` (`intra_node` / `inter_node`) columns to any NcclAnalyser DataFrame that has `rank` and/or `Process Group Ranks` columns. DataFrames without these columns (e.g. fully-aggregated summaries) are returned unchanged.
- New `detect_gpus_per_node(trace_filepath)` utility auto-detects GPUs per node from the trace file's `deviceProperties` metadata (length of the locally-visible GPU list). Returns `None` gracefully for non-PyTorch traces, CPU-only traces, or missing metadata.
- `--gpus_per_node` CLI argument added to `generate_multi_rank_collective_report_pytorch.py`. If omitted, auto-detected from the first trace file — zero friction for users.
- No changes to `NcclAnalyser` — node topology labeling is a post-processing step applied to the generated DataFrames, keeping separation of concerns clean.
- Documentation updated in `docs/generate_multi_rank_collective_report_pytorch.md`.

## Test plan
Tested against 2-node / 16-rank Primus Megatron traces (8 GPUs per node, MI300X):
- Auto-detection correctly inferred `gpus_per_node=8` from `deviceProperties`.
- All collectives labeled `inter_node` (consistent with FSDP-only topology where all process groups span both nodes).
- `nccl_summary_long` and `nccl_long` gain `node_id` + `node_span`; `nccl_implicit_sync` gains `node_span`; `nccl_summary_implicit_sync` (no rank/PG columns) left unchanged.
- Edge cases verified: None/empty DataFrames, missing `deviceProperties`, empty `deviceProperties`, nonexistent trace files, DataFrames without relevant columns.
 
```bash
python -m TraceLens.Reporting.generate_multi_rank_collective_report_pytorch \  
  --trace_pattern "/path/to/traces/rank*_trace.json.gz" \  
  --world_size 16 \  
  --detailed_analysis \  
  --output_xlsx_path "/path/to/output/nccl_analysis_report.xlsx"
```

When deviceProperties is present in the traces, node_id and node_span columns appear automatically without any extra flags.