### PR TITLE
[Feat] Idle Time Analysis for the GPU Kernel Stream

### DIFF
--- a/TraceLens/TreePerf/__init__.py
+++ b/TraceLens/TreePerf/__init__.py
@@ -10,6 +10,7 @@ from .gpu_event_analyser import (
     PytorchGPUEventAnalyser,
     JaxGPUEventAnalyser,
 )
+from .idle_time_analysis import IdleTimeAnalyser
 from .jax_analyses import JaxAnalyses
 from .jax_analyses import JaxAnalyses
 
@@ -19,5 +20,6 @@ __all__ = [
     "GPUEventAnalyser",
     "PytorchGPUEventAnalyser",
     "JaxGPUEventAnalyser",
+    "IdleTimeAnalyser",
     "JaxAnalyses",
 ]

--- a/TraceLens/TreePerf/idle_time_analysis.py
+++ b/TraceLens/TreePerf/idle_time_analysis.py
@@ -1,0 +1,498 @@
+###############################################################################
+# Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+import bisect
+from collections import defaultdict
+
+import pandas as pd
+
+from ..util import TraceEventUtils
+
+_SYNC_PATTERNS = frozenset(
+    {
+        "cudadevicesynchronize",
+        "cudastreamsynchronize",
+        "cudaeventsynchronize",
+        "hipdevicesynchronize",
+        "hipstreamsynchronize",
+        "hipeventsynchronize",
+    }
+)
+
+_STREAM_WAIT_PATTERNS = frozenset(
+    {
+        "cudastreamwaitevent",
+        "hipstreamwaitevent",
+    }
+)
+
+_MEMORY_PATTERNS = frozenset(
+    {
+        "cudamemcpy",
+        "cudamemcpyasync",
+        "cudamemset",
+        "cudamemsetasync",
+        "cudamalloc",
+        "cudamallocasync",
+        "cudafree",
+        "cudafreeasync",
+        "hipmemcpy",
+        "hipmemcpyasync",
+        "hipmemset",
+        "hipmemsetasync",
+        "hipmalloc",
+        "hipmallocasync",
+        "hipfree",
+        "hipfreeasync",
+        "cudamallocmanaged",
+        "cudamemcpy2d",
+        "cudamemcpy2dasync",
+        "cudamemcpy3d",
+        "cudamemcpy3dasync",
+    }
+)
+
+REASON_EXPLICIT_SYNC = "explicit_sync"
+REASON_CROSS_STREAM_DEP = "cross_stream_dep"
+REASON_CPU_BOTTLENECK = "cpu_bottleneck"
+REASON_LAUNCH_OVERHEAD = "launch_overhead"
+REASON_MEMORY_OP_STALL = "memory_op_stall"
+REASON_SCHEDULER_SATURATION = "scheduler_saturation"
+REASON_UNKNOWN = "unknown"
+
+
+def _name_lower(event):
+    return event.get("name", "").lower()
+
+
+def _matches_any(name_lower, patterns):
+    return any(name_lower.startswith(p) for p in patterns)
+
+
+class IdleTimeAnalyser:
+    """Classifies every idle gap on GPU stream(s) by root cause.
+
+    Requires a *built* TraceToTree instance (build_tree() already called)
+    so that parent/children links, per-stream ordering, and GPU-to-runtime
+    correlation are all in place.
+    """
+
+    def __init__(
+        self,
+        tree,
+        event_to_category=None,
+        launch_overhead_thresh_us=10.0,
+    ):
+        self.tree = tree
+        self.event_to_category = (
+            event_to_category or TraceEventUtils.default_categorizer
+        )
+        self.launch_overhead_thresh_us = launch_overhead_thresh_us
+        self._runtime_index_built = False
+        self._all_runtime_sorted = []
+        self._runtime_ts_keys = []
+
+    def _build_runtime_event_index(self):
+        """Pre-sort all cuda_runtime/cuda_driver events by ts for fast interval queries."""
+        if self._runtime_index_built:
+            return
+
+        runtime_cats = {"cuda_runtime", "cuda_driver"}
+        runtime_events = []
+        for event in self.tree.events:
+            cat = self.event_to_category(event)
+            if cat in runtime_cats:
+                if "t_end" not in event:
+                    ts = event.get("ts")
+                    dur = event.get("dur", 0)
+                    if ts is not None:
+                        event["t_end"] = ts + dur
+                if event.get("ts") is not None:
+                    runtime_events.append(event)
+
+        runtime_events.sort(key=lambda e: e["ts"])
+        self._all_runtime_sorted = runtime_events
+        self._runtime_ts_keys = [e["ts"] for e in runtime_events]
+        self._runtime_index_built = True
+
+    def _find_runtime_events_in_interval(self, t_start, t_end):
+        """Find runtime events whose [ts, t_end] overlaps [t_start, t_end]."""
+        self._build_runtime_event_index()
+        if not self._all_runtime_sorted:
+            return []
+
+        # Events that could overlap must have ts < t_end.
+        # Start scanning from events whose ts could overlap: ts < t_end.
+        right = bisect.bisect_left(self._runtime_ts_keys, t_end)
+        results = []
+        for i in range(right - 1, -1, -1):
+            evt = self._all_runtime_sorted[i]
+            evt_end = evt.get("t_end", evt["ts"])
+            if evt_end <= t_start:
+                # Events are sorted by ts; once t_end <= t_start we can
+                # keep scanning because earlier events might still overlap
+                # if they have long durations. But in practice runtime
+                # events are short, so use a generous cutoff.
+                if evt["ts"] < t_start - 1_000_000:
+                    break
+                continue
+            if evt["ts"] < t_end and evt_end > t_start:
+                results.append(evt)
+        return results
+
+    def _get_launch_parent(self, gpu_event):
+        """Return the cuda_runtime launch event that spawned this GPU kernel."""
+        parent_uid = gpu_event.get("parent")
+        if parent_uid is None:
+            return None
+        parent = self.tree.events_by_uid.get(parent_uid)
+        if parent is None:
+            return None
+        cat = self.event_to_category(parent)
+        if cat in {"cuda_runtime", "cuda_driver"}:
+            return parent
+        return None
+
+    def _get_cpu_op_ancestor(self, event):
+        """Walk up the parent chain to find the nearest cpu_op ancestor."""
+        current_uid = event.get("parent")
+        while current_uid is not None:
+            parent = self.tree.events_by_uid.get(current_uid)
+            if parent is None:
+                return None
+            if self.event_to_category(parent) == "cpu_op":
+                return parent
+            current_uid = parent.get("parent")
+        return None
+
+    def _get_per_stream_gaps(self, stream_id=None):
+        """Enumerate gaps between consecutive GPU events on each stream."""
+        if not hasattr(self.tree, "dict_stream_index2event"):
+            return []
+
+        stream_index_map = self.tree.dict_stream_index2event
+        streams = defaultdict(list)
+        for (stream, idx), event in stream_index_map.items():
+            streams[stream].append((idx, event))
+
+        gaps = []
+        for stream, idx_events in streams.items():
+            if stream_id is not None and stream != stream_id:
+                continue
+            idx_events.sort(key=lambda x: x[0])
+            for i in range(len(idx_events) - 1):
+                _, prev_event = idx_events[i]
+                _, next_event = idx_events[i + 1]
+                prev_end = prev_event.get("t_end", prev_event.get("ts", 0))
+                next_start = next_event.get("ts", 0)
+                duration = next_start - prev_end
+                if duration <= 0:
+                    continue
+                gaps.append(
+                    {
+                        "stream": stream,
+                        "gap_start": prev_end,
+                        "gap_end": next_start,
+                        "duration_us": duration,
+                        "prev_event": prev_event,
+                        "next_event": next_event,
+                    }
+                )
+        gaps.sort(key=lambda g: g["gap_start"])
+        return gaps
+
+    @staticmethod
+    def _same_thread(event_a, event_b):
+        """True if two events share the same (pid, tid)."""
+        if event_a is None or event_b is None:
+            return False
+        return (
+            event_a.get("pid") == event_b.get("pid")
+            and event_a.get("tid") == event_b.get("tid")
+        )
+
+    def _classify_gap(self, gap_info):
+        """Classify a single gap by examining CPU-side context.
+
+        The key insight: first determine whether the CPU was "late" issuing
+        the next launch.  If the launch was already queued before the gap
+        started, the gap is GPU-side (pipeline latency or scheduler
+        saturation) and we should NOT blame CPU-side events that merely
+        happen to overlap temporally (e.g. a sync on a different logical
+        path).  CPU-side investigation only matters when the launch was
+        demonstrably delayed.
+        """
+        gap_start = gap_info["gap_start"]
+        gap_end = gap_info["gap_end"]
+        duration = gap_info["duration_us"]
+        prev_event = gap_info["prev_event"]
+        next_event = gap_info["next_event"]
+
+        launch_event = self._get_launch_parent(next_event)
+        cpu_op_ancestor = None
+        if launch_event is not None:
+            cpu_op_ancestor = self._get_cpu_op_ancestor(launch_event)
+
+        # --- No launch event at all: the next GPU event (often a memset
+        #     or memcpy) isn't linked to a CPU-side launch via ac2g
+        #     correlation.  Check for GPU-side stream waits, then fall back.
+        if launch_event is None:
+            runtime_during_gap = self._find_runtime_events_in_interval(
+                gap_start, gap_end
+            )
+            for rt_evt in runtime_during_gap:
+                nl = _name_lower(rt_evt)
+                if _matches_any(nl, _STREAM_WAIT_PATTERNS):
+                    return self._build_result(
+                        gap_info,
+                        REASON_CROSS_STREAM_DEP,
+                        f"Stream wait '{rt_evt.get('name')}' active during gap",
+                        launch_event,
+                        cpu_op_ancestor,
+                    )
+            next_cat = next_event.get("cat", "")
+            next_name = next_event.get("name", "")
+            return self._build_result(
+                gap_info,
+                REASON_UNKNOWN,
+                (
+                    f"No launch event linked for next GPU op "
+                    f"(cat='{next_cat}', name='{next_name[:60]}')"
+                ),
+                launch_event,
+                cpu_op_ancestor,
+            )
+
+        launch_ts = launch_event.get("ts", 0)
+        launch_end = launch_event.get(
+            "t_end", launch_ts + launch_event.get("dur", 0)
+        )
+        prev_event_end = prev_event.get("t_end", prev_event.get("ts", 0))
+
+        # Was the launch already issued before this gap started?
+        launch_was_pipelined = launch_ts <= gap_start
+
+        # ------------------------------------------------------------------
+        # PATH A: Launch was pipelined (CPU issued it before gap started).
+        # The gap is GPU-side: either normal pipeline latency, a GPU-level
+        # cross-stream wait, or scheduler saturation.
+        # ------------------------------------------------------------------
+        if launch_was_pipelined:
+            # A1. Check for cross-stream dependency (GPU-side wait).
+            #     hipStreamWaitEvent affects the GPU stream regardless of
+            #     which CPU thread issued it.
+            runtime_during_gap = self._find_runtime_events_in_interval(
+                gap_start, gap_end
+            )
+            for rt_evt in runtime_during_gap:
+                nl = _name_lower(rt_evt)
+                if _matches_any(nl, _STREAM_WAIT_PATTERNS):
+                    return self._build_result(
+                        gap_info,
+                        REASON_CROSS_STREAM_DEP,
+                        f"Stream wait '{rt_evt.get('name')}' active during gap",
+                        launch_event,
+                        cpu_op_ancestor,
+                    )
+
+            # A2. Small gap → normal kernel launch overhead.
+            if duration <= self.launch_overhead_thresh_us:
+                return self._build_result(
+                    gap_info,
+                    REASON_LAUNCH_OVERHEAD,
+                    (
+                        f"Gap {duration:.1f}us <= threshold "
+                        f"{self.launch_overhead_thresh_us:.1f}us; "
+                        f"launch was pipelined"
+                    ),
+                    launch_event,
+                    cpu_op_ancestor,
+                )
+
+            # A3. Larger gap with pipelined launch → scheduler saturation.
+            next_kernel_start = next_event.get("ts", 0)
+            queuing_delay = next_kernel_start - launch_end
+            return self._build_result(
+                gap_info,
+                REASON_SCHEDULER_SATURATION,
+                (
+                    f"Launch completed {queuing_delay:.1f}us before kernel started; "
+                    f"GPU scheduler likely saturated"
+                ),
+                launch_event,
+                cpu_op_ancestor,
+            )
+
+        # ------------------------------------------------------------------
+        # PATH B: Launch was NOT pipelined (CPU issued it after the gap
+        # started → launch_ts > gap_start).  The CPU was late.
+        # Investigate WHY: sync, memory op, or general CPU work.
+        # ------------------------------------------------------------------
+        runtime_during_gap = self._find_runtime_events_in_interval(
+            gap_start, gap_end
+        )
+
+        # B1. Explicit synchronization on the launch thread.
+        for rt_evt in runtime_during_gap:
+            nl = _name_lower(rt_evt)
+            if _matches_any(nl, _SYNC_PATTERNS):
+                if self._same_thread(rt_evt, launch_event):
+                    return self._build_result(
+                        gap_info,
+                        REASON_EXPLICIT_SYNC,
+                        f"Sync API '{rt_evt.get('name')}' blocked launch thread during gap",
+                        launch_event,
+                        cpu_op_ancestor,
+                    )
+
+        # B2. Cross-stream dependency (GPU-side wait).
+        for rt_evt in runtime_during_gap:
+            nl = _name_lower(rt_evt)
+            if _matches_any(nl, _STREAM_WAIT_PATTERNS):
+                return self._build_result(
+                    gap_info,
+                    REASON_CROSS_STREAM_DEP,
+                    f"Stream wait '{rt_evt.get('name')}' active during gap",
+                    launch_event,
+                    cpu_op_ancestor,
+                )
+
+        # B3. Memory operation stall on the launch thread.
+        for rt_evt in runtime_during_gap:
+            nl = _name_lower(rt_evt)
+            if _matches_any(nl, _MEMORY_PATTERNS):
+                if self._same_thread(rt_evt, launch_event):
+                    return self._build_result(
+                        gap_info,
+                        REASON_MEMORY_OP_STALL,
+                        (
+                            f"Memory API '{rt_evt.get('name')}' "
+                            f"blocked launch thread during gap"
+                        ),
+                        launch_event,
+                        cpu_op_ancestor,
+                    )
+
+        # B4. General CPU bottleneck: the launch was late but no specific
+        #     blocking API was found — CPU was busy with other work.
+        cpu_delay = launch_ts - prev_event_end
+        if cpu_op_ancestor:
+            detail_msg = (
+                f"CPU launch '{launch_event.get('name')}' started "
+                f"{cpu_delay:.1f}us after prev kernel ended; "
+                f"CPU op ancestor: '{cpu_op_ancestor.get('name')}'"
+            )
+        else:
+            detail_msg = (
+                f"CPU launch '{launch_event.get('name')}' started "
+                f"{cpu_delay:.1f}us after prev kernel ended"
+            )
+        return self._build_result(
+            gap_info,
+            REASON_CPU_BOTTLENECK,
+            detail_msg,
+            launch_event,
+            cpu_op_ancestor,
+        )
+
+    @staticmethod
+    def _build_result(gap_info, reason, details, launch_event, cpu_op_ancestor):
+        return {
+            "stream": gap_info["stream"],
+            "gap_start": gap_info["gap_start"],
+            "gap_end": gap_info["gap_end"],
+            "duration_us": gap_info["duration_us"],
+            "reason": reason,
+            "prev_gpu_event_uid": gap_info["prev_event"].get("UID"),
+            "prev_gpu_event_name": gap_info["prev_event"].get("name"),
+            "next_gpu_event_uid": gap_info["next_event"].get("UID"),
+            "next_gpu_event_name": gap_info["next_event"].get("name"),
+            "launch_event_uid": launch_event.get("UID") if launch_event else None,
+            "launch_event_name": launch_event.get("name") if launch_event else None,
+            "cpu_op_ancestor_uid": (
+                cpu_op_ancestor.get("UID") if cpu_op_ancestor else None
+            ),
+            "cpu_op_ancestor_name": (
+                cpu_op_ancestor.get("name") if cpu_op_ancestor else None
+            ),
+            "details": details,
+        }
+
+    def get_gaps_df(self, stream_id=None):
+        """One row per idle gap with classification.
+
+        Returns a DataFrame with columns: stream, gap_start, gap_end,
+        duration_us, reason, prev/next GPU event info, launch event info,
+        cpu_op ancestor info, and a human-readable details string.
+        """
+        self._build_runtime_event_index()
+        raw_gaps = self._get_per_stream_gaps(stream_id=stream_id)
+        classified = [self._classify_gap(g) for g in raw_gaps]
+        if not classified:
+            return pd.DataFrame(
+                columns=[
+                    "stream",
+                    "gap_start",
+                    "gap_end",
+                    "duration_us",
+                    "reason",
+                    "prev_gpu_event_uid",
+                    "prev_gpu_event_name",
+                    "next_gpu_event_uid",
+                    "next_gpu_event_name",
+                    "launch_event_uid",
+                    "launch_event_name",
+                    "cpu_op_ancestor_uid",
+                    "cpu_op_ancestor_name",
+                    "details",
+                ]
+            )
+        return pd.DataFrame(classified)
+
+    def get_summary_df(self, stream_id=None):
+        """Aggregated idle time by reason category.
+
+        Returns a DataFrame with columns: reason, count, total_time_us,
+        mean_duration_us, max_duration_us, pct_of_total_idle.
+        """
+        df = self.get_gaps_df(stream_id=stream_id)
+        if df.empty:
+            return pd.DataFrame(
+                columns=[
+                    "reason",
+                    "count",
+                    "total_time_us",
+                    "mean_duration_us",
+                    "max_duration_us",
+                    "pct_of_total_idle",
+                ]
+            )
+
+        total_idle = df["duration_us"].sum()
+        summary = (
+            df.groupby("reason")["duration_us"]
+            .agg(["count", "sum", "mean", "max"])
+            .reset_index()
+        )
+        summary.columns = [
+            "reason",
+            "count",
+            "total_time_us",
+            "mean_duration_us",
+            "max_duration_us",
+        ]
+        summary["pct_of_total_idle"] = summary["total_time_us"] / total_idle * 100
+        summary = summary.sort_values("total_time_us", ascending=False).reset_index(
+            drop=True
+        )
+        return summary
+
+    def get_top_gaps(self, n=10, stream_id=None):
+        """The N largest idle gaps with their classifications."""
+        df = self.get_gaps_df(stream_id=stream_id)
+        if df.empty:
+            return df
+        return df.nlargest(n, "duration_us").reset_index(drop=True)

