### PR TITLE
Fix TraceDiff bugs

### DIFF
--- a/TraceLens/TraceDiff/trace_diff.py
+++ b/TraceLens/TraceDiff/trace_diff.py
@@ -228,17 +228,21 @@ class TraceDiff:
                 while True:
                     children = current.get("children", [])
                     if len(children) == 1:
-                        current = tree.get_UID2event(children[0])
+                        child = tree.get_UID2event(children[0])
+                        if (child.get("cat") or child.get("category")) == "cpu_op":
+                            break
+                        current = child
                     else:
-                        children = current.get("children", [])
-                        root["children"] = children
-                        for child_uid in children:
-                            child_event = tree.get_UID2event(child_uid)
-                            child_event["parent"] = root.get(
-                                TraceLens.util.TraceEventUtils.TraceKeys.UID
-                            )
-                        current = root
                         break
+                if current is not root:
+                    children = current.get("children", [])
+                    root["children"] = children
+                    root_uid = root.get(
+                        TraceLens.util.TraceEventUtils.TraceKeys.UID
+                    )
+                    for child_uid in children:
+                        child_event = tree.get_UID2event(child_uid)
+                        child_event["parent"] = root_uid
                 return current.get(TraceLens.util.TraceEventUtils.TraceKeys.UID)
             current = tree.get_UID2event(parent_uid)
 
@@ -580,11 +584,33 @@ class TraceDiff:
             merged_events.append(event)
             return merged_id
 
-        root_uid1 = self._get_top_level_root(tree1, tree1.cpu_root_nodes[0])
-        root_uid2 = self._get_top_level_root(tree2, tree2.cpu_root_nodes[0])
+        # Collect unique top-level roots from each trace
+        seen1, roots1 = set(), []
+        for crn in tree1.cpu_root_nodes:
+            root = self._get_top_level_root(tree1, crn)
+            if root not in seen1:
+                seen1.add(root)
+                roots1.append(root)
 
-        merged_root_id = traverse_and_merge(root_uid1, root_uid2)
-        merged_root_ids = [merged_root_id]
+        seen2, roots2 = set(), []
+        for crn in tree2.cpu_root_nodes:
+            root = self._get_top_level_root(tree2, crn)
+            if root not in seen2:
+                seen2.add(root)
+                roots2.append(root)
+
+        print(
+            f"[TraceDiff] Found {len(roots1)} root trees in trace1, "
+            f"{len(roots2)} in trace2"
+        )
+
+        # Match roots by position: i-th root in trace1 pairs with i-th in trace2
+        merged_root_ids = []
+        n = max(len(roots1), len(roots2))
+        for i in range(n):
+            uid1 = roots1[i] if i < len(roots1) else None
+            uid2 = roots2[i] if i < len(roots2) else None
+            merged_root_ids.append(traverse_and_merge(uid1, uid2))
 
         self.merged_tree = (merged_events, merged_root_ids)
         return self.merged_tree
@@ -1007,6 +1033,7 @@ class TraceDiff:
                                         "cpu_op_name": self._get_op_name(
                                             parent_uid, tree_num
                                         ),
+                                        "cpu_op_uid": parent_uid,
                                         "source": source,
                                         "Input Dims": get_input_shape(parent_node),
                                         "Input Strides": get_input_strides(parent_node),
@@ -1084,6 +1111,7 @@ class TraceDiff:
                             {
                                 "name": gpu_event["name"],
                                 "cpu_op_name": child_name,
+                                "cpu_op_uid": parent_uid,
                                 "source": "trace1",
                                 "Input Dims": get_input_shape(parent_node),
                                 "Input Strides": get_input_strides(parent_node),
@@ -1142,6 +1170,7 @@ class TraceDiff:
                             {
                                 "name": gpu_event["name"],
                                 "cpu_op_name": child_name,
+                                "cpu_op_uid": parent_uid,
                                 "source": "trace2",
                                 "Input Dims": get_input_shape(parent_node),
                                 "Input Strides": get_input_strides(parent_node),
@@ -1177,6 +1206,12 @@ class TraceDiff:
             traverse(root_id, None)
 
         df = pd.DataFrame(rows)
+
+        if df.empty:
+            print("[TraceDiff] No GPU events found in either trace")
+            self.identical_traces = True
+            self.diff_stats_df = df
+            return df
 
         df_trace1 = df[df["source"] == "trace1"].drop(columns=["source"])
         df_trace2 = df[df["source"] == "trace2"].drop(columns=["source"])

--- a/TraceLens/TraceDiff/trace_diff.py
+++ b/TraceLens/TraceDiff/trace_diff.py
@@ -238,9 +238,7 @@ class TraceDiff:
                 if current is not root:
                     children = current.get("children", [])
                     root["children"] = children
-                    root_uid = root.get(
-                        TraceLens.util.TraceEventUtils.TraceKeys.UID
-                    )
+                    root_uid = root.get(TraceLens.util.TraceEventUtils.TraceKeys.UID)
                     for child_uid in children:
                         child_event = tree.get_UID2event(child_uid)
                         child_event["parent"] = root_uid

--- a/TraceLens/TraceDiff/trace_diff.py
+++ b/TraceLens/TraceDiff/trace_diff.py
@@ -229,7 +229,8 @@ class TraceDiff:
                     children = current.get("children", [])
                     if len(children) == 1:
                         child = tree.get_UID2event(children[0])
-                        if (child.get("cat") or child.get("category")) == "cpu_op":
+                        child_cat = child.get("cat") or child.get("category")
+                        if child_cat in ("cpu_op", "cuda_runtime"):
                             break
                         current = child
                     else:


### PR DESCRIPTION
Previously, TraceDiff could only parse through one root node. This is problematic for some traces (training traces) that contain many root nodes. Now TraceDiff properly parses through every root node.

Additionally, TraceDiff performs an initial tree compression via truncating the top level nodes that only have one children. Ex:

```
node A
|____ node B
      |____ node C
             |____ node D
             |____ node E
```
becomes
```
node A
|____ node D
|____ node E
```

This is problematic if every node in the subtree has only children. In these cases the entire tree compresses to nothing. Now, the tree compression will stop when a CPU operation or kernel is encountered.
TraceDiff tests in private repo pass.
Closes #569
Closes #570 