### PR TITLE
Add perf model and categorization for CK grouped GEMM, SSM, MoE, RoPE, and CrossEntropy ops

### DIFF
--- a/TraceLens/PerfModel/perf_model.py
+++ b/TraceLens/PerfModel/perf_model.py
@@ -4591,6 +4591,286 @@ class RMSNormBwd(Normalization):
 
 
 # ==============================================================================
+# MoE Communication – MoEDispatch / MoECombine (token routing)
+# ==============================================================================
+
+
+class MoEComm:
+    """
+    MoE all-to-all token dispatch/combine: pure communication, no FLOPS.
+
+    In the trace:
+      MoEDispatch:  Input Dims[0] = (num_tokens_local, hidden_dim)
+      MoECombine:   Input Dims[0] = (num_tokens_dispatched, hidden_dim)
+
+    bytes() = num_tokens × hidden_dim × bpe (data volume moved).
+    """
+
+    def __init__(self, event, arch=None, python_path=None):
+        self.event = event
+        self.arch = arch
+        self.python_path = python_path
+        self.param_details = self.get_param_details(event)
+        self.num_tokens = self.param_details["num_tokens"]
+        self.hidden_dim = self.param_details["hidden_dim"]
+        self.bpe = self.param_details["bpe"]
+
+    @staticmethod
+    def get_param_details(event):
+        input_dims = event["args"].get("Input Dims", [])
+        input_types = event["args"].get("Input type", [])
+        tok_shape = input_dims[0] if input_dims else []
+        num_tokens = tok_shape[0] if len(tok_shape) >= 1 else None
+        hidden_dim = tok_shape[1] if len(tok_shape) >= 2 else None
+        dtype = input_types[0] if input_types else ""
+        bpe = name2bpe(dtype) if dtype else None
+        return {"num_tokens": num_tokens, "hidden_dim": hidden_dim, "bpe": bpe}
+
+    def flops(self):
+        return 0
+
+    def flops_bwd(self):
+        return 0
+
+    def bytes(self):
+        if self.num_tokens is None or self.hidden_dim is None or self.bpe is None:
+            return None
+        return self.num_tokens * self.hidden_dim * self.bpe
+
+    def bytes_bwd(self, bytes_per_element=None):
+        return self.bytes()
+
+    def get_maf_type(self):
+        return None
+
+    def get_compute_precision(self):
+        return None
+
+
+class moe_dispatch(MoEComm):
+    """MoEDispatch (forward): routes local tokens to remote expert ranks."""
+
+    pass
+
+
+class moe_combine(MoEComm):
+    """MoECombine (forward): collects expert outputs back to local tokens."""
+
+    pass
+
+
+# ==============================================================================
+# Causal Conv1D – DaoAILab depthwise 1D convolution
+# ==============================================================================
+
+
+class CausalConv1d:
+    """
+    DaoAILab causal_conv1d: depthwise 1D convolution used in Mamba/SSM.
+
+    In the trace:
+      Input Dims[0] = (batch, channels, seq_len)  — input tensor
+      Input Dims[1] = (channels, kernel_size)      — conv weight
+      Input Dims[2] = (channels,)                  — bias (optional)
+
+    FLOPS = 2 × batch × channels × seq_len × kernel_size (depthwise conv).
+    """
+
+    def __init__(self, event, arch=None, python_path=None):
+        self.event = event
+        self.arch = arch
+        self.python_path = python_path
+        self.param_details = self.get_param_details(event)
+        input_types = event["args"].get("Input type", [])
+        dtype = input_types[0] if input_types else "c10::BFloat16"
+        bpe = name2bpe(dtype) if dtype else None
+        self.bpe = bpe if bpe is not None else 2
+
+    @staticmethod
+    def get_param_details(event):
+        input_dims = event["args"]["Input Dims"]
+
+        x_shape = input_dims[0]
+        w_shape = input_dims[1]
+
+        batch = x_shape[0]
+        channels = x_shape[1]
+        seq_len = x_shape[2]
+        kernel_size = w_shape[1]
+
+        has_bias = (
+            len(input_dims) > 2
+            and isinstance(input_dims[2], (list, tuple))
+            and len(input_dims[2]) > 0
+        )
+
+        return {
+            "batch": batch,
+            "channels": channels,
+            "seq_len": seq_len,
+            "kernel_size": kernel_size,
+            "has_bias": has_bias,
+        }
+
+    def flops(self):
+        p = self.param_details
+        return 2 * p["batch"] * p["channels"] * p["seq_len"] * p["kernel_size"]
+
+    def bytes(self):
+        if self.bpe is None:
+            return None
+        p = self.param_details
+        input_bytes = p["batch"] * p["channels"] * p["seq_len"] * self.bpe
+        weight_bytes = p["channels"] * p["kernel_size"] * self.bpe
+        output_bytes = p["batch"] * p["channels"] * p["seq_len"] * self.bpe
+        bias_bytes = p["channels"] * self.bpe if p["has_bias"] else 0
+        return input_bytes + weight_bytes + output_bytes + bias_bytes
+
+    def get_maf_type(self):
+        return "matrix"
+
+    def get_compute_precision(self):
+        dtype = self.event["args"].get("Input type", [None])[0]
+        return torch_dtype_map(dtype) if dtype else None
+
+
+class causal_conv1d_fwd(CausalConv1d):
+    """DaoAILab::_causal_conv1d_fwd_cpp forward pass."""
+
+    pass
+
+
+# ==============================================================================
+# RoPE – Fused Rotary Position Embedding
+# ==============================================================================
+
+
+class FusedRoPE:
+    """
+    TransformerEngine FusedRoPEFunc: elementwise rotary position embedding.
+
+    In the trace:
+      Input Dims[0] = (seq_len, batch, heads, head_dim)  — input tensor
+      Input Dims[1] = (seq_len, 1, 1, head_dim)          — cos/sin table
+
+    FLOPS: each pair of elements in head_dim requires 4 muls + 2 adds = 6 ops.
+    Total = 3 × num_elements (since 6 ops per 2 elements).
+    """
+
+    def __init__(self, event, arch=None, python_path=None):
+        self.event = event
+        self.arch = arch
+        self.python_path = python_path
+        self.param_details = self.get_param_details(event)
+        input_types = event["args"].get("Input type", [])
+        dtype = input_types[0] if input_types else "c10::BFloat16"
+        bpe = name2bpe(dtype) if dtype else None
+        self.bpe = bpe if bpe is not None else 2
+
+    @staticmethod
+    def get_param_details(event):
+        input_dims = event["args"]["Input Dims"]
+        t_shape = input_dims[0]
+        return {
+            "seq_len": t_shape[0],
+            "batch": t_shape[1],
+            "heads": t_shape[2],
+            "head_dim": t_shape[3],
+            "num_elements": prod(t_shape),
+        }
+
+    def flops(self):
+        return 3 * self.param_details["num_elements"]
+
+    def bytes(self):
+        if self.bpe is None:
+            return None
+        n = self.param_details["num_elements"]
+        return 2 * n * self.bpe
+
+    def get_maf_type(self):
+        return "vector"
+
+    def get_compute_precision(self):
+        input_types = self.event["args"].get("Input type", [])
+        dtype = input_types[0] if input_types else None
+        return torch_dtype_map(dtype) if dtype else None
+
+
+class fused_rope_fwd(FusedRoPE):
+    """FusedRoPEFunc forward pass."""
+
+    pass
+
+
+# ==============================================================================
+# CrossEntropy – Fused softmax + negative log-likelihood
+# ==============================================================================
+
+
+class CrossEntropy:
+    """
+    Fused CrossEntropyFunction: online softmax + cross-entropy loss.
+
+    In the trace:
+      Input Dims[0] = (batch, 1, vocab_size)  — logits
+      Input Dims[1] = (batch, 1)              — targets
+
+    FLOPS ≈ 5 × batch × vocab_size (exp + sum + log + subtract + lookup per element).
+    """
+
+    def __init__(self, event, arch=None, python_path=None):
+        self.event = event
+        self.arch = arch
+        self.python_path = python_path
+        self.param_details = self.get_param_details(event)
+        input_types = event["args"].get("Input type", [])
+        dtype = input_types[0] if input_types else "c10::BFloat16"
+        bpe = name2bpe(dtype) if dtype else None
+        self.bpe = bpe if bpe is not None else 2
+
+    @staticmethod
+    def get_param_details(event):
+        input_dims = event["args"]["Input Dims"]
+        logits_shape = input_dims[0]
+        batch = logits_shape[0]
+        vocab_size = logits_shape[-1]
+        return {
+            "batch": batch,
+            "vocab_size": vocab_size,
+            "logits_shape": logits_shape,
+        }
+
+    def flops(self):
+        p = self.param_details
+        return 5 * p["batch"] * p["vocab_size"]
+
+    def bytes(self):
+        if self.bpe is None:
+            return None
+        p = self.param_details
+        logits_bytes = prod(p["logits_shape"]) * self.bpe
+        target_bpe = 8  # long int
+        target_bytes = p["batch"] * target_bpe
+        output_bytes = p["batch"] * 4  # loss is float32
+        return logits_bytes + target_bytes + output_bytes
+
+    def get_maf_type(self):
+        return "vector"
+
+    def get_compute_precision(self):
+        input_types = self.event["args"].get("Input type", [])
+        dtype = input_types[0] if input_types else None
+        return torch_dtype_map(dtype) if dtype else None
+
+
+class cross_entropy_fwd(CrossEntropy):
+    """CrossEntropyFunction forward pass."""
+
+    pass
+
+
+# ==============================================================================
 # MambaSSD – MambaSplitConv1dScanCombinedFn (fused SSM kernel)
 # ==============================================================================
 

