### PR TITLE
fix(trace2tree): attach "bleeding" runtime events to a containing ancestor

### DIFF
--- a/TraceLens/Trace2Tree/trace_to_tree.py
+++ b/TraceLens/Trace2Tree/trace_to_tree.py
@@ -139,10 +139,17 @@ class BaseTraceToTree(ABC):
             stack = dict_pidtid2stack[stack_key]
             nn_module_stack = dict_pidtid2nn_module_stack[stack_key]
 
-            while (
-                stack
-                and event[TraceLens.util.TraceEventUtils.TraceKeys.TimeStamp]
+            # Pop the stack top while it either (a) has already ended before this
+            # event starts, or (b) would end before this event ends and therefore
+            # cannot fully contain it. Case (b) handles "event bleed" where a
+            # runtime event (e.g. hipLaunchKernel) is timestamped slightly inside
+            # a sibling CPU op but extends past it; without popping past that
+            # sibling, the event would otherwise be dropped from the tree.
+            while stack and (
+                event[TraceLens.util.TraceEventUtils.TraceKeys.TimeStamp]
                 >= stack[-1][TraceLens.util.TraceEventUtils.TraceKeys.TimeEnd]
+                or event[TraceLens.util.TraceEventUtils.TraceKeys.TimeEnd]
+                > stack[-1][TraceLens.util.TraceEventUtils.TraceKeys.TimeEnd]
             ):
                 popped_event = stack.pop()
                 if self.event_to_category(popped_event) == "cpu_op":
@@ -150,15 +157,6 @@ class BaseTraceToTree(ABC):
                 # Pop from nn_module_stack if this was an nn.Module event
                 if self._is_nn_module_event(popped_event):
                     nn_module_stack.pop()
-
-            if (
-                stack
-                and event[TraceLens.util.TraceEventUtils.TraceKeys.TimeEnd]
-                > stack[-1][TraceLens.util.TraceEventUtils.TraceKeys.TimeEnd]
-            ):
-                # TODO add following to logging when logging level is debug
-                # print(f"Invalid event ordering: {event[TraceLens.util.TraceEventUtils.TraceKeys.Name]} ends after the stack top event.")
-                continue
 
             # Set nn_module_stack for the current event (copy to avoid reference issues)
             if nn_module_stack:


### PR DESCRIPTION
## Summary

`build_host_call_stack_tree` silently dropped any host event whose end timestamp extended past the current stack top, leaving the event with `parent = None` and omitting it from the tree. In real profiles this happens when a CUDA runtime
event (e.g. `hipLaunchKernel`) is timestamped slightly inside a sibling CPU op but ends after it. 

This fix pops the violating stack top so the event attaches to the nearest ancestor that actually contains it (Perfetto already renders the tree this way).

## Example

One `hipLaunchKernel` (E) starts 0.15 µs before `aten::empty_strided` (D) ends, but runs 7.78 µs — ending ~5 µs past D. The enclosing `aten::native_layer_norm_backward` (C) comfortably contains E.


```
time (µs)  →    0       10      20      30      40      50      60      70      80      90     100
                |───────|───────|───────|───────|───────|───────|───────|───────|───────|───────|
depth 0  (A)   ┌────────────────────────────────────────────────────────────────────────────────┐
               │  autograd::evaluate_function (A)                                               │
               │                  dur = 100                                                     │
               └────────────────────────────────────────────────────────────────────────────────┘
depth 1  (B)        ┌────────────────────────────────────────────────────────────────┐
                    │  NativeLayerNormBackward0 (B)                 dur = 80                    │
                    └────────────────────────────────────────────────────────────────┘
depth 2  (C)                ┌────────────────────────────────────────────────┐
                            │  aten::native_layer_norm_backward(C)         dur = 60      │
                            └────────────────────────────────────────────────┘
depth 3  (D)                                                ┌───┐
                                                            │ D │  aten::empty_strided
                                                            └───┘    dur = 5
depth 3  (E)                                                   ┌────────┐          ← BLEEDS past D
                                                               │   E    │  hipLaunchKernel
                                                               └────────┘    dur = 10
                                                                  ▲
                                                                  │  ac2g flow
                                                                  ▼
GPU stream                                                     ┌──────┐              (much later)
                                                               │  K   │  gpu_kernel
                                                               └──────┘
(intervals: A=[0,100]   B=[5,85]   C=[15,75]   D=[50,55]   E=[54,64])
```

### Before

When processing E, the working stack is `[A, B, C, D]`.

- Old pop condition only pops if `E.ts >= top.end` → does not pop D (`E.ts 53.8 < D.end 53.9`).
- A secondary check then sees `E.end 61.6 > D.end 53.9` and executes `continue`, so E is never given a parent and never pushed onto the stack.

Result: `E.parent = None`. Kernel K's parent chain is `K → E → None`, so it is treated as an orphan — no `cpu_op` ancestor, rendered as a `Synthetic Op` in `unified_perf_summary`.

### After

The pop loop is widened to also pop any stack frame that cannot fully contain the incoming event (`event.end > top.end`). On E:

1. Pop D (E.end > D.end).
2. New top is C; C fully contains E → stop, set `E.parent = C`, push E.

Result: `E.parent = C`, and K's parent chain is now `K → E → C (aten::native_layer_norm_backward) → B → A`. The kernel no longer produces a `Synthetic Op` row.

Made with [Cursor](https://cursor.com)