--- a/TraceLens/TreePerf/idle_time_analysis.py
+++ b/TraceLens/TreePerf/idle_time_analysis.py
@@ -11,17 +11,6 @@ import pandas as pd
 
 from ..util import TraceEventUtils
 
-_SYNC_PATTERNS = frozenset(
-    {
-        "cudadevicesynchronize",
-        "cudastreamsynchronize",
-        "cudaeventsynchronize",
-        "hipdevicesynchronize",
-        "hipstreamsynchronize",
-        "hipeventsynchronize",
-    }
-)
-
 _STREAM_WAIT_PATTERNS = frozenset(
     {
         "cudastreamwaitevent",
@@ -55,7 +44,6 @@ _MEMORY_PATTERNS = frozenset(
     }
 )
 
-REASON_EXPLICIT_SYNC = "explicit_sync"
 REASON_CROSS_STREAM_DEP = "cross_stream_dep"
 REASON_CPU_BOTTLENECK = "cpu_bottleneck"
 REASON_LAUNCH_OVERHEAD = "launch_overhead"
@@ -209,10 +197,9 @@ class IdleTimeAnalyser:
         """True if two events share the same (pid, tid)."""
         if event_a is None or event_b is None:
             return False
-        return (
-            event_a.get("pid") == event_b.get("pid")
-            and event_a.get("tid") == event_b.get("tid")
-        )
+        return event_a.get("pid") == event_b.get("pid") and event_a.get(
+            "tid"
+        ) == event_b.get("tid")
 
     def _classify_gap(self, gap_info):
         """Classify a single gap by examining CPU-side context.
@@ -267,9 +254,7 @@ class IdleTimeAnalyser:
             )
 
         launch_ts = launch_event.get("ts", 0)
-        launch_end = launch_event.get(
-            "t_end", launch_ts + launch_event.get("dur", 0)
-        )
+        launch_end = launch_event.get("t_end", launch_ts + launch_event.get("dur", 0))
         prev_event_end = prev_event.get("t_end", prev_event.get("ts", 0))
 
         # Was the launch already issued before this gap started?
@@ -329,26 +314,11 @@ class IdleTimeAnalyser:
         # ------------------------------------------------------------------
         # PATH B: Launch was NOT pipelined (CPU issued it after the gap
         # started → launch_ts > gap_start).  The CPU was late.
-        # Investigate WHY: sync, memory op, or general CPU work.
+        # Investigate WHY: memory op, stream wait, or general CPU work.
         # ------------------------------------------------------------------
-        runtime_during_gap = self._find_runtime_events_in_interval(
-            gap_start, gap_end
-        )
+        runtime_during_gap = self._find_runtime_events_in_interval(gap_start, gap_end)
 
-        # B1. Explicit synchronization on the launch thread.
-        for rt_evt in runtime_during_gap:
-            nl = _name_lower(rt_evt)
-            if _matches_any(nl, _SYNC_PATTERNS):
-                if self._same_thread(rt_evt, launch_event):
-                    return self._build_result(
-                        gap_info,
-                        REASON_EXPLICIT_SYNC,
-                        f"Sync API '{rt_evt.get('name')}' blocked launch thread during gap",
-                        launch_event,
-                        cpu_op_ancestor,
-                    )
-
-        # B2. Cross-stream dependency (GPU-side wait).
+        # B1. Cross-stream dependency (GPU-side wait).
         for rt_evt in runtime_during_gap:
             nl = _name_lower(rt_evt)
             if _matches_any(nl, _STREAM_WAIT_PATTERNS):
@@ -360,7 +330,7 @@ class IdleTimeAnalyser:
                     cpu_op_ancestor,
                 )
 
-        # B3. Memory operation stall on the launch thread.
+        # B2. Memory operation stall on the launch thread.
         for rt_evt in runtime_during_gap:
             nl = _name_lower(rt_evt)
             if _matches_any(nl, _MEMORY_PATTERNS):
@@ -376,7 +346,7 @@ class IdleTimeAnalyser:
                         cpu_op_ancestor,
                     )
 
-        # B4. General CPU bottleneck: the launch was late but no specific
+        # B3. General CPU bottleneck: the launch was late but no specific
         #     blocking API was found — CPU was busy with other work.
         cpu_delay = launch_ts - prev_event_end
         if cpu_op_ancestor:
@@ -430,7 +400,7 @@ class IdleTimeAnalyser:
         """
         self._build_runtime_event_index()
         raw_gaps = self._get_per_stream_gaps(stream_id=stream_id)
-        classified = [self._classify_gap(g) for g in raw_gaps]
+        classified = [r for g in raw_gaps if (r := self._classify_gap(g)) is not None]
         if not classified:
             return pd.DataFrame(
                 columns=[

--- a/TraceLens/TreePerf/tree_perf.py
+++ b/TraceLens/TreePerf/tree_perf.py
@@ -34,6 +34,7 @@ from ..Trace2Tree.trace_capture_merge_experimental import merge_capture_trace_in
 from ..Trace2Tree.trace_to_tree import JaxTraceToTree, TraceToTree
 from ..util import DataLoader, JaxProfileProcessor, TraceEventUtils
 from .gpu_event_analyser import GPUEventAnalyser, JaxGPUEventAnalyser
+from .idle_time_analysis import IdleTimeAnalyser
 from .jax_analyses import JaxAnalyses
 from ..Trace2Tree.extensions import apply_pseudo_op_extensions
 from ..PerfModel.utils import add_simulation_time_columns
@@ -2540,6 +2541,37 @@ class TreePerfAnalyzer:
         out = pd.concat(dfs, ignore_index=True)
         cols = ["type", "time ms", "percent", "is_recompute"]
         return out[[c for c in cols if c in out.columns]]
+
+    def get_df_idle_analysis(self, stream_id=None, launch_overhead_thresh_us=10.0):
+        """Classify every idle gap on GPU stream(s) by root cause.
+
+        Returns a DataFrame with one row per gap. See IdleTimeAnalyser for
+        the full taxonomy of gap reasons.
+        """
+        analyser = IdleTimeAnalyser(
+            self.tree,
+            event_to_category=self.event_to_category,
+            launch_overhead_thresh_us=launch_overhead_thresh_us,
+        )
+        return analyser.get_gaps_df(stream_id=stream_id)
+
+    def get_idle_summary_df(self, stream_id=None, launch_overhead_thresh_us=10.0):
+        """Aggregated idle time breakdown by reason category."""
+        analyser = IdleTimeAnalyser(
+            self.tree,
+            event_to_category=self.event_to_category,
+            launch_overhead_thresh_us=launch_overhead_thresh_us,
+        )
+        return analyser.get_summary_df(stream_id=stream_id)
+
+    def get_top_idle_gaps(self, n=10, stream_id=None, launch_overhead_thresh_us=10.0):
+        """The N largest idle gaps with their classifications."""
+        analyser = IdleTimeAnalyser(
+            self.tree,
+            event_to_category=self.event_to_category,
+            launch_overhead_thresh_us=launch_overhead_thresh_us,
+        )
+        return analyser.get_top_gaps(n=n, stream_id=stream_id)
 
     def get_kernel_details(
         self,

--- a/docs/IdleAnalysis.md
+++ b/docs/IdleAnalysis.md
@@ -1,0 +1,220 @@
+# GPU Idle Time Analysis
+
+## Overview
+
+TraceLens can classify every idle gap on a GPU stream by its root cause. Rather than reporting GPU idle time as a single number, the idle time analyser breaks it down into categories that explain *why* the GPU was idle, giving engineers actionable information for optimisation.
+
+The analysis is per-stream: for each GPU stream, it looks at every gap between consecutive GPU events (kernels, memcpy, memset) and classifies the gap by correlating it with the CPU-side call stack, CUDA/HIP runtime events, and the kernel launch timeline.
+
+## Key Concept: The Pipelined Launch Model
+
+Modern GPU programming uses an asynchronous launch model. The CPU issues kernel launches via runtime APIs (`cudaLaunchKernel` / `hipLaunchKernel`), which enqueue work onto a GPU stream. The GPU executes kernels from the queue independently. When the CPU stays ahead of the GPU (i.e., the next launch is issued before the current kernel finishes), the GPU pipeline stays full and gaps are minimal.
+
+The entire classification algorithm hinges on one question:
+
+> **Was the CPU-side launch for the next kernel issued *before* or *after* the gap started?**
+
+This divides every gap into one of two paths:
+
+```
+For each gap between kernel[i] and kernel[i+1] on the same stream:
+
+    Find the CPU-side launch event for kernel[i+1]
+
+    if launch.ts <= gap_start:
+        --> PATH A: Launch was pipelined (GPU-side gap)
+    else:
+        --> PATH B: Launch was late (CPU-side gap)
+```
+
+### Path A: Launch Was Pipelined (GPU-Side Gap)
+
+The CPU did its job -- it issued the launch before the previous kernel even finished. The gap exists because the GPU itself couldn't start the next kernel immediately. This means the root cause is on the GPU side, and we should **not** blame CPU-side events (like a sync call on another thread) that merely happen to overlap temporally.
+
+### Path B: Launch Was Late (CPU-Side Gap)
+
+The CPU didn't issue the launch until after the previous kernel had already finished. The GPU was starved -- it had nothing to execute. The root cause is on the CPU side, and we investigate *what* the CPU was doing during the gap that delayed the launch.
+
+This two-path split is critical for avoiding false classifications. Without it, a long-running `hipEventSynchronize` on a profiling thread (which doesn't block kernel launches at all) would be falsely blamed for every tiny inter-kernel gap that happens to overlap with it temporally.
+
+## Classification Taxonomy
+
+### Path A Classifications (GPU-side gaps)
+
+#### A1. Cross-Stream Dependency (`cross_stream_dep`)
+
+A `cudaStreamWaitEvent` / `hipStreamWaitEvent` was issued during the gap interval. This API makes a GPU stream wait until an event recorded on another stream completes. Stream-wait affects the GPU stream directly regardless of which CPU thread issued it.
+
+**How detected:** Find `cuda_runtime` events with names matching stream-wait patterns whose time interval overlaps the gap.
+
+**Typical cause:** Multi-stream workloads where one stream depends on another's output (e.g., a compute stream waiting for a data transfer stream).
+
+#### A2. Launch Overhead (`launch_overhead`)
+
+The gap is small (below a configurable threshold, default 10us) and the launch was pipelined. This is the irreducible cost of the GPU hardware dispatch pipeline -- the time between one kernel finishing and the next starting, even when work is already queued.
+
+**How detected:** `gap_duration <= launch_overhead_thresh_us` and the launch was pipelined.
+
+**Typical cause:** Normal GPU operation. These gaps are expected and typically sub-microsecond to single-digit microseconds. A high count with tiny durations is healthy.
+
+#### A3. Scheduler Saturation (`scheduler_saturation`)
+
+The launch was pipelined, but the gap is larger than the launch overhead threshold and no stream-wait was found. The CPU issued the launch in time, the GPU just didn't start the kernel promptly.
+
+**How detected:** Pipelined launch + gap exceeds threshold + no stream-wait found.
+
+**Typical cause:** GPU hardware scheduler contention -- too many pending kernels across streams, resource conflicts (registers, shared memory), or hardware queue depth limits. Can also indicate resource-intensive kernels that prevent the next kernel from starting.
+
+### Path B Classifications (CPU-side gaps)
+
+For Path B, we investigate what was happening on the **same CPU thread** as the kernel launch. This is important because CUDA/HIP runtime APIs block only the *calling* thread. An API running on thread A does not prevent `hipLaunchKernel` on thread B.
+
+#### B1. Cross-Stream Dependency (`cross_stream_dep`)
+
+Same as A1, but found on the late-launch path. A stream-wait was active during the gap even though the launch was late.
+
+#### B2. Memory Operation Stall (`memory_op_stall`)
+
+A synchronous memory API was active on the launch thread during the gap, blocking it from issuing the next launch.
+
+**How detected:** Find `cuda_runtime`/`cuda_driver` events with memory-pattern names that (a) overlap the gap interval and (b) ran on the **same (pid, tid)** as the launch event.
+
+**Matched API names include:**
+- `cudaMemcpy` / `hipMemcpy` (synchronous variants)
+- `cudaMalloc` / `hipMalloc`
+- `cudaFree` / `hipFree`
+- `cudaMemset` / `hipMemset`
+- And their async/2D/3D variants
+
+**Typical cause:** Synchronous host-device data transfers, runtime memory allocation (which may trigger device synchronisation internally), or memory deallocation.
+
+#### B3. CPU Bottleneck (`cpu_bottleneck`)
+
+The launch was late but no specific blocking API (memory, stream-wait) was found on the launch thread. The CPU was simply busy doing other work -- framework overhead, Python execution, tensor metadata computation, etc.
+
+**How detected:** Fallback when the launch was late and no specific blocking API matched. The analyser reports the CPU delay (how late the launch was) and the nearest `cpu_op` ancestor in the call stack to help identify what the CPU was doing.
+
+**Typical cause:** Heavy CPU-side computation between kernel launches (e.g., complex control flow, dynamic shape computation, Python overhead in eager mode). Also common for operators that are CPU-bound (sorting, data-dependent indexing).
+
+### Special Case: Unknown (`unknown`)
+
+The next GPU event has no linked CPU-side launch event (common for `gpu_memset` and `gpu_memcpy` operations that are issued via runtime APIs other than `cudaLaunchKernel` and may not have ac2g correlation links in the trace).
+
+## Classification Decision Flowchart
+
+```
+                    ┌─────────────────────────────┐
+                    │  Gap between GPU event[i]    │
+                    │  and GPU event[i+1]          │
+                    │  on the same stream          │
+                    └──────────────┬───────────────┘
+                                   │
+                    ┌──────────────▼───────────────┐
+                    │  Find launch event for        │
+                    │  GPU event[i+1]               │
+                    └──────────────┬───────────────┘
+                                   │
+                          ┌────────▼────────┐
+                          │ Launch found?    │
+                          └───┬─────────┬───┘
+                          No  │         │ Yes
+                              │         │
+                  ┌───────────▼──┐  ┌───▼──────────────────┐
+                  │ Check for    │  │ launch.ts <= gap_start│
+                  │ stream wait  │  │ (was it pipelined?)   │
+                  │ → cross_     │  └───┬──────────────┬───┘
+                  │   stream_dep │    Yes│              │No
+                  │ else:        │      │              │
+                  │ → unknown    │      │              │
+                  └──────────────┘  ┌───▼────┐   ┌────▼────────┐
+                                    │ PATH A │   │   PATH B    │
+                                    │GPU-side│   │  CPU-side   │
+                                    └───┬────┘   └────┬────────┘
+                                        │             │
+                        ┌───────────────▼──┐   ┌──────▼───────────┐
+                        │ Stream wait?     │   │ Stream wait?     │
+                        │ → cross_stream_  │   │ → cross_stream_  │
+                        │   dep            │   │   dep            │
+                        │                  │   │                  │
+                        │ Small gap?       │   │ Memory op on     │
+                        │ → launch_        │   │ same thread?     │
+                        │   overhead       │   │ → memory_op_     │
+                        │                  │   │   stall          │
+                        │ Large gap?       │   │                  │
+                        │ → scheduler_     │   │ Else:            │
+                        │   saturation     │   │ → cpu_bottleneck │
+                        └──────────────────┘   └──────────────────┘
+```
+
+## The Same-Thread Check
+
+A subtle but important detail: CUDA/HIP runtime APIs and memory operations block only the **calling CPU thread**. A `hipEventSynchronize` on thread 42 does not prevent `hipLaunchKernel` from being called on thread 100.
+
+In real traces, profiling infrastructure often calls `hipEventSynchronize` on a background thread for timing purposes. Without the same-thread check, these profiling-related calls would be falsely blamed for every gap that happens to overlap them temporally -- potentially misclassifying hundreds of thousands of gaps.
+
+The analyser only blames memory APIs when they ran on the **same (pid, tid)** as the launch event for the next kernel. Cross-stream waits (`cudaStreamWaitEvent`) are exempt from this check because they affect the GPU stream directly, regardless of which CPU thread issued them.
+
+## Usage
+
+```python
+from TraceLens import TraceToTree
+from TraceLens.TreePerf.tree_perf import TreePerfAnalyzer
+
+tree = TraceToTree(events)
+perf = TreePerfAnalyzer(tree)
+
+# Detailed per-gap classification
+idle_df = perf.get_df_idle_analysis()
+
+# Summary breakdown by reason
+summary = perf.get_idle_summary_df()
+
+# Top N largest gaps
+top = perf.get_top_idle_gaps(n=10)
+
+# Filter to a specific stream
+idle_stream7 = perf.get_df_idle_analysis(stream_id=7)
+
+# Adjust the launch overhead threshold (default 10us)
+idle_df = perf.get_df_idle_analysis(launch_overhead_thresh_us=20.0)
+```
+
+## Output Columns
+
+### `get_df_idle_analysis()` -- one row per gap
+
+| Column | Description |
+|---|---|
+| `stream` | GPU stream ID |
+| `gap_start` | Timestamp (us) where the previous GPU event ended |
+| `gap_end` | Timestamp (us) where the next GPU event started |
+| `duration_us` | Gap duration in microseconds |
+| `reason` | Classification label (see taxonomy above) |
+| `prev_gpu_event_uid` | UID of the GPU event before the gap |
+| `prev_gpu_event_name` | Kernel/memcpy/memset name before the gap |
+| `next_gpu_event_uid` | UID of the GPU event after the gap |
+| `next_gpu_event_name` | Kernel/memcpy/memset name after the gap |
+| `launch_event_uid` | UID of the CPU-side launch for the next kernel |
+| `launch_event_name` | Name of the launch API (e.g., `hipLaunchKernel`) |
+| `cpu_op_ancestor_uid` | UID of the nearest `cpu_op` ancestor of the launch |
+| `cpu_op_ancestor_name` | Name of the cpu_op (e.g., `aten::matmul`) |
+| `details` | Human-readable explanation of the classification |
+
+### `get_idle_summary_df()` -- aggregated by reason
+
+| Column | Description |
+|---|---|
+| `reason` | Classification label |
+| `count` | Number of gaps with this reason |
+| `total_time_us` | Total idle time for this reason |
+| `mean_duration_us` | Average gap duration |
+| `max_duration_us` | Largest single gap |
+| `pct_of_total_idle` | Percentage of total idle time |
+
+## Note on Per-Stream vs. Global Idle
+
+This analysis is **per-stream**: it counts every gap on every stream independently. This means the total idle time across all streams will generally be **larger** than the global GPU idle time reported by `get_df_gpu_timeline()`, because when stream A is idle but stream B is busy, this analysis counts stream A's gap while the global metric does not (since the GPU as a whole was not idle).
+
+Both views are useful:
+- **Per-stream idle** tells you how well-utilised each individual stream is and what's causing each stream to stall.
+- **Global idle** (from `get_df_gpu_timeline()`) tells you when the entire GPU had no work at all.

--- a/tests/test_idle_analysis.py
+++ b/tests/test_idle_analysis.py
@@ -1,0 +1,316 @@
+###############################################################################
+# Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Unit tests for IdleTimeAnalyser and the TreePerfAnalyzer idle analysis
+delegation methods.
+
+Each test constructs a minimal synthetic trace that triggers a specific
+gap classification, builds a TraceToTree + TreePerfAnalyzer, and asserts
+the reason column in the resulting DataFrame.
+"""
+
+import pytest
+from copy import deepcopy
+
+from TraceLens.Trace2Tree.trace_to_tree import TraceToTree
+from TraceLens.TreePerf.tree_perf import TreePerfAnalyzer
+from TraceLens.TreePerf.idle_time_analysis import (
+    IdleTimeAnalyser,
+    REASON_LAUNCH_OVERHEAD,
+    REASON_EXPLICIT_SYNC,
+    REASON_CROSS_STREAM_DEP,
+    REASON_CPU_BOTTLENECK,
+    REASON_MEMORY_OP_STALL,
+    REASON_SCHEDULER_SATURATION,
+    REASON_UNKNOWN,
+)
+
+CPU_PID, CPU_TID = 100, 100
+GPU_PID, GPU_TID = 0, 7
+STREAM = 7
+
+
+def _ev(cat, name, ts, dur, pid=CPU_PID, tid=CPU_TID, args=None):
+    return {
+        "ph": "X",
+        "cat": cat,
+        "name": name,
+        "pid": pid,
+        "tid": tid,
+        "ts": ts,
+        "dur": dur,
+        "args": args or {},
+    }
+
+
+def _kernel(name, ts, dur, corr, stream=STREAM):
+    return _ev(
+        "kernel",
+        name,
+        ts,
+        dur,
+        pid=GPU_PID,
+        tid=stream,
+        args={"correlation": corr, "stream": stream},
+    )
+
+
+def _launch(ts, dur, corr, name="hipLaunchKernel"):
+    return _ev("cuda_runtime", name, ts, dur, args={"correlation": corr})
+
+
+def _ac2g(corr, ts, phase, stream=STREAM):
+    evt = {
+        "ph": phase,
+        "id": corr,
+        "pid": GPU_PID,
+        "tid": stream,
+        "ts": ts,
+        "cat": "ac2g",
+        "name": "ac2g",
+    }
+    if phase == "f":
+        evt["bp"] = "e"
+    return evt
+
+
+def _build(events):
+    """Build tree and analyzer from events, return TreePerfAnalyzer."""
+    trace = {"traceEvents": deepcopy(events)}
+    tree = TraceToTree(trace["traceEvents"])
+    return TreePerfAnalyzer(tree, add_python_func=False)
+
+
+def _two_kernel_trace(
+    corr1, k1_ts, k1_dur,
+    corr2, launch2_ts, launch2_dur, k2_ts, k2_dur,
+    extra_events=None,
+    stream=STREAM,
+    cpu_op_ts=None, cpu_op_dur=None,
+):
+    """Build a complete two-kernel trace with a wrapping cpu_op.
+
+    The cpu_op is sized to encompass both launches by default.
+    Pass extra_events (list) to inject additional runtime events (sync, etc.)
+    between the two kernels.
+    """
+    if cpu_op_ts is None:
+        cpu_op_ts = k1_ts - 100
+    if cpu_op_dur is None:
+        cpu_op_dur = (k2_ts + k2_dur) - cpu_op_ts + 100
+
+    events = [
+        _ev("cpu_op", "aten::op", ts=cpu_op_ts, dur=cpu_op_dur),
+        _launch(ts=k1_ts - 50, dur=5, corr=corr1),
+        _kernel("kernel_A", k1_ts, k1_dur, corr1, stream=stream),
+        _ac2g(corr1, k1_ts, "s", stream=stream),
+        _ac2g(corr1, k1_ts, "f", stream=stream),
+    ]
+    if extra_events:
+        events.extend(extra_events)
+    events.extend([
+        _launch(ts=launch2_ts, dur=launch2_dur, corr=corr2),
+        _kernel("kernel_B", k2_ts, k2_dur, corr2, stream=stream),
+        _ac2g(corr2, k2_ts, "s", stream=stream),
+        _ac2g(corr2, k2_ts, "f", stream=stream),
+    ])
+    return events
+
+
+class TestLaunchOverhead:
+    def test_small_pipelined_gap(self):
+        """Gap < threshold with pipelined launch → launch_overhead."""
+        # launch for kernel_B starts BEFORE kernel_A ends (pipelined),
+        # kernel_B starts shortly after kernel_A ends → small gap.
+        events = _two_kernel_trace(
+            1, k1_ts=1000, k1_dur=100,
+            corr2=2, launch2_ts=1050, launch2_dur=5, k2_ts=1105, k2_dur=100,
+        )
+        perf = _build(events)
+        df = perf.get_df_idle_analysis(launch_overhead_thresh_us=10.0)
+        assert len(df) == 1
+        assert df.iloc[0]["reason"] == REASON_LAUNCH_OVERHEAD
+        assert df.iloc[0]["duration_us"] == 5.0  # 1105 - 1100
+
+
+class TestExplicitSync:
+    def test_sync_blocks_launch_thread(self):
+        """Sync API on the same thread as the launch → explicit_sync."""
+        # Sync blocks the launch thread for 500us after kernel_A ends.
+        events = _two_kernel_trace(
+            1, k1_ts=1000, k1_dur=100,
+            corr2=2, launch2_ts=1560, launch2_dur=5, k2_ts=1600, k2_dur=100,
+            extra_events=[
+                _ev("cuda_runtime", "hipEventSynchronize", ts=1050, dur=500),
+            ],
+        )
+        perf = _build(events)
+        df = perf.get_df_idle_analysis()
+        assert len(df) == 1
+        assert df.iloc[0]["reason"] == REASON_EXPLICIT_SYNC
+
+    def test_sync_on_different_thread_not_blamed(self):
+        """Sync on a different thread should NOT be blamed."""
+        events = _two_kernel_trace(
+            1, k1_ts=1000, k1_dur=100,
+            corr2=2, launch2_ts=1200, launch2_dur=5, k2_ts=1300, k2_dur=100,
+            extra_events=[
+                # Sync on a DIFFERENT thread (tid=999).
+                _ev("cuda_runtime", "hipEventSynchronize", ts=1050, dur=500, tid=999),
+            ],
+        )
+        perf = _build(events)
+        df = perf.get_df_idle_analysis()
+        assert len(df) == 1
+        # Should be cpu_bottleneck, NOT explicit_sync.
+        assert df.iloc[0]["reason"] == REASON_CPU_BOTTLENECK
+
+
+class TestCrossStreamDep:
+    def test_stream_wait_event(self):
+        """hipStreamWaitEvent during gap → cross_stream_dep."""
+        # Stream wait issued during the gap interval [1100, 1200].
+        events = _two_kernel_trace(
+            1, k1_ts=1000, k1_dur=100,
+            corr2=2, launch2_ts=1050, launch2_dur=5, k2_ts=1200, k2_dur=100,
+            extra_events=[
+                _ev("cuda_runtime", "hipStreamWaitEvent", ts=1100, dur=50),
+            ],
+        )
+        perf = _build(events)
+        df = perf.get_df_idle_analysis()
+        assert len(df) == 1
+        assert df.iloc[0]["reason"] == REASON_CROSS_STREAM_DEP
+
+
+class TestCpuBottleneck:
+    def test_late_launch(self):
+        """Launch issued after prev kernel ended, no blocking API → cpu_bottleneck."""
+        events = _two_kernel_trace(
+            1, k1_ts=1000, k1_dur=100,
+            corr2=2, launch2_ts=1200, launch2_dur=5, k2_ts=1300, k2_dur=100,
+        )
+        perf = _build(events)
+        df = perf.get_df_idle_analysis()
+        assert len(df) == 1
+        assert df.iloc[0]["reason"] == REASON_CPU_BOTTLENECK
+        assert "cpu_op_ancestor_name" in df.columns
+        assert df.iloc[0]["cpu_op_ancestor_name"] == "aten::op"
+
+
+class TestMemoryOpStall:
+    def test_memcpy_blocks_launch_thread(self):
+        """Memory API on launch thread during gap → memory_op_stall."""
+        events = _two_kernel_trace(
+            1, k1_ts=1000, k1_dur=100,
+            corr2=2, launch2_ts=1160, launch2_dur=5, k2_ts=1200, k2_dur=100,
+            extra_events=[
+                _ev("cuda_runtime", "hipMemcpy", ts=1050, dur=100),
+            ],
+        )
+        perf = _build(events)
+        df = perf.get_df_idle_analysis()
+        assert len(df) == 1
+        assert df.iloc[0]["reason"] == REASON_MEMORY_OP_STALL
+
+
+class TestSchedulerSaturation:
+    def test_pipelined_large_gap(self):
+        """Pipelined launch but large gap with no stream wait → scheduler_saturation."""
+        events = _two_kernel_trace(
+            1, k1_ts=1000, k1_dur=100,
+            corr2=2, launch2_ts=1050, launch2_dur=5, k2_ts=1200, k2_dur=100,
+        )
+        perf = _build(events)
+        df = perf.get_df_idle_analysis(launch_overhead_thresh_us=10.0)
+        assert len(df) == 1
+        assert df.iloc[0]["reason"] == REASON_SCHEDULER_SATURATION
+        assert df.iloc[0]["duration_us"] == 100.0  # 1200 - 1100
+
+
+class TestUnknown:
+    def test_unlinked_gpu_op(self):
+        """GPU event with no launch parent → unknown."""
+        events = [
+            _ev("cpu_op", "aten::op", ts=900, dur=500),
+            _kernel("kernel_A", 1000, 100, corr=1),
+            _ac2g(1, 1000, "s"),
+            _ac2g(1, 1000, "f"),
+            _launch(ts=950, dur=5, corr=1),
+            # A memset with no launch parent or ac2g links.
+            {
+                "ph": "X",
+                "cat": "gpu_memset",
+                "name": "Memset (Device)",
+                "pid": GPU_PID,
+                "tid": STREAM,
+                "ts": 1200,
+                "dur": 10,
+                "args": {"stream": STREAM},
+            },
+        ]
+        perf = _build(events)
+        df = perf.get_df_idle_analysis()
+        assert len(df) == 1
+        assert df.iloc[0]["reason"] == REASON_UNKNOWN
+
+
+class TestDelegationMethods:
+    """Verify the TreePerfAnalyzer thin delegation methods work."""
+
+    def _make_analyzer(self):
+        events = _two_kernel_trace(
+            1, k1_ts=1000, k1_dur=100,
+            corr2=2, launch2_ts=1200, launch2_dur=5, k2_ts=1300, k2_dur=100,
+        )
+        return _build(events)
+
+    def test_get_df_idle_analysis(self):
+        perf = self._make_analyzer()
+        df = perf.get_df_idle_analysis()
+        assert not df.empty
+        assert "reason" in df.columns
+
+    def test_get_idle_summary_df(self):
+        perf = self._make_analyzer()
+        summary = perf.get_idle_summary_df()
+        assert not summary.empty
+        assert "pct_of_total_idle" in summary.columns
+        assert summary["pct_of_total_idle"].sum() == pytest.approx(100.0)
+
+    def test_get_top_idle_gaps(self):
+        perf = self._make_analyzer()
+        top = perf.get_top_idle_gaps(n=5)
+        assert len(top) <= 5
+
+    def test_stream_filter(self):
+        perf = self._make_analyzer()
+        df_all = perf.get_df_idle_analysis()
+        df_filtered = perf.get_df_idle_analysis(stream_id=STREAM)
+        assert len(df_filtered) <= len(df_all)
+        if not df_filtered.empty:
+            assert (df_filtered["stream"] == STREAM).all()
+
+
+class TestEmptyTrace:
+    def test_no_gpu_events(self):
+        events = [_ev("cpu_op", "aten::op", ts=1000, dur=100)]
+        perf = _build(events)
+        df = perf.get_df_idle_analysis()
+        assert df.empty
+
+    def test_single_kernel(self):
+        events = [
+            _ev("cpu_op", "aten::op", ts=900, dur=300),
+            _launch(ts=950, dur=5, corr=1),
+            _kernel("kernel_A", 1000, 100, corr=1),
+            _ac2g(1, 1000, "s"),
+            _ac2g(1, 1000, "f"),
+        ]
+        perf = _build(events)
+        df = perf.get_df_idle_analysis()
+        assert df.empty

--- a/tests/test_idle_analysis.py
+++ b/tests/test_idle_analysis.py
@@ -21,7 +21,6 @@ from TraceLens.TreePerf.tree_perf import TreePerfAnalyzer
 from TraceLens.TreePerf.idle_time_analysis import (
     IdleTimeAnalyser,
     REASON_LAUNCH_OVERHEAD,
-    REASON_EXPLICIT_SYNC,
     REASON_CROSS_STREAM_DEP,
     REASON_CPU_BOTTLENECK,
     REASON_MEMORY_OP_STALL,
@@ -135,39 +134,6 @@ class TestLaunchOverhead:
         assert len(df) == 1
         assert df.iloc[0]["reason"] == REASON_LAUNCH_OVERHEAD
         assert df.iloc[0]["duration_us"] == 5.0  # 1105 - 1100
-
-
-class TestExplicitSync:
-    def test_sync_blocks_launch_thread(self):
-        """Sync API on the same thread as the launch → explicit_sync."""
-        # Sync blocks the launch thread for 500us after kernel_A ends.
-        events = _two_kernel_trace(
-            1, k1_ts=1000, k1_dur=100,
-            corr2=2, launch2_ts=1560, launch2_dur=5, k2_ts=1600, k2_dur=100,
-            extra_events=[
-                _ev("cuda_runtime", "hipEventSynchronize", ts=1050, dur=500),
-            ],
-        )
-        perf = _build(events)
-        df = perf.get_df_idle_analysis()
-        assert len(df) == 1
-        assert df.iloc[0]["reason"] == REASON_EXPLICIT_SYNC
-
-    def test_sync_on_different_thread_not_blamed(self):
-        """Sync on a different thread should NOT be blamed."""
-        events = _two_kernel_trace(
-            1, k1_ts=1000, k1_dur=100,
-            corr2=2, launch2_ts=1200, launch2_dur=5, k2_ts=1300, k2_dur=100,
-            extra_events=[
-                # Sync on a DIFFERENT thread (tid=999).
-                _ev("cuda_runtime", "hipEventSynchronize", ts=1050, dur=500, tid=999),
-            ],
-        )
-        perf = _build(events)
-        df = perf.get_df_idle_analysis()
-        assert len(df) == 1
-        # Should be cpu_bottleneck, NOT explicit_sync.
-        assert df.iloc[0]["reason"] == REASON_CPU_BOTTLENECK
 
 
 class TestCrossStreamDep:


### PR DESCRIPTION
TraceLens can classify every idle gap on a GPU stream by its root cause. Rather than reporting GPU idle time as a single number, we need to break it down into categories that explain why the GPU was idle, giving engineers actionable information for optimization.

This change adds an IdleAnalyzer module that looks at every gap between consecutive GPU events (kernels, memcpy, memset) and classifies the gap by correlating it with the CPU-side call stack, CUDA/HIP runtime events, and the kernel launch timeline.

What's New:

- New IdleTimeAnalyser class that generates three CSV reports containing statistics 
- Unit tests for IdleTimeAnalyzer classification