--- a/TraceLens/PerfModel/torch_op_mapping.py
+++ b/TraceLens/PerfModel/torch_op_mapping.py
@@ -59,6 +59,15 @@ op_to_perf_model_class_map = {
     # CK grouped GEMM (same layout as primus_turbo grouped GEMM)
     "primus_turbo_cpp_extension::ck_grouped_gemm": perf_model.primus_turbo_grouped_gemm,
     "primus_turbo_cpp_extension::ck_grouped_gemm_variable_k": perf_model.primus_turbo_grouped_gemm_variable_k,
+    # MoE dispatch/combine (communication — bytes only, flops = 0)
+    "MoEDispatch": perf_model.moe_dispatch,
+    "MoECombine": perf_model.moe_combine,
+    # Causal Conv1D (SSM / Mamba depthwise conv)
+    "DaoAILab::_causal_conv1d_fwd_cpp": perf_model.causal_conv1d_fwd,
+    # RoPE (elementwise rotation)
+    "FusedRoPEFunc": perf_model.fused_rope_fwd,
+    # CrossEntropy (fused softmax + nll loss)
+    "CrossEntropyFunction": perf_model.cross_entropy_fwd,
     # Mamba SSD (fused conv1d + selective scan, issue #552)
     "MambaSplitConv1dScanCombinedFn": perf_model.mamba_ssd_fwd,
 }
