### PR TITLE
fix trace splitting and graph merge script

### DIFF
--- a/TraceLens/Trace2Tree/trace_capture_merge_experimental.py
+++ b/TraceLens/Trace2Tree/trace_capture_merge_experimental.py
@@ -67,7 +67,7 @@ def verify_subtree_events(capture_events, graph_events):
         # print("=========matching ========")
         for j, i in zip(capture_events, graph_events):
             if "kernel" not in j.get("args", {}).keys():
-                if "hipMemcpy" in j["name"]:
+                if "Memcpy" in j["name"] or "Memset" in j["name"]:
                     continue
                 warnings.warn(
                     "Kernel name missing in capture event args, "
@@ -250,6 +250,12 @@ def _get_cached_capture_tree(key, filepath, TreePerfAnalyzer):
     Uses LRU eviction with at most ``_CAPTURE_TREE_CACHE_MAX_SIZE`` entries.
     Callers must deep-copy any events they intend to mutate so the cached tree
     stays clean for subsequent look-ups.
+
+    Returns:
+        (capture_tree, capture_roots, capture_root_data) where
+        *capture_root_data* is a list of ``(capture_events, filtered_uids)``
+        tuples — one per capture root — pre-computed from
+        :func:`get_subtree_events`.
     """
     if key in _capture_tree_cache:
         _capture_tree_cache.move_to_end(key)

--- a/TraceLens/TraceUtils/split_inference_trace_annotation.py
+++ b/TraceLens/TraceUtils/split_inference_trace_annotation.py
@@ -599,32 +599,23 @@ def extract_phases_and_save(
             )
             name_append = f"decode_{phase_details['num_decode']}_bs{phase_details['avg_bs']}_conc{phase_details['avg_conc']}"
 
-        iter_details = [
-            get_iter_details_from_name(r["name"], prefix) for r in decode_steps
-        ]
-        phase_details = find_phase_from_window(iter_details)
-        iter_trace, batch_list, num_gpu_events, gpu_dur, gpu_busy = extract_iteration(
-            decode_steps, events, trace_json, gpu_corr_map, flow_corr_map, meta_events
-        )
-        name_append = f"decode_{phase_details['num_decode']}_bs{phase_details['avg_bs']}_conc{phase_details['avg_conc']}"
+            out_path = os.path.join(output_dir, f"{name_append}_{base_name}.json.gz")
+            with gzip.open(out_path, "wb") as f:
+                f.write(json.dumps(iter_trace).encode("utf-8"))
 
-        out_path = os.path.join(output_dir, f"{name_append}_{base_name}.json.gz")
-        with gzip.open(out_path, "wb") as f:
-            f.write(json.dumps(iter_trace).encode("utf-8"))
-
-        print(f"  {prefix}: {len(iter_trace['traceEvents'])} events -> {out_path}")
-        extraction_summary.append(
-            {
-                "idx": 0,
-                "output_path": out_path,
-                "event_count": len(iter_trace["traceEvents"]),
-                "num_gpu_events": num_gpu_events,
-                "gpu_duration": gpu_dur,
-                "gpu_busy_duration": gpu_busy,
-                "steps": iter_details,
-                "phase": phase_details,
-            }
-        )
+            print(f"  {prefix}: {len(iter_trace['traceEvents'])} events -> {out_path}")
+            extraction_summary.append(
+                {
+                    "idx": 0,
+                    "output_path": out_path,
+                    "event_count": len(iter_trace["traceEvents"]),
+                    "num_gpu_events": num_gpu_events,
+                    "gpu_duration": gpu_dur,
+                    "gpu_busy_duration": gpu_busy,
+                    "steps": iter_details,
+                    "phase": phase_details,
+                }
+            )
     return extraction_summary
 
 


### PR DESCRIPTION
This pull request includes minor improvements and documentation updates to the trace processing utilities, focusing on clarifying function return values and refining event filtering logic.

**Event filtering logic:**

* Modified the filtering condition in `verify_subtree_events` to skip events whose names contain either `"Memcpy"` or `"Memset"` (instead of only `"hipMemcpy"`), broadening the exclusion criteria for memory-related events.

**Code cleanup:**

* Removed redundant or duplicate code in the `extract_phases_and_save` function in `split_inference_trace_annotation.py` related to phase detail extraction and name construction, likely to prevent unnecessary re-computation and improve code clarity.
<!--
Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.

See LICENSE for license information.
-->


