### PR TITLE
Support vLLM/SGLang custom collective kernels in NcclAnalyser

### DIFF
--- a/TraceLens/NcclAnalyser/nccl_analyser.py
+++ b/TraceLens/NcclAnalyser/nccl_analyser.py
@@ -48,13 +48,62 @@ def _parse_split_sizes(value):
     return None
 
 
-def _nccl_filter_event_fn(event):
-    """Filters NCCL kernel events."""
-    is_nccl_kernel = (
-        event.get("cat") == "kernel" and "nccl" in event.get("name", "").lower()
+import re
+
+DEFAULT_CUSTOM_COLLECTIVE_PATTERNS = [
+    (r"cross_device_reduce", "allreduce"),
+]
+
+_DEFAULT_FILTER_PATTERNS = [re.compile(r"nccl", re.IGNORECASE)] + [
+    re.compile(p, re.IGNORECASE) for p, _ in DEFAULT_CUSTOM_COLLECTIVE_PATTERNS
+]
+
+_DEFAULT_INFERENCE_RULES = [
+    (re.compile(p, re.IGNORECASE), collective)
+    for p, collective in DEFAULT_CUSTOM_COLLECTIVE_PATTERNS
+]
+
+
+def _build_filter_and_inference_rules(custom_patterns):
+    """Build compiled regex lists from user-provided (pattern, collective) tuples."""
+    filter_patterns = [re.compile(r"nccl", re.IGNORECASE)]
+    inference_rules = []
+    for pattern, collective in custom_patterns:
+        compiled = re.compile(pattern, re.IGNORECASE)
+        filter_patterns.append(compiled)
+        inference_rules.append((compiled, collective))
+    return filter_patterns, inference_rules
+
+
+def _infer_collective_name(kernel_name, inference_rules):
+    """Infer a normalised collective name from the GPU kernel name.
+
+    Returns the collective name string if a known pattern matches,
+    otherwise ``None`` (meaning the caller should keep whatever the
+    trace already provides).
+    """
+    for pattern, collective in inference_rules:
+        if pattern.search(kernel_name):
+            return collective
+    return None
+
+
+def _collective_filter(event, filter_patterns):
+    """Filters collective kernel events (NCCL and custom collectives)."""
+    if event.get("cat") != "kernel":
+        return False
+    name = event.get("name", "")
+    is_collective = any(p.search(name) for p in filter_patterns)
+    args = event.get("args", {})
+    is_linked = (
+        args.get("correlation") is not None or args.get("External id") is not None
     )
-    is_linked = event.get("args", {}).get("External id") is not None
-    return is_nccl_kernel and is_linked
+    return is_collective and is_linked
+
+
+def _nccl_filter_event_fn(event):
+    """Default filter using built-in patterns (for multiprocessing path)."""
+    return _collective_filter(event, _DEFAULT_FILTER_PATTERNS)
 
 
 def _load_single_rank_process(rank, filepath):
@@ -78,7 +127,19 @@ class NcclAnalyser:
         world_size,
         use_multiprocessing=False,
         max_workers=None,
+        custom_collective_patterns=None,
     ):
+        """
+        Parameters
+        ----------
+        custom_collective_patterns : list of (str, str) tuples, optional
+            Each tuple is ``(regex_pattern, collective_name)``.  The regex
+            is matched against GPU kernel names to identify custom
+            collective kernels (e.g. vLLM's ``cross_device_reduce``).
+            When a kernel matches and has no ``Collective name`` in its
+            trace metadata, *collective_name* is used as the inferred type.
+            Defaults to ``DEFAULT_CUSTOM_COLLECTIVE_PATTERNS``.
+        """
         self.logger = logging.getLogger(__name__)
         self.list_profile_filepaths = list_profile_filepaths
         self.world_size = world_size
@@ -86,6 +147,15 @@ class NcclAnalyser:
         # Default to cpu_count (user can override with max_workers parameter if needed)
         self.max_workers = (
             max_workers if max_workers is not None else (os.cpu_count() or 8)
+        )
+
+        patterns = (
+            custom_collective_patterns
+            if custom_collective_patterns is not None
+            else DEFAULT_CUSTOM_COLLECTIVE_PATTERNS
+        )
+        self._filter_patterns, self._inference_rules = (
+            _build_filter_and_inference_rules(patterns)
         )
 
         # Byte sizes per dtype