@@ -149,6 +158,10 @@ dict_base_class2category = {
     perf_model.UnaryElementwise: "UnaryElementwise",
     perf_model.BinaryElementwise: "BinaryElementwise",
     perf_model.Normalization: "Normalization",
+    perf_model.MoEComm: "MoE_comm",
+    perf_model.CausalConv1d: "SSM",
+    perf_model.FusedRoPE: "RoPE",
+    perf_model.CrossEntropy: "CrossEntropy",
     perf_model.MambaSSD: "SSM",
 }
 
@@ -186,6 +199,9 @@ def categorize_torch_op(row):
              'RoPE_fwd', 'RoPE_bwd', 'CrossEntropy_fwd', 'CrossEntropy_bwd',
              'elementwise', 'triton', 'reduce', 'multi_tensor_apply',
              'record_param_comms', or 'other'.
+
+    Note: Backward variants and auxiliary ops (TokenPermuteMaskMap, etc.)
+    are categorization-only (timing without GFLOPS or TB/s).
     """
 
     debug = False
@@ -233,7 +249,6 @@ def categorize_torch_op(row):
         return "MoE_unfused"
     elif row["name"] in dict_cat2names.get("SSM", []) or row["name"] in [
         "MambaSplitConv1dScanCombinedFn",
-        "DaoAILab::_causal_conv1d_fwd_cpp",
     ]:
         return "SSM_fwd"
     elif row["name"] in [

--- a/tests/test_primus_op_categorization.py
+++ b/tests/test_primus_op_categorization.py
@@ -13,6 +13,15 @@ categorization (#543).
 from TraceLens.PerfModel.perf_model import (
     primus_turbo_grouped_gemm,
     primus_turbo_grouped_gemm_variable_k,
+    MoEComm,
+    moe_dispatch,
+    moe_combine,
+    CausalConv1d,
+    causal_conv1d_fwd,
+    FusedRoPE,
+    fused_rope_fwd,
+    CrossEntropy,
+    cross_entropy_fwd,
 )
 from TraceLens.PerfModel.torch_op_mapping import (
     categorize_torch_op,
@@ -154,3 +163,243 @@ def test_cross_entropy_categorizes_as_ce_fwd():
 def test_cross_entropy_bwd_categorizes_as_ce_bwd():
     row = {"name": "CrossEntropyFunctionBackward", "kernel_details": []}
     assert categorize_torch_op(row) == "CrossEntropy_bwd"
+
+
+# ---------------------------------------------------------------------------
+# MoE comm — perf model tests
+# ---------------------------------------------------------------------------
+
+
+def _moe_dispatch_event(num_tokens=4096, hidden=7168, dtype="c10::BFloat16"):
+    return {
+        "name": "MoEDispatch",
+        "args": {
+            "Input Dims": [
+                [num_tokens, hidden],
+                [num_tokens, 8],
+                [num_tokens, 8],
+                [],
+                [],
+                [],
+                [],
+            ],
+            "Input type": [
+                dtype,
+                "long int",
+                "float",
+                "Scalar",
+                "Scalar",
+                "Scalar",
+                "Scalar",
+            ],
+            "Concrete Inputs": ["", "", "", "64", "True", "True", "32768"],
+        },
+    }
+
+
+def _moe_combine_event(num_tokens=32768, hidden=7168, dtype="c10::BFloat16"):
+    return {
+        "name": "MoECombine",
+        "args": {
+            "Input Dims": [[num_tokens, hidden], [], []],
+            "Input type": [dtype, "Scalar", "Scalar"],
+            "Concrete Inputs": ["", "True", "True"],
+        },
+    }
+
+
+def test_moe_dispatch_mapped():
+    assert op_to_perf_model_class_map["MoEDispatch"] is moe_dispatch
+
+
+def test_moe_combine_mapped():
+    assert op_to_perf_model_class_map["MoECombine"] is moe_combine
+
+
+def test_moe_dispatch_flops_zero():
+    model = moe_dispatch(_moe_dispatch_event())
+    assert model.flops() == 0
+
+
+def test_moe_dispatch_bytes():
+    model = moe_dispatch(_moe_dispatch_event(num_tokens=4096, hidden=7168))
+    expected = 4096 * 7168 * 2  # bf16
+    assert model.bytes() == expected
+
+
+def test_moe_combine_bytes():
+    model = moe_combine(_moe_combine_event(num_tokens=32768, hidden=7168))
+    expected = 32768 * 7168 * 2
+    assert model.bytes() == expected
+
+
+def test_moe_combine_larger_than_dispatch():
+    dispatch = moe_dispatch(_moe_dispatch_event(num_tokens=4096, hidden=7168))
+    combine = moe_combine(_moe_combine_event(num_tokens=32768, hidden=7168))
+    assert combine.bytes() > dispatch.bytes()
+
+
+def test_moe_inherits_moecomm():
+    assert issubclass(moe_dispatch, MoEComm)
+    assert issubclass(moe_combine, MoEComm)
+
+
+# ---------------------------------------------------------------------------
+# Causal Conv1D — perf model tests
+# ---------------------------------------------------------------------------
+
+
+def _conv1d_event(batch=8, channels=3072, seq_len=8192, kernel_size=4):
+    return {
+        "name": "DaoAILab::_causal_conv1d_fwd_cpp",
+        "args": {
+            "Input Dims": [
+                [batch, channels, seq_len],
+                [channels, kernel_size],
+                [channels],
+                [],
+                [],
+                [batch, channels, seq_len],
+                [],
+                [],
+            ],
+            "Input type": [
+                "c10::BFloat16",
+                "c10::BFloat16",
+                "c10::BFloat16",
+                "",
+                "",
+                "c10::BFloat16",
+                "",
+                "Scalar",
+            ],
+        },
+    }
+
+
+def test_causal_conv1d_mapped():
+    assert (
+        op_to_perf_model_class_map["DaoAILab::_causal_conv1d_fwd_cpp"]
+        is causal_conv1d_fwd
+    )
+
+
+def test_causal_conv1d_flops():
+    model = causal_conv1d_fwd(
+        _conv1d_event(batch=8, channels=3072, seq_len=8192, kernel_size=4)
+    )
+    expected = 2 * 8 * 3072 * 8192 * 4
+    assert model.flops() == expected
+
+
+def test_causal_conv1d_bytes():
+    model = causal_conv1d_fwd(
+        _conv1d_event(batch=8, channels=3072, seq_len=8192, kernel_size=4)
+    )
+    bpe = 2
+    input_bytes = 8 * 3072 * 8192 * bpe
+    weight_bytes = 3072 * 4 * bpe
+    output_bytes = 8 * 3072 * 8192 * bpe
+    bias_bytes = 3072 * bpe  # has bias (Input Dims[2] = [3072])
+    assert model.bytes() == input_bytes + weight_bytes + output_bytes + bias_bytes
+
+
+def test_causal_conv1d_inherits():
+    assert issubclass(causal_conv1d_fwd, CausalConv1d)
+
+
+# ---------------------------------------------------------------------------
+# RoPE — perf model tests
+# ---------------------------------------------------------------------------
+
+
+def _rope_event(seq_len=4096, batch=4, heads=32, head_dim=128):
+    return {
+        "name": "FusedRoPEFunc",
+        "args": {
+            "Input Dims": [
+                [seq_len, batch, heads, head_dim],
+                [seq_len, 1, 1, head_dim],
+                [],
+                [],
+                [],
+                [],
+                [],
+            ],
+            "Input type": [
+                "c10::BFloat16",
+                "float",
+                "",
+                "Scalar",
+                "",
+                "Scalar",
+                "Scalar",
+            ],
+        },
+    }
+
+
+def test_rope_mapped():
+    assert op_to_perf_model_class_map["FusedRoPEFunc"] is fused_rope_fwd
+
+
+def test_rope_flops():
+    model = fused_rope_fwd(_rope_event(seq_len=4096, batch=4, heads=32, head_dim=128))
+    num_elements = 4096 * 4 * 32 * 128
+    expected = 3 * num_elements
+    assert model.flops() == expected
+
+
+def test_rope_bytes():
+    model = fused_rope_fwd(_rope_event(seq_len=4096, batch=4, heads=32, head_dim=128))
+    num_elements = 4096 * 4 * 32 * 128
+    bpe = 2
+    expected = 2 * num_elements * bpe
+    assert model.bytes() == expected
+
+
+def test_rope_inherits():
+    assert issubclass(fused_rope_fwd, FusedRoPE)
+
+
+# ---------------------------------------------------------------------------
+# CrossEntropy — perf model tests
+# ---------------------------------------------------------------------------
+
+
+def _ce_event(batch=4096, vocab_size=163840):
+    return {
+        "name": "CrossEntropyFunction",
+        "args": {
+            "Input Dims": [
+                [batch, 1, vocab_size],
+                [batch, 1],
+                [],
+                [],
+            ],
+            "Input type": ["c10::BFloat16", "long int", "Scalar", "Scalar"],
+        },
+    }
+
+
+def test_ce_mapped():
+    assert op_to_perf_model_class_map["CrossEntropyFunction"] is cross_entropy_fwd
+
+
+def test_ce_flops():
+    model = cross_entropy_fwd(_ce_event(batch=4096, vocab_size=163840))
+    expected = 5 * 4096 * 163840
+    assert model.flops() == expected
+
+
+def test_ce_bytes():
+    model = cross_entropy_fwd(_ce_event(batch=4096, vocab_size=163840))
+    bpe = 2
+    logits_bytes = 4096 * 1 * 163840 * bpe
+    target_bytes = 4096 * 8  # long int
+    output_bytes = 4096 * 4  # float32 loss
+    assert model.bytes() == logits_bytes + target_bytes + output_bytes
+
+
+def test_ce_inherits():
+    assert issubclass(cross_entropy_fwd, CrossEntropy)


### PR DESCRIPTION
## Summary

Closes #540, #541, #542, #543 (sub-issues of #516)

Adds CK grouped GEMM perf model mapping, perf models for MoE comm/causal conv1d/RoPE/CrossEntropy, and SSM categorization for ops found in Primus traces:

### #540 — CK grouped GEMM
- Maps `ck_grouped_gemm` and `ck_grouped_gemm_variable_k` to existing `primus_turbo_grouped_gemm` perf models (full GFLOPS + TB/s)

### #541 — SSM/Mamba ops
- `DaoAILab::_causal_conv1d_fwd_cpp` → **CausalConv1d perf model** (FLOPS = 2 × B × C × L × K, depthwise conv)
- `MambaSplitConv1dScanCombinedFn` → categorization-only as SSM_fwd/SSM_bwd (complex fused kernel, deferred to #552)

### #542 — MoE dispatch/combine
- **MoEComm perf model** for MoEDispatch/MoECombine: bytes = tokens × hidden × bpe, flops = 0 (pure communication)
- Auxiliary ops (TokenPermuteMaskMap, _OperationFuserAutogradFunction) → categorization-only
- Backward variants → categorization-only

### #543 — RoPE + CrossEntropy
- **FusedRoPE perf model** for FusedRoPEFunc: FLOPS = 3 × num_elements (6 ops per element pair), bytes = 2 × num_elements × bpe
- **CrossEntropy perf model** for CrossEntropyFunction: FLOPS ≈ 5 × batch × vocab_size, bytes = logits + targets + loss
- Backward variants → categorization-only

Models benefiting: Qwen3-8B, Mamba-370M, Zebra-Llama-1B, Kimi-K2

## Test plan

- [x] 40 unit tests in `tests/test_primus_op_categorization.py`:
  - CK GEMM: mapping, categorization, FLOPS
  - SSM: categorization for Mamba and causal_conv1d (fwd/bwd) + causal_conv1d FLOPS/bytes
  - MoE comm: mapping, categorization, bytes, flops=0, relative magnitude
  - RoPE: mapping, FLOPS, bytes
  - CrossEntropy: mapping, FLOPS, bytes