### PR TITLE
Add straggler_summary sheet and enable detailed analysis by default

### DIFF
--- a/TraceLens/NcclAnalyser/nccl_analyser.py
+++ b/TraceLens/NcclAnalyser/nccl_analyser.py
@@ -712,6 +712,83 @@ class NcclAnalyser:
         summary_df = summary_df[[c for c in columns_order if c in summary_df.columns]]
         return summary_df
 
+    def build_df_straggler_summary(self, strict_metadata_check=True):
+        """Build a per-rank straggler summary from implicit-sync data.
+
+        Returns a DataFrame with one row per rank showing:
+        - total_wait_time_us: sum of wait time across all collectives
+        - mean_wait_time_us: average wait time per collective
+        - times_arrived_last: how often this rank was the straggler
+        - times_arrived_first: how often this rank arrived earliest
+        - pct_arrived_last: percentage of collectives where this rank was last
+        - total_nccl_dur_us: total NCCL kernel duration for this rank
+
+        The rank with the lowest total_wait_time (and highest times_arrived_last)
+        is the straggler.
+        """
+        import pandas as pd
+
+        if hasattr(self, "df_implicit_sync_cat_detailed"):
+            df_isync = self.df_implicit_sync_cat_detailed
+        else:
+            df_isync = self.build_df_nccl_implicit_sync_cat(
+                detailed=True, strict_metadata_check=strict_metadata_check
+            )
+        if df_isync.empty:
+            return pd.DataFrame()
+
+        wait_cols = [
+            c for c in df_isync.columns
+            if c.startswith("rank_") and c.endswith("_wait_time")
+        ]
+        if not wait_cols:
+            return pd.DataFrame()
+
+        ranks = sorted(
+            int(c.replace("rank_", "").replace("_wait_time", ""))
+            for c in wait_cols
+        )
+        num_collectives = len(df_isync)
+
+        straggler_rank_per_row = df_isync[wait_cols].idxmin(axis=1)
+
+        rows = []
+        for r in ranks:
+            wc = f"rank_{r}_wait_time"
+            total_wait = df_isync[wc].sum()
+            mean_wait = df_isync[wc].mean()
+            times_last = (straggler_rank_per_row == wc).sum()
+            times_first = (df_isync["earliest arrival rank"] == r).sum()
+            rows.append({
+                "rank": r,
+                "total_wait_time_us": round(total_wait, 1),
+                "mean_wait_time_us": round(mean_wait, 1),
+                "times_arrived_last": int(times_last),
+                "times_arrived_first": int(times_first),
+                "pct_arrived_last": round(100.0 * times_last / num_collectives, 1),
+                "num_collectives": num_collectives,
+            })
+
+        df_straggler = pd.DataFrame(rows)
+
+        if hasattr(self, "df_per_rank_coll") and not self.df_per_rank_coll.empty:
+            dur_by_rank = (
+                self.df_per_rank_coll.groupby("rank")["dur"]
+                .sum()
+                .reset_index()
+                .rename(columns={"dur": "total_nccl_dur_us"})
+            )
+            df_straggler = df_straggler.merge(dur_by_rank, on="rank", how="left")
+            df_straggler["total_nccl_dur_us"] = df_straggler[
+                "total_nccl_dur_us"
+            ].round(1)
+
+        df_straggler = df_straggler.sort_values(
+            "total_wait_time_us", ascending=True
+        ).reset_index(drop=True)
+
+        return df_straggler
+
     def build_df_nccl_all2allv(self, detailed=False, strict_metadata_check=True):
         """Build a per-collective-instance DataFrame for all_to_allv.
 

--- a/TraceLens/Reporting/generate_multi_rank_collective_report_pytorch.py
+++ b/TraceLens/Reporting/generate_multi_rank_collective_report_pytorch.py
@@ -93,7 +93,7 @@ def generate_collective_report(
     world_size: Optional[int] = None,
     output_xlsx_path: Optional[str] = None,
     output_csvs_dir: Optional[str] = None,
-    detailed_analysis: bool = False,
+    detailed_analysis: bool = True,
     agg_metrics: List[str] = ["mean", "median", "min", "max"],
     strict_world_size_check: bool = True,
     use_multiprocessing: bool = False,
@@ -241,6 +241,12 @@ def generate_collective_report(
         if df_all2allv is not None and not df_all2allv.empty:
             report_dfs["nccl_all2allv"] = df_all2allv
 
+    # Straggler summary — always generated when implicit-sync data exists
+    print("Generating straggler summary...")
+    df_straggler = nccl_analyser.build_df_straggler_summary()
+    if not df_straggler.empty:
+        report_dfs["straggler_summary"] = df_straggler
+
     # Add node_id and node_span columns when gpus_per_node is known
     if gpus_per_node is not None and gpus_per_node > 0:
         print(f"Adding node_span columns (gpus_per_node={gpus_per_node})...")
@@ -323,7 +329,7 @@ def main():
 
     # Analysis options
     parser.add_argument(
-        "--detailed_analysis", action="store_true", help="Include detailed information"
+        "--detailed_analysis", action="store_true", default=True, help="Include detailed information (enabled by default)"
     )
     parser.add_argument(
         "--agg_metrics",

--- a/docs/generate_multi_rank_collective_report_pytorch.md
+++ b/docs/generate_multi_rank_collective_report_pytorch.md
@@ -93,6 +93,7 @@ TraceLens_generate_multi_rank_collective_report_pytorch   --trace_dir /path/to/t
 | `nccl_summary_all2allv` | Aggregated all2allv metrics by (Process Group, dtype). Includes throughput, wall time, size imbalance, and timing skew. Unlike implicit-sync collectives, all2allv uses aggregate throughput rather than algo/bus bandwidth since per-rank data sizes vary. |
 | `nccl_all2allv` | Detailed All2AllV analysis: variable send/recv sizes and splits per rank, with timing and skew columns per rank. |
 | `nccl_all2allv_heatmap` | *(when `--all2allv_heatmap` is set)* Per rank-pair total send volumes across all all2allv invocations. Useful for identifying hot pairs in MoE/expert-parallel routing. |
+| `straggler_summary` | One row per rank with aggregated straggler metrics: total/mean wait time, how often the rank arrived last or first, and total NCCL duration. Sorted ascending by wait time so the straggler (lowest wait time) is at the top. See [Identifying Straggler Ranks](#-identifying-straggler-ranks). |
 
 _Notes:_
 - Summary sheets (`nccl_summary_*`, `nccl_summary_all2allv`) are **always** produced when the corresponding collective type exists in the trace; detailed per-event sheets (`nccl_long`, `nccl_implicit_sync`, `nccl_all2allv`) appear when `--detailed_analysis` is set.
@@ -111,6 +112,47 @@ _Notes:_
 
 **Lowest Common Directory (pattern mode)**  
 When using `--trace_pattern`, the tool expands the pattern by replacing `*` with `0..world_size-1`, then computes the **lowest common ancestor directory** of those paths to pick a default output location.
+
+---
+
+## 🔍 Identifying Straggler Ranks
+
+A **straggler** is the rank that consistently arrives last at collectives, forcing all other ranks to wait in implicit synchronization.
+
+### Quick answer: open `straggler_summary`
+
+The `straggler_summary` sheet is sorted so **the straggler is in the first row** (lowest total wait time). Example from an 8-rank Llama 70B FSDP run:
+
+| rank | total_wait_time_us | mean_wait_time_us | times_arrived_last | times_arrived_first | pct_arrived_last | num_collectives | total_nccl_dur_us |
+|------|-------------------|-------------------|-------------------|--------------------|-----------------:|----------------:|------------------:|
+| 4 | 27,195 | 55.7 | 420 | 6 | 86.1% | 488 | 3,910,753 |
+| 5 | 4,660,353 | 9,549.9 | 39 | 10 | 8.0% | 488 | 8,463,896 |
+| ... | ... | ... | ... | ... | ... | ... | ... |
+| 0 | 13,358,753 | 27,374.5 | 3 | 320 | 0.6% | 488 | 17,203,432 |
+
+**How to read it:**
+
+| Column | What it tells you |
+|--------|-------------------|
+| `total_wait_time_us` | Sum of this rank's wait time across all collectives. The straggler has the **lowest** value — it arrives last, so it rarely waits. |
+| `times_arrived_last` | Number of collectives where this rank was the last to arrive. The straggler dominates this column. |
+| `times_arrived_first` | Number of collectives where this rank arrived first. The rank that appears here most often pays the biggest sync penalty. |
+| `pct_arrived_last` | `times_arrived_last / num_collectives`. A rank at 86% is a persistent straggler. |
+| `total_nccl_dur_us` | Total time inside NCCL kernels. The straggler typically has the **lowest** value — other ranks' durations are inflated by implicit-sync wait time. |
+
+### Next step: visualize with TraceFusion
+
+Once you know the straggler rank, use [TraceFusion](TraceFusion.md) to merge the straggler's trace with a fast rank (e.g. the one with the highest `times_arrived_first`) into a single file and open it in Perfetto UI. Viewing both timelines side-by-side makes it straightforward to see what compute or memory work is delaying the straggler before each collective.
+
+```python
+from TraceLens import TraceFuse
+
+fuser = TraceFuse(
+    trace_files=["rank4_trace.json.gz", "rank0_trace.json.gz"],
+    output_file="straggler_vs_fast.json.gz",
+)
+fuser.fuse()
+```
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds a new `straggler_summary` sheet to the multi-rank NCCL collective report. One row per rank with total/mean wait time, arrival-last/first counts, percentage, and total NCCL duration — sorted so the straggler is the first row. Reuses cached implicit-sync data (~7ms overhead in normal report flow).
- Defaults `detailed_analysis` to `True` so `nccl_long`, `nccl_implicit_sync`, and `nccl_all2allv` sheets are always included without needing `--detailed_analysis`.
- Updates docs with straggler identification guide and TraceFusion next-step.

## Test plan
- [x] Ran on llama 70B FSDP 8-rank test traces — straggler_summary correctly identifies rank 4 (86.1% arrived last, lowest wait time)
- [x] Regression test `test_collective_analysis` passes (reference CSVs match)
- [x] Benchmarked: 7ms warm-cache overhead on top of ~45s total report time


Made with [Cursor](https://cursor.com)