### PR TITLE
Changing backward-forward linking logic

### DIFF
--- a/TraceLens/Reporting/generate_perf_report_pytorch.py
+++ b/TraceLens/Reporting/generate_perf_report_pytorch.py
@@ -151,6 +151,18 @@ def apply_extension(perf_analyzer, extension_path):
             if not isinstance(names, list):
                 raise ValueError(f"Expected names to be a list, got {type(names)}")
             perf_analyzer.dict_cat2names[cat].extend(names)
+    if hasattr(extension, "categorize_extension"):
+        print(f"Applying categorize extension from {extension_path}")
+        original_categorizer = perf_analyzer.op_categorizer
+        ext_categorizer = extension.categorize_extension
+
+        def combined_categorizer(row):
+            result = ext_categorizer(row, None)
+            if result is not None:
+                return result
+            return original_categorizer(row)
+
+        perf_analyzer.op_categorizer = combined_categorizer
 
 
 def trunc_kernel_details(row, kernel_detail_col, trunc_length=64):

--- a/TraceLens/Trace2Tree/trace_to_tree.py
+++ b/TraceLens/Trace2Tree/trace_to_tree.py
@@ -1103,8 +1103,13 @@ class TraceToTree(BaseTraceToTree):
             leaf_fwd_ts = -1
             for uid in uids:
                 event = self.events_by_uid[uid]
-                # Skip events on the same thread as the backward autograd event
-                if event.get("pid") == bwd_pid and event.get("tid") == bwd_tid:
+                # Skip events with autograd::engine::evaluate_function or backward in name
+                if (
+                    event.get("name", "").startswith(
+                        "autograd::engine::evaluate_function:"
+                    )
+                    or "backward" in event.get("name", "").lower()
+                ):
                     continue
                 # This is a forward event - check if it's the latest (leaf)
                 ts = event.get(TraceLens.util.TraceEventUtils.TraceKeys.TimeStamp, 0)

--- a/examples/example_megatron_extension.py
+++ b/examples/example_megatron_extension.py
@@ -407,6 +407,10 @@ def categorize_extension(row, plugin):
         return "SDPA_fwd"
     if row["name"] == "FusedAttnFuncBackward":
         return "SDPA_bwd"
+    if row["name"] == "GroupedGemm":
+        return "GroupedGEMM_fwd"
+    if row["name"] == "GroupedGemmBackward":
+        return "GroupedGEMM_bwd"
     return None
 
 


### PR DESCRIPTION
Problem: link_all_fwd_bwd_events() used a thread-based filter (pid/tid) to distinguish forward from backward events sharing the same sequence number. This assumed backward ops always run on a separate autograd thread. In traces where forward and backward ops run on the same thread, the filter skipped all events — including the forward op — resulting in no forward-backward linkage.

This can happen when the autograd engine executes the backward pass on the same thread as the forward pass, which was observed with Transformer Engine's GroupedGemm/GroupedGemmBackward ops.

Fix: Replaced the pid/tid filter with a name-based filter that skips events matching autograd::engine::evaluate_function:* or containing "backward" (case-insensitive). This correctly identifies backward events regardless of thread placement.

Also modified perf report generation to use categorization extension.
<!--
Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.

See LICENSE for license information.
-->