@@ -137,15 +207,12 @@ class NcclAnalyser:
 
         # Internal storage
         self.rank2trace_data = {}  # Stores per-rank data
+        self._simplified_mode = False
         self.load_trace_data()
 
     def _nccl_filter_event_fn(self, event):
-        """Filters NCCL kernel events."""
-        is_nccl_kernel = (
-            event.get("cat") == "kernel" and "nccl" in event.get("name", "").lower()
-        )
-        is_linked = event.get("args", {}).get("External id") is not None
-        return is_nccl_kernel and is_linked
+        """Filters collective kernel events using instance patterns."""
+        return _collective_filter(event, self._filter_patterns)
 
     def load_trace_data(self):
         """Loads NCCL JSON trace data and extracts relevant events."""
@@ -205,6 +272,12 @@ class NcclAnalyser:
                     if isinstance(field_value, list):
                         field_value = list_to_tuple(field_value)
                     row[field] = field_value
+                if row["Collective name"] is None:
+                    inferred = _infer_collective_name(
+                        evt.get("name", ""), self._inference_rules
+                    )
+                    if inferred is not None:
+                        row["Collective name"] = inferred
                 bytes_per_elem = (
                     self.dtype2bytes[row["dtype"]]
                     if row["dtype"] in self.dtype2bytes
@@ -230,21 +303,49 @@ class NcclAnalyser:
 
         df_long = df_long.reset_index(drop=True)
 
-        # Assign an index within each process group and rank
-        df_long["Process Group Name"] = df_long["Process Group Name"].fillna(
-            "Unknown_Group"
+        # Detect simplified inference mode: all NCCL kernels on a single
+        # stream per rank and no Process Group metadata.  When both
+        # conditions hold we match collectives across ranks purely by
+        # their temporal order on the stream (idx_instream).
+        pg_all_missing = (
+            df_long["Process Group Name"].isna().all()
+            or (
+                df_long["Process Group Name"].fillna("Unknown_Group") == "Unknown_Group"
+            ).all()
         )
-        df_long["index_in_group"] = (
-            df_long.groupby(["Process Group Name", "rank"])["ts"]
-            .rank(method="first")
-            .astype(int)
-            - 1
+        single_stream_per_rank = all(
+            df_long.loc[df_long["rank"] == r, "stream"].nunique() <= 1
+            for r in df_long["rank"].unique()
         )
+        self._simplified_mode = pg_all_missing and single_stream_per_rank
 
-        # Create a composite collective ID (process group + index)
-        df_long["collective_id"] = (
-            df_long["Process Group Name"] + "_" + df_long["index_in_group"].astype(str)
-        )
+        if self._simplified_mode:
+            self.logger.info(
+                "Detected simplified inference mode: all NCCL kernels on a "
+                "single stream with no Process Group metadata. Matching "
+                "collectives by stream-order index."
+            )
+            df_long["Process Group Name"] = "all"
+            df_long["index_in_group"] = (
+                df_long.groupby(["rank"])["ts"].rank(method="first").astype(int) - 1
+            )
+            df_long["collective_id"] = df_long["index_in_group"].astype(str)
+        else:
+            # Regular path: match by (Process Group Name, temporal order)
+            df_long["Process Group Name"] = df_long["Process Group Name"].fillna(
+                "Unknown_Group"
+            )
+            df_long["index_in_group"] = (
+                df_long.groupby(["Process Group Name", "rank"])["ts"]
+                .rank(method="first")
+                .astype(int)
+                - 1
+            )
+            df_long["collective_id"] = (
+                df_long["Process Group Name"]
+                + "_"
+                + df_long["index_in_group"].astype(str)
+            )
 
         desired_col_order = [
             "collective_id",
@@ -386,26 +487,33 @@ class NcclAnalyser:
             rank_events = df[df["collective_id"] == cid]
             rank_events = rank_events.set_index("rank")
 
-            # Skip if the collective type is not in the implicit sync category
             collective_name = rank_events.iloc[0]["Collective name"]
-            if (
-                self.collective_name2type.get(collective_name)
-                not in self.implicit_sync_cat
-            ):
-                continue
+            c_type = self.collective_name2type.get(collective_name)
 
-            # **Metadata Consistency Check**
+            if self._simplified_mode:
+                # In simplified mode, include all collectives when the name
+                # is missing or unrecognised; otherwise still filter.
+                if collective_name is not None and c_type is not None:
+                    if c_type not in self.implicit_sync_cat:
+                        continue
+            else:
+                if c_type not in self.implicit_sync_cat:
+                    continue
+
+            # **Metadata Consistency Check** (skip in simplified mode —
+            # fields may be uniformly absent)
             ref_metadata = {
                 field: rank_events.iloc[0][field] for field in metadata_fields
             }
-            for field in metadata_fields:
-                unique_values = rank_events[field].unique()
-                if len(unique_values) > 1:
-                    msg_mismatch = f"Metadata mismatch in '{field}' for collective {cid}: {unique_values}"
-                    if strict_metadata_check:
-                        self.logger.error(msg_mismatch)
-                        raise ValueError(msg_mismatch)
-                    self.logger.warning(msg_mismatch)
+            if not self._simplified_mode:
+                for field in metadata_fields:
+                    unique_values = rank_events[field].unique()
+                    if len(unique_values) > 1:
+                        msg_mismatch = f"Metadata mismatch in '{field}' for collective {cid}: {unique_values}"
+                        if strict_metadata_check:
+                            self.logger.error(msg_mismatch)
+                            raise ValueError(msg_mismatch)
+                        self.logger.warning(msg_mismatch)
 
             row = {"collective_id": cid, **ref_metadata}
 
@@ -443,18 +551,36 @@ class NcclAnalyser:
             )
             row["skew in end time"] = latest_end - earliest_end
 
-            # Compute algorithmic and bus bandwidth
-            c_type = self.collective_name2type.get(row["Collective name"])
-            row["Full msg size (MB)"] = (
-                row["Out msg size (MB)"]
-                if c_type == "allgather"
-                else row["In msg size (MB)"]
+            # Compute algorithmic and bus bandwidth (when metadata allows)
+            has_msg_size = (
+                row.get("In msg size (MB)") is not None
+                and row.get("Out msg size (MB)") is not None
             )
-            row["algo bw (GB/s)"] = (row["Full msg size (MB)"] / 1024) / (
-                row["comm_latency"] / 1e6
-            )
-            scaling_factor = self.collective2scaling_factor[c_type](row["Group size"])
-            row["bus bw (GB/s)"] = row["algo bw (GB/s)"] * scaling_factor
+            has_group_size = row.get("Group size") is not None
+
+            if has_msg_size and c_type is not None:
+                row["Full msg size (MB)"] = (
+                    row["Out msg size (MB)"]
+                    if c_type == "allgather"
+                    else row["In msg size (MB)"]
+                )
+                if row["comm_latency"] > 0:
+                    row["algo bw (GB/s)"] = (row["Full msg size (MB)"] / 1024) / (
+                        row["comm_latency"] / 1e6
+                    )
+                else:
+                    row["algo bw (GB/s)"] = float("nan")
+                if has_group_size and c_type in self.collective2scaling_factor:
+                    scaling_factor = self.collective2scaling_factor[c_type](
+                        row["Group size"]
+                    )
+                    row["bus bw (GB/s)"] = row["algo bw (GB/s)"] * scaling_factor
+                else:
+                    row["bus bw (GB/s)"] = float("nan")
+            else:
+                row["Full msg size (MB)"] = float("nan")
+                row["algo bw (GB/s)"] = float("nan")
+                row["bus bw (GB/s)"] = float("nan")
 
             rows.append(row)
 
@@ -519,26 +645,41 @@ class NcclAnalyser:
                 strict_metadata_check=strict_metadata_check
             )
 
-        # Aggregation logic
-
         df = self.df_implicit_sync_cat
+        if df.empty:
+            self.logger.warning(
+                "Implicit sync collective dataframe is empty. "
+                "Returning empty summary."
+            )
+            return df
+
+        # Core metrics always available (straggler analysis)
         agg_logic = {
-            "comm_latency": agg_metrics
-            + ["size", lambda x: x.sum() / 1000],  # Size and sum (convert to ms)
+            "comm_latency": agg_metrics + ["size", lambda x: x.sum() / 1000],
             "skew in start time": agg_metrics,
             "skew in end time": agg_metrics,
-            "algo bw (GB/s)": agg_metrics,
-            "bus bw (GB/s)": agg_metrics,
         }
+        # Bandwidth metrics only when data is present
+        if not df["algo bw (GB/s)"].isna().all():
+            agg_logic["algo bw (GB/s)"] = agg_metrics
+        if not df["bus bw (GB/s)"].isna().all():
+            agg_logic["bus bw (GB/s)"] = agg_metrics
+
         metric_fields = list(agg_logic.keys()).copy()
         for col in metadata_fields:
-            agg_logic[col] = "first"
+            if col in df.columns:
+                agg_logic[col] = "first"
 
+        # In simplified mode, Collective name / dtype / In msg nelems may be
+        # uniformly None.  Use a fillna so groupby doesn't drop them.
         groupby_cols = ["Collective name", "dtype", "In msg nelems"]
-        agg_result = df.groupby(groupby_cols).agg(agg_logic)
+        df_grouped = df.copy()
+        for col in groupby_cols:
+            if col in df_grouped.columns:
+                df_grouped[col] = df_grouped[col].fillna("Unknown")
+        agg_result = df_grouped.groupby(groupby_cols).agg(agg_logic)
 
         # Post-processing: rename columns and sort
-
         agg_result.columns = [
             f"{col[0]}_{col[1]}" if col[1] != "" else col[0]
             for col in agg_result.columns
@@ -548,19 +689,25 @@ class NcclAnalyser:
             "comm_latency_size": "count",
         }
         for col in metadata_fields:
-            column_renames[col + "_first"] = col
+            rename_key = col + "_first"
+            if rename_key in agg_result.columns:
+                column_renames[rename_key] = col
 
         agg_result.rename(columns=column_renames, inplace=True)
         summary_df = agg_result.reset_index()
         summary_df = summary_df.sort_values(
             by="Total comm latency (ms)", ascending=False
         )
-        columns_order = groupby_cols + metadata_fields
+        columns_order = groupby_cols + [
+            c for c in metadata_fields if c in summary_df.columns
+        ]
         for group in metric_fields:
             for agg in agg_metrics:
-                columns_order.append(f"{group}_{agg}")
+                col_name = f"{group}_{agg}"
+                if col_name in summary_df.columns:
+                    columns_order.append(col_name)
         columns_order.extend(["count", "Total comm latency (ms)"])
-        summary_df = summary_df[columns_order]
+        summary_df = summary_df[[c for c in columns_order if c in summary_df.columns]]
         return summary_df
 
     def build_df_nccl_all2allv(self, detailed=False, strict_metadata_check=True):

--- a/tests/test_simplified_nccl_mode.py
+++ b/tests/test_simplified_nccl_mode.py
@@ -1,0 +1,246 @@
+###############################################################################
+# Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Tests for the simplified inference-mode path in NcclAnalyser.
+
+The simplified path activates when all NCCL kernels sit on a single stream
+per rank and no Process Group metadata is present (typical for vLLM / SGLang
+traces).  Collectives are matched across ranks by their temporal order on
+the stream rather than by Process Group Name.
+"""
+
+import gzip
+import json
+import os
+import shutil
+import tempfile
+
+import pandas as pd
+import pytest
+
+from TraceLens import NcclAnalyser
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_trace(rank, n_collectives, *, include_pg=False, multi_stream=False):
+    """Create a minimal synthetic trace for one rank.
+
+    Parameters
+    ----------
+    rank : int
+    n_collectives : int
+    include_pg : bool
+        When True, add Process Group metadata (regular path).
+    multi_stream : bool
+        When True, alternate kernels between two streams.
+    """
+    events = []
+    base_ts = 1_000_000 + rank * 50
+    for i in range(n_collectives):
+        ts = base_ts + i * 1000 + rank * (5 if i % 3 == 0 else 2)
+        dur = 50 + rank * 3
+        args = {
+            "External id": 100 + i,
+            "device": rank,
+            "stream": 3 if not multi_stream else (3 + i % 2),
+            "correlation": 50 + i,
+            "kind": "Dispatch Kernel",
+        }
+        if include_pg:
+            args.update(
+                {
+                    "Process Group Name": "default_pg",
+                    "Process Group Ranks": list(range(4)),
+                    "Collective name": "_allgather_base",
+                    "Group size": 4,
+                    "dtype": "BFloat16",
+                    "In msg nelems": 40960,
+                    "Out msg nelems": 163840,
+                    "In split size": "[]",
+                    "Out split size": "[]",
+                }
+            )
+        events.append(
+            {
+                "ph": "X",
+                "cat": "kernel",
+                "name": "void rcclGenericKernel<1, false>"
+                "(ncclDevKernelArgsStorage<4096ul>)",
+                "pid": rank,
+                "tid": 3,
+                "ts": ts,
+                "dur": dur,
+                "args": args,
+            }
+        )
+    return {"traceEvents": events}
+
+
+def _write_traces(tmpdir, world_size, n_collectives, **kwargs):
+    """Write per-rank traces and return list of paths."""
+    paths = []
+    for rank in range(world_size):
+        trace = _make_trace(rank, n_collectives, **kwargs)
+        path = os.path.join(tmpdir, f"rank_{rank}.json.gz")
+        with gzip.open(path, "wt") as f:
+            json.dump(trace, f)
+        paths.append(path)
+    return paths
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def tmpdir():
+    d = tempfile.mkdtemp(prefix="nccl_simplified_test_")
+    yield d
+    shutil.rmtree(d)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSimplifiedModeDetection:
+    """Verify the auto-detection logic picks the right path."""
+
+    def test_simplified_mode_activates(self, tmpdir):
+        files = _write_traces(tmpdir, 4, 20, include_pg=False)
+        analyser = NcclAnalyser(files, world_size=4)
+        analyser.build_df_long()
+        assert analyser._simplified_mode is True
+
+    def test_regular_mode_with_pg(self, tmpdir):
+        files = _write_traces(tmpdir, 4, 20, include_pg=True)
+        analyser = NcclAnalyser(files, world_size=4)
+        analyser.build_df_long()
+        assert not analyser._simplified_mode
+
+    def test_regular_mode_multi_stream_no_pg(self, tmpdir):
+        """Multiple streams but no PG → regular path (can't safely match)."""
+        files = _write_traces(tmpdir, 4, 20, include_pg=False, multi_stream=True)
+        analyser = NcclAnalyser(files, world_size=4)
+        analyser.build_df_long()
+        assert analyser._simplified_mode is False
+
+
+class TestSimplifiedMatching:
+    """Verify collectives are correctly matched across ranks."""
+
+    def test_collective_ids_match_all_ranks(self, tmpdir):
+        files = _write_traces(tmpdir, 4, 10, include_pg=False)
+        analyser = NcclAnalyser(files, world_size=4)
+        df = analyser.build_df_long()
+        for cid in df["collective_id"].unique():
+            ranks = sorted(df.loc[df["collective_id"] == cid, "rank"].tolist())
+            assert ranks == [0, 1, 2, 3], f"collective {cid} missing ranks: {ranks}"
+
+    def test_index_in_group_sequential(self, tmpdir):
+        files = _write_traces(tmpdir, 4, 15, include_pg=False)
+        analyser = NcclAnalyser(files, world_size=4)
+        df = analyser.build_df_long()
+        for r in range(4):
+            rank_df = df[df["rank"] == r].sort_values("ts")
+            assert list(rank_df["index_in_group"]) == list(range(15))
+
+
+class TestSimplifiedStragglerAnalysis:
+    """Verify straggler analysis works without msg size metadata."""
+
+    def test_straggler_columns_present(self, tmpdir):
+        files = _write_traces(tmpdir, 4, 10, include_pg=False)
+        analyser = NcclAnalyser(files, world_size=4)
+        analyser.build_df_long()
+        df = analyser.build_df_nccl_implicit_sync_cat(strict_metadata_check=False)
+        assert not df.empty
+        for col in [
+            "comm_latency",
+            "skew in start time",
+            "earliest arrival rank",
+            "avg_wait_time",
+            "skew in end time",
+        ]:
+            assert col in df.columns, f"Missing column: {col}"
+
+    def test_bandwidth_columns_nan(self, tmpdir):
+        """Without msg size metadata, bandwidth should be NaN."""
+        files = _write_traces(tmpdir, 4, 10, include_pg=False)
+        analyser = NcclAnalyser(files, world_size=4)
+        analyser.build_df_long()
+        df = analyser.build_df_nccl_implicit_sync_cat(strict_metadata_check=False)
+        assert df["algo bw (GB/s)"].isna().all()
+        assert df["bus bw (GB/s)"].isna().all()
+
+    def test_earliest_arrival_is_rank_0(self, tmpdir):
+        """With the synthetic skew, rank 0 always starts first."""
+        files = _write_traces(tmpdir, 4, 10, include_pg=False)
+        analyser = NcclAnalyser(files, world_size=4)
+        analyser.build_df_long()
+        df = analyser.build_df_nccl_implicit_sync_cat(strict_metadata_check=False)
+        assert (df["earliest arrival rank"] == 0).all()
+
+    def test_skew_is_positive(self, tmpdir):
+        files = _write_traces(tmpdir, 4, 10, include_pg=False)
+        analyser = NcclAnalyser(files, world_size=4)
+        analyser.build_df_long()
+        df = analyser.build_df_nccl_implicit_sync_cat(strict_metadata_check=False)
+        assert (df["skew in start time"] > 0).all()
+
+
+class TestSimplifiedSummary:
+    """Verify the summary table works in simplified mode."""
+
+    def test_summary_not_empty(self, tmpdir):
+        files = _write_traces(tmpdir, 4, 20, include_pg=False)
+        analyser = NcclAnalyser(files, world_size=4)
+        analyser.build_df_long()
+        analyser.build_df_nccl_implicit_sync_cat(strict_metadata_check=False)
+        summary = analyser.build_df_summary_nccl_implicit_sync_cat(
+            strict_metadata_check=False
+        )
+        assert not summary.empty
+
+    def test_summary_has_count(self, tmpdir):
+        files = _write_traces(tmpdir, 4, 20, include_pg=False)
+        analyser = NcclAnalyser(files, world_size=4)
+        analyser.build_df_long()
+        analyser.build_df_nccl_implicit_sync_cat(strict_metadata_check=False)
+        summary = analyser.build_df_summary_nccl_implicit_sync_cat(
+            strict_metadata_check=False
+        )
+        assert "count" in summary.columns
+        assert summary["count"].sum() == 20
+
+    def test_summary_omits_bw_when_all_nan(self, tmpdir):
+        """Bandwidth agg columns should not appear when data is all NaN."""
+        files = _write_traces(tmpdir, 4, 20, include_pg=False)
+        analyser = NcclAnalyser(files, world_size=4)
+        analyser.build_df_long()
+        analyser.build_df_nccl_implicit_sync_cat(strict_metadata_check=False)
+        summary = analyser.build_df_summary_nccl_implicit_sync_cat(
+            strict_metadata_check=False
+        )
+        bw_cols = [c for c in summary.columns if "bw" in c.lower()]
+        assert len(bw_cols) == 0, f"Unexpected bw columns: {bw_cols}"
+
+
+class TestRegularPathUnchanged:
+    """Sanity-check that the regular path still produces bandwidth."""
+
+    def test_regular_has_bandwidth(self, tmpdir):
+        files = _write_traces(tmpdir, 4, 10, include_pg=True)
+        analyser = NcclAnalyser(files, world_size=4)
+        analyser.build_df_long()
+        df = analyser.build_df_nccl_implicit_sync_cat(strict_metadata_check=False)
+        assert not df["algo bw (GB/s)"].isna().all()
+        assert not df["bus bw (GB/s)"].isna().all()


### PR DESCRIPTION
Inference frameworks like vLLM use custom cross-device reduction kernels instead of NCCL, which lack Process Group metadata and Collective name annotations. This change adds:

- Configurable kernel-name-to-collective mapping via regex patterns (custom_collective_patterns param) with vLLM defaults built-in
- Simplified inference mode: auto-detects single-stream / no-PG traces and matches collectives by stream-order index
- Graceful bandwidth degradation when msg size metadata is absent, while straggler analysis (skew, wait time, earliest arrival) always works
- Broadened filter to accept correlation OR External id for linked check
