### PR TITLE
Added new perf models

### DIFF
--- a/TraceLens/PerfModel/extensions/__init__.py
+++ b/TraceLens/PerfModel/extensions/__init__.py
@@ -21,6 +21,7 @@ from .moe_perf_model_extensions import (
 from .attention_perf_model_extensions import (
     InferenceAttention,
     mha_varlen_fwd,
+    aiter_fmha_v3_varlen_fwd,
     vllm_unified_attention_with_output,
     gdn_attention_core,
 )
@@ -32,10 +33,13 @@ from .perf_model_extensions import (
 )
 from .rmsnorm_perf_model_extensions import (
     aiter_rms_norm,
+    aiter_rmsnorm,
     aiter_rmsnorm2d_fwd_with_add_ck,
+    aiter_add_rmsnorm,
     aiter_rmsnorm2d_fwd_with_dynamicquant_ck,
     vllm_rocm_aiter_rmsnorm_fp8_group_quant,
     vllm_rocm_aiter_rmsnorm_with_add_fp8_group_quant,
+    vllm_rocm_aiter_triton_add_rmsnorm_pad,
 )
 from .custom_collectives_perf_model_extensions import (
     aiter_fused_allreduce_rmsnorm,
@@ -58,6 +62,7 @@ __all__ = [
     "moe_gptq_awq_up",
     "moe_gptq_awq_down",
     "mha_varlen_fwd",
+    "aiter_fmha_v3_varlen_fwd",
     "vllm_unified_attention_with_output",
     "gdn_attention_core",
     "gemm_a8w8_blockscale",
@@ -65,15 +70,22 @@ __all__ = [
     "aiter_gelu_tanh_and_mul",
     # RMSNorm classes
     "aiter_rms_norm",
+    "aiter_rmsnorm",
     "aiter_rmsnorm2d_fwd_with_add_ck",
+    "aiter_add_rmsnorm",
     "aiter_rmsnorm2d_fwd_with_dynamicquant_ck",
     "vllm_rocm_aiter_rmsnorm_fp8_group_quant",
     "vllm_rocm_aiter_rmsnorm_with_add_fp8_group_quant",
+    "vllm_rocm_aiter_triton_add_rmsnorm_pad",
     # Collective classes
     "aiter_fused_allreduce_rmsnorm",
     "custom_ar_all_reduce",
     "aiter_reduce_scatter",
     "aiter_all_gather_reg",
+    "sgl_kernel_all_reduce_reg",
+    "sgl_kernel_qr_all_reduce",
+    "sgl_kernel_reg_all_gather_into_tensor",
+    "custom_ar_qr_all_reduce",
     # Utility functions
     "get_pseudo_op_mappings",
     "get_pseudo_op_categories",

--- a/TraceLens/PerfModel/extensions/attention_perf_model_extensions.py
+++ b/TraceLens/PerfModel/extensions/attention_perf_model_extensions.py
@@ -22,6 +22,12 @@ class InferenceAttention:
     Subclasses only need to implement ``get_param_details`` to extract
     parameters from their framework-specific event format. The returned
     dict must contain at least the keys listed in ``REQUIRED_PARAM_KEYS``.
+
+    **No perf estimate:** If parsing fails, :meth:`get_param_details` returns
+    :meth:`no_perf_param_details` (includes ``_no_perf: True``). In that case
+    :meth:`flops`, :meth:`bytes`, and :meth:`get_compute_precision` return
+    ``None``. Subclasses that extend the parent dict should return early when
+    ``params.get("_no_perf")`` is true.
     """
 
     REQUIRED_PARAM_KEYS = (
@@ -56,68 +62,97 @@ class InferenceAttention:
         self.d_h_v = self.param_details["d_h_v"]
 
     @staticmethod
-    def get_param_details(event):
-        annotation = str(event.get("annotation"))
-        if annotation == "NA":
-            raise NotImplementedError(
-                "VLLM attention without annotation is not supported"
-            )
-
-        if "sq" not in annotation:
-            requests = annotation.replace("(", "_").replace(")", "_").split("_")
-            if len(requests) < 8:
-                raise NotImplementedError(
-                    "VLLM attention without annotation is not supported"
-                )
-            c_sq = int(requests[3])
-            c_sk = int(requests[3])
-            c_sqsq = int(requests[4])
-            c_sqsk = int(requests[4])
-            g_sq, g_sk, g_sqsq, g_sqsk = 0, 0, 0, 0
-        else:
-            name = annotation.replace("(", "_").replace(")", "_")
-            requests = re.sub(r"[sqk]+", "_", name).split("_")
-            if len(requests) < 16:
-                raise NotImplementedError(
-                    "VLLM attention without annotation is not supported"
-                )
-            c_sq = int(requests[5])
-            c_sk = int(requests[6])
-            c_sqsq = int(requests[7])
-            c_sqsk = int(requests[8])
-            g_sq = int(requests[13])
-            g_sk = int(requests[14])
-            g_sqsq = int(requests[15])
-            g_sqsk = int(requests[16])
-
-        input_dims = event["args"]["Input Dims"]
-        q_shape, k_shape = input_dims[0], input_dims[1]
-        N_Q, H_Q, d_h_qk = q_shape
-        N_KV, H_KV, d_h_v = k_shape[-3:]
-        dtype_Q = event["args"]["Input type"][0]
+    def no_perf_param_details():
+        """Placeholder params when annotation/inputs cannot be parsed; disables FLOPs/bytes."""
         return {
             "B": 1,
-            "N_Q": N_Q,
-            "H_Q": H_Q,
-            "H_V": H_KV,
-            "H_K": H_KV,
-            "N_KV": N_KV,
-            "H_KV": H_KV,
-            "d_h_qk": d_h_qk,
-            "d_h_v": d_h_v,
+            "N_Q": 0,
+            "H_Q": 0,
+            "N_KV": 0,
+            "H_KV": 0,
+            "d_h_qk": 0,
+            "d_h_v": 0,
+            "c_sq": 0,
+            "c_sk": 0,
+            "c_sqsq": 0,
+            "c_sqsk": 0,
+            "g_sq": 0,
+            "g_sk": 0,
+            "g_sqsq": 0,
+            "g_sqsk": 0,
             "dropout": 0.0,
             "causal": False,
             "flash_impl": True,
-            "c_sq": c_sq,
-            "c_sk": c_sk,
-            "c_sqsq": c_sqsq,
-            "c_sqsk": c_sqsk,
-            "g_sq": g_sq,
-            "g_sk": g_sk,
-            "g_sqsq": g_sqsq,
-            "g_sqsk": g_sqsk,
-            "dtype_Q": dtype_Q,
+            "dtype_Q": None,
+            "_no_perf": True,
         }
+
+    @staticmethod
+    def get_param_details(event):
+        try:
+            annotation = str(event.get("annotation"))
+            if annotation == "NA":
+                raise NotImplementedError(
+                    "VLLM attention without annotation is not supported"
+                )
+
+            if "sq" not in annotation:
+                requests = annotation.replace("(", "_").replace(")", "_").split("_")
+                if len(requests) < 8:
+                    raise NotImplementedError(
+                        "VLLM attention without annotation is not supported"
+                    )
+                c_sq = int(requests[3])
+                c_sk = int(requests[3])
+                c_sqsq = int(requests[4])
+                c_sqsk = int(requests[4])
+                g_sq, g_sk, g_sqsq, g_sqsk = 0, 0, 0, 0
+            else:
+                name = annotation.replace("(", "_").replace(")", "_")
+                requests = re.sub(r"[sqk]+", "_", name).split("_")
+                if len(requests) < 16:
+                    raise NotImplementedError(
+                        "VLLM attention without annotation is not supported"
+                    )
+                c_sq = int(requests[5])
+                c_sk = int(requests[6])
+                c_sqsq = int(requests[7])
+                c_sqsk = int(requests[8])
+                g_sq = int(requests[13])
+                g_sk = int(requests[14])
+                g_sqsq = int(requests[15])
+                g_sqsk = int(requests[16])
+
+            input_dims = event["args"]["Input Dims"]
+            q_shape, k_shape = input_dims[0], input_dims[1]
+            N_Q, H_Q, d_h_qk = q_shape
+            N_KV, H_KV, d_h_v = k_shape[-3:]
+            dtype_Q = event["args"]["Input type"][0]
+            return {
+                "B": 1,
+                "N_Q": N_Q,
+                "H_Q": H_Q,
+                "H_V": H_KV,
+                "H_K": H_KV,
+                "N_KV": N_KV,
+                "H_KV": H_KV,
+                "d_h_qk": d_h_qk,
+                "d_h_v": d_h_v,
+                "dropout": 0.0,
+                "causal": False,
+                "flash_impl": True,
+                "c_sq": c_sq,
+                "c_sk": c_sk,
+                "c_sqsq": c_sqsq,
+                "c_sqsk": c_sqsk,
+                "g_sq": g_sq,
+                "g_sk": g_sk,
+                "g_sqsq": g_sqsq,
+                "g_sqsk": g_sqsk,
+                "dtype_Q": dtype_Q,
+            }
+        except (NotImplementedError, ValueError, IndexError, KeyError, TypeError):
+            return InferenceAttention.no_perf_param_details()
 
     # ------------------------------------------------------------------
     # Static helpers – reusable across subclasses
@@ -181,6 +216,8 @@ class InferenceAttention:
     # ------------------------------------------------------------------
 
     def flops(self):
+        if self.param_details.get("_no_perf"):
+            return None
         if self.param_details["c_sq"] == 0 and self.param_details["g_sq"] == 0:
             raise NotImplementedError(
                 "Attention perf model for decode phase requires custom annotations"
@@ -194,7 +231,12 @@ class InferenceAttention:
             self.param_details["g_sqsk"],
         )
 
-    def bytes(self, bytes_per_element=2):
+    def bytes(self, bytes_per_element=None):
+        if self.param_details.get("_no_perf"):
+            return None
+        bpe = bytes_per_element
+        if bpe is None:
+            bpe = name2bpe(self.param_details.get("dtype_Q")) or 2
         return self.bytes_func(
             self.B,
             self.H_Q,
@@ -205,7 +247,7 @@ class InferenceAttention:
             self.param_details["c_sk"],
             self.param_details["g_sq"],
             self.param_details["g_sk"],
-            bytes_per_element,
+            bpe,
         )
 
     def flops_bwd(self):
@@ -215,6 +257,8 @@ class InferenceAttention:
         raise NotImplementedError("Backward pass for attention is not defined.")
 
     def get_compute_precision(self):
+        if self.param_details.get("_no_perf"):
+            return None
         dtype = self.param_details.get("dtype_Q", None)
         return torch_dtype_map(dtype) if dtype else None
 
@@ -232,6 +276,30 @@ class mha_varlen_fwd(InferenceAttention):
     pass
 
 
+class aiter_fmha_v3_varlen_fwd(InferenceAttention):
+    """
+    Performance model for ``aiter::fmha_v3_varlen_fwd`` (inference: sglang / vLLM).
+
+    Uses the same chunk statistics as :class:`InferenceAttention` (``annotation``
+    on the event). Sets ``d_h_v`` from the **v** tensor (``Input Dims[2]``) so MLA
+    shapes with differing Q/K vs V head dims are modeled correctly.
+
+    Unparseable annotation yields :meth:`InferenceAttention.no_perf_param_details`
+    (see base class); no packed-tensor fallback.
+    """
+
+    @staticmethod
+    def get_param_details(event):
+        params = InferenceAttention.get_param_details(event)
+        if params.get("_no_perf"):
+            return params
+        args = event.get("args") or {}
+        dims = args.get("Input Dims") or []
+        if len(dims) > 2 and len(dims[2]) >= 1:
+            params["d_h_v"] = dims[2][-1]
+        return params
+
+
 class mla_decode_fwd(InferenceAttention):
     pass
 
@@ -241,6 +309,8 @@ class mla_tilelang_sparse_fwd(InferenceAttention):
     @staticmethod
     def get_param_details(event):
         params = InferenceAttention.get_param_details(event)
+        if params.get("_no_perf"):
+            return params
         concrete = event.get("Concrete Inputs", [])
         if len(concrete) < 5:
             params["d_h_v"] = 512

--- a/TraceLens/PerfModel/extensions/custom_collectives_perf_model_extensions.py
+++ b/TraceLens/PerfModel/extensions/custom_collectives_perf_model_extensions.py
@@ -124,6 +124,112 @@ class custom_ar_all_reduce(CustomCollective):
         return 2 * self.num_elems * self.bpe_in
 
 
+class sgl_kernel_all_reduce_reg(custom_ar_all_reduce):
+    """
+    Performance model for sgl_kernel::all_reduce_reg.
+
+    Reference implementation:
+        python/sglang/srt/distributed/device_communicators/custom_all_reduce_ops.py  # all_reduce_reg(fa, inp, out)
+        python/sglang/srt/distributed/device_communicators/custom_all_reduce.py      # CustomAllreduce.all_reduce_reg
+        sgl-kernel/csrc/allreduce/custom_all_reduce.cu                               # cross_device_reduce_2stage<T, world_size>
+
+    SGLang's registered-buffer custom all-reduce. Launches the
+    `sglang::cross_device_reduce_2stage<__hip_bfloat16, 8>` 2-stage ring kernel
+    (TP=8 here) on a pre-registered IPC buffer. Pure inter-GPU communication;
+    no on-chip compute FLOPs.
+
+    Signature: all_reduce_reg(fa, inp, out) -> None
+        fa   - int handle (Scalar in trace)
+        inp  - shape [M, N], dtype BFloat16
+        out  - shape [M, N], dtype BFloat16 (allreduced result)
+
+    Expected Input Dims from trace:
+        [(), (M, N), (M, N)]
+        e.g. [(), (32, 7168), (32, 7168)]   # DSR1 hidden=7168, batch=32
+
+    Expected Input type from trace:
+        ['Scalar', 'c10::BFloat16', 'c10::BFloat16']
+
+    flops/bytes inherited from custom_ar_all_reduce (FLOPs=0; HBM bytes per GPU
+    = 2 * num_elems * bpe_in for the local read+write; inter-GPU bandwidth is
+    a separate concern from the on-chip roofline).
+    """
+
+
+class sgl_kernel_qr_all_reduce(custom_ar_all_reduce):
+    """
+    Performance model for sgl_kernel::qr_all_reduce.
+
+    Reference implementation:
+        python/sglang/srt/distributed/device_communicators/custom_all_reduce_ops.py  # qr_all_reduce(fa, inp, out, quant_level, cast_bf2half)
+        python/sglang/srt/distributed/device_communicators/quick_all_reduce.py        # QuickAllReduce.quick_all_reduce
+        sgl-kernel/csrc/allreduce/quick_all_reduce.cu                                # quickreduce::allreduce_prototype_*
+
+    SGLang's QuickReduce all-reduce variant (typically used for larger payloads
+    on the ROCm path). Launches `quickreduce::allreduce_prototype_twoshot<...>`
+    or related kernels. Same per-GPU HBM accounting as the registered
+    all-reduce: read local input, write allreduced output.
+
+    Signature: qr_all_reduce(fa, inp, out, quant_level, cast_bf2half) -> None
+        fa             - int handle (Scalar)
+        inp            - shape [M, N], dtype BFloat16
+        out            - shape [M, N], dtype BFloat16 (allreduced result)
+        quant_level    - int (Scalar; 0=bf16, 3=int4-quantized, ...)
+        cast_bf2half   - bool (Scalar)
+
+    Expected Input Dims from trace:
+        [(), (M, N), (M, N), (), ()]
+        e.g. [(), (1866, 7168), (1866, 7168), (), ()]   # DSR1 prefill, isl=1866
+
+    Expected Input type from trace:
+        ['Scalar', 'c10::BFloat16', 'c10::BFloat16', 'Scalar', 'Scalar']
+
+    flops/bytes inherited from custom_ar_all_reduce (uses indices [1]/[2] for
+    inp/out shape and dtype; trailing scalars are ignored). This deliberately
+    counts only the BF16 HBM traffic; intra-kernel int4 quant for higher
+    `quant_level` reduces inter-GPU bytes but not the HBM read/write step
+    modeled here.
+    """
+
+
+class custom_ar_qr_all_reduce(custom_ar_all_reduce):
+    """
+    Performance model for _C_custom_ar::qr_all_reduce.
+
+    Reference implementation:
+        vllm/_custom_ops.py                                       # qr_all_reduce(fa, inp, out, quant_level, cast_bf2half)
+        vllm/distributed/device_communicators/quick_all_reduce.py # QuickAllReduce.quick_all_reduce
+        csrc/custom_all_reduce/quick_all_reduce.cu                # quickreduce::allreduce_prototype_*
+
+    vLLM's QuickReduce all-reduce variant on the ROCm path. Launches
+    `quickreduce::allreduce_prototype_twoshot<...>` (CodecQ4 / CodecBF16 / etc.
+    depending on `quant_level`). Same per-GPU HBM accounting as a plain
+    custom all-reduce: read local input, write the allreduced output.
+
+    Signature: qr_all_reduce(fa, inp, out, quant_level, cast_bf2half) -> None
+        fa             - int handle (Scalar)
+        inp            - shape [M, N], dtype BFloat16
+        out            - shape [M, N], dtype BFloat16 (allreduced result)
+        quant_level    - int (Scalar; 0=bf16, 3=int4-quantized, ...)
+        cast_bf2half   - bool (Scalar)
+
+    Expected Input Dims from trace:
+        [(), (M, N), (M, N), (), ()]
+        e.g. [(), (1689, 7168), (1689, 7168), (), ()]   # DSR1 prefill
+
+    Expected Input type from trace:
+        ['Scalar', 'c10::BFloat16', 'c10::BFloat16', 'Scalar', 'Scalar']
+
+    Concrete Inputs[3] = `quant_level` (e.g. '3' for int4 codec).
+    Concrete Inputs[4] = `cast_bf2half` ('True'/'False').
+
+    flops/bytes inherited from custom_ar_all_reduce (uses Input Dims[1] for
+    `op_shape` and Input type[1] for dtype; trailing scalar args are ignored).
+    The HBM read+write is BF16 regardless of the inter-GPU codec; modeled as
+    `2 * num_elems * bpe_in` bytes per GPU.
+    """
+
+
 class aiter_reduce_scatter(CustomCollective):
     """
     Performance model for aiter::reduce_scatter.
@@ -217,3 +323,66 @@ class aiter_all_gather_reg(CustomCollective):
         # read inp shard + write full gathered out
         num_elems_out = prod(self.param_details["out_shape"])
         return (self.num_elems + num_elems_out) * self.bpe_in
+
+
+class sgl_kernel_reg_all_gather_into_tensor(CustomCollective):
+    """
+    Performance model for sglang::reg_all_gather_into_tensor.
+
+    Reference implementation:
+        python/sglang/srt/distributed/device_communicators/custom_all_reduce.py     # CustomAllreduce.all_gather (registered buffer path)
+        sgl-kernel/csrc/allreduce/custom_all_reduce.cu                              # all_gather_reg kernel
+
+    SGLang's registered-buffer all-gather: each rank contributes a shard
+    `[M / W, N]`, the output is the gathered `[M, N]` tensor. Pure inter-GPU
+    communication; no FLOPs.
+
+    Signature: reg_all_gather_into_tensor(out, inp, fa) -> None
+        out - shape [M, N],          dtype BFloat16 (gathered)
+        inp - shape [M / W, N],      dtype BFloat16 (this rank's shard)
+        fa  - int handle (Scalar)
+
+    Expected Input Dims from trace:
+        [out_shape, inp_shape, ()]
+        e.g. [(256, 16160), (32, 16160), ()]   # W=8, M=32 -> gathered M=256
+
+    Expected Input type from trace:
+        ['c10::BFloat16', 'c10::BFloat16', 'Scalar']
+
+    Roofline -- FLOPs:
+        0 (pure communication).
+
+    Roofline -- bytes moved:
+        bytes_read_inp  = num_elems_inp_shard * bpe_in
+        bytes_write_out = num_elems_out_full  * bpe_in
+        Total           = bytes_read_inp + bytes_write_out
+
+    Notes:
+        get_param_details reads Input Dims[0] for `out_shape` and Input Dims[1]
+        for the per-rank `op_shape` (shard). dtype is taken from Input type[0].
+    """
+
+    def __init__(self, event, arch=None, python_path=None):
+        self.event = event
+        self.arch = arch
+        self.param_details = self.get_param_details(event)
+        self.num_elems = prod(self.param_details["op_shape"])
+        self.num_elems_out = prod(self.param_details["out_shape"])
+        self.bpe_in = name2bpe(self.param_details["dtype_in"])
+
+    @staticmethod
+    def get_param_details(event):
+        out_shape = tuple(event["args"]["Input Dims"][0])
+        op_shape = tuple(event["args"]["Input Dims"][1])
+        dtype_in = event["args"]["Input type"][0]
+        return {
+            "out_shape": out_shape,
+            "op_shape": op_shape,
+            "dtype_in": dtype_in,
+        }
+
+    def flops(self):
+        return 0
+
+    def bytes(self):
+        return (self.num_elems + self.num_elems_out) * self.bpe_in

--- a/TraceLens/PerfModel/extensions/custom_collectives_perf_model_extensions.py
+++ b/TraceLens/PerfModel/extensions/custom_collectives_perf_model_extensions.py
@@ -130,12 +130,8 @@ class sgl_kernel_all_reduce_reg(custom_ar_all_reduce):
 
     Reference implementation:
         python/sglang/srt/distributed/device_communicators/custom_all_reduce_ops.py  # all_reduce_reg(fa, inp, out)
-        python/sglang/srt/distributed/device_communicators/custom_all_reduce.py      # CustomAllreduce.all_reduce_reg
-        sgl-kernel/csrc/allreduce/custom_all_reduce.cu                               # cross_device_reduce_2stage<T, world_size>
 
-    SGLang's registered-buffer custom all-reduce. Launches the
-    `sglang::cross_device_reduce_2stage<__hip_bfloat16, 8>` 2-stage ring kernel
-    (TP=8 here) on a pre-registered IPC buffer. Pure inter-GPU communication;
+    SGLang's registered-buffer custom all-reduce. Pure inter-GPU communication;
     no on-chip compute FLOPs.
 
     Signature: all_reduce_reg(fa, inp, out) -> None
@@ -163,10 +159,8 @@ class sgl_kernel_qr_all_reduce(custom_ar_all_reduce):
     Reference implementation:
         python/sglang/srt/distributed/device_communicators/custom_all_reduce_ops.py  # qr_all_reduce(fa, inp, out, quant_level, cast_bf2half)
         python/sglang/srt/distributed/device_communicators/quick_all_reduce.py        # QuickAllReduce.quick_all_reduce
-        sgl-kernel/csrc/allreduce/quick_all_reduce.cu                                # quickreduce::allreduce_prototype_*
 
-    SGLang's QuickReduce all-reduce variant (typically used for larger payloads
-    on the ROCm path). Launches `quickreduce::allreduce_prototype_twoshot<...>`
+    SGLang's QuickReduce all-reduce variant. Launches `quickreduce::allreduce_prototype_twoshot<...>`
     or related kernels. Same per-GPU HBM accounting as the registered
     all-reduce: read local input, write allreduced output.
 
@@ -201,9 +195,7 @@ class custom_ar_qr_all_reduce(custom_ar_all_reduce):
         vllm/distributed/device_communicators/quick_all_reduce.py # QuickAllReduce.quick_all_reduce
         csrc/custom_all_reduce/quick_all_reduce.cu                # quickreduce::allreduce_prototype_*
 
-    vLLM's QuickReduce all-reduce variant on the ROCm path. Launches
-    `quickreduce::allreduce_prototype_twoshot<...>` (CodecQ4 / CodecBF16 / etc.
-    depending on `quant_level`). Same per-GPU HBM accounting as a plain
+    vLLM's QuickReduce all-reduce variant.  Same per-GPU HBM accounting as a plain
     custom all-reduce: read local input, write the allreduced output.
 
     Signature: qr_all_reduce(fa, inp, out, quant_level, cast_bf2half) -> None

--- a/TraceLens/PerfModel/extensions/moe_perf_model_extensions.py
+++ b/TraceLens/PerfModel/extensions/moe_perf_model_extensions.py
@@ -861,6 +861,7 @@ class moe_aiter_unfused_up(UnfusedMoE_Up):
 
         input_dtype = args["Input type"][0]
         weight_dtype = args["Input type"][1]
+        output_dtype = args["Input type"][2]
         return {
             "num_tokens": num_tokens,
             "hidden_dim": hidden_dim,
@@ -870,6 +871,7 @@ class moe_aiter_unfused_up(UnfusedMoE_Up):
             "gated": gated,
             "input_dtype": input_dtype,
             "weight_dtype": weight_dtype,
+            "output_dtype": output_dtype,
         }
 
     def flops(self):
@@ -892,7 +894,9 @@ class moe_aiter_unfused_up(UnfusedMoE_Up):
         weight_bpe = DTYPE_TO_BYTES.get(
             self.param_details["weight_dtype"], 1
         )  # Default to 1 (FP8)
-        output_bpe = input_bpe  # Output typically same as input
+        output_bpe = DTYPE_TO_BYTES.get(
+            self.param_details["output_dtype"], 2
+        )  # Output typically same as input
 
         return self.bytes_func(
             self.param_details["num_tokens"],
@@ -964,6 +968,7 @@ class moe_aiter_unfused_down(UnfusedMoE_Down):
 
         input_dtype = args["Input type"][0]
         weight_dtype = args["Input type"][1]
+        out_dtype = args["Input type"][2]
 
         return {
             "num_tokens": num_tokens,
@@ -973,6 +978,7 @@ class moe_aiter_unfused_down(UnfusedMoE_Down):
             "topk": topk,
             "input_dtype": input_dtype,
             "weight_dtype": weight_dtype,
+            "output_dtype": out_dtype,
         }
 
     def flops(self):
@@ -994,7 +1000,9 @@ class moe_aiter_unfused_down(UnfusedMoE_Down):
         weight_bpe = DTYPE_TO_BYTES.get(
             self.param_details["weight_dtype"], 1
         )  # Default to 1 (FP8)
-        output_bpe = input_bpe  # Output typically same as input
+        output_bpe = DTYPE_TO_BYTES.get(
+            self.param_details["output_dtype"], 2
+        )  # Output typically same as input
 
         return self.bytes_func(
             self.param_details["num_tokens"],

--- a/TraceLens/PerfModel/extensions/perf_model_extensions.py
+++ b/TraceLens/PerfModel/extensions/perf_model_extensions.py
@@ -598,6 +598,33 @@ class aiter_silu_and_mul(UnaryElementwise):
         return 2 * self.nelems * self.bpe_in + self.nelems * self.bpe_out
 
 
+class sgl_kernel_silu_and_mul(aiter_silu_and_mul):
+    """
+    Performance model for sgl_kernel::silu_and_mul.
+
+    Gated SiLU (same math as aiter::silu_and_mul):
+        out[..., :inter_dim] = silu(input[..., :inter_dim]) * input[..., inter_dim:]
+
+    SGLang registers this op from sgl_kernel (e.g. sgl_kernel/elementwise.py silu_and_mul,
+    used by srt/layers/activation.py SiluAndMul).
+
+    Signature: silu_and_mul(out, input) -> None
+        out   — shape [M, inter_dim],     dtype BFloat16
+        input — shape [M, 2 * inter_dim], dtype BFloat16
+
+    Expected Input Dims from trace:
+        [out_shape, input_shape]
+        e.g. [(65536, 2304), (65536, 4608)]
+
+    Expected Input type from trace:
+        [dtype_out, dtype_input]
+
+    FLOPs and bytes are inherited from aiter_silu_and_mul.
+    """
+
+    pass
+
+
 class aiter_gelu_and_mul(aiter_silu_and_mul):
     """
     Performance model for aiter::gelu_and_mul.

--- a/TraceLens/PerfModel/extensions/pseudo_ops_perf_utils.py
+++ b/TraceLens/PerfModel/extensions/pseudo_ops_perf_utils.py
@@ -45,6 +45,7 @@ def get_pseudo_op_mappings():
         # Attention pseudo ops
         "vllm::unified_attention_with_output": attention_perf_model_extensions.vllm_unified_attention_with_output,
         "aiter::mha_varlen_fwd": attention_perf_model_extensions.mha_varlen_fwd,
+        "aiter::fmha_v3_varlen_fwd": attention_perf_model_extensions.aiter_fmha_v3_varlen_fwd,
         "pseudo_mla_decode_fwd": attention_perf_model_extensions.mla_decode_fwd,
         "sglang_profiler::tilelang_kernel_tilelang_sparse_fwd_586": attention_perf_model_extensions.mla_tilelang_sparse_fwd,
         ## Misc ops
@@ -70,22 +71,30 @@ def get_pseudo_op_mappings():
         ## Activation ops
         "aiter::silu_and_mul": perf_model_extensions.aiter_silu_and_mul,
         "_C::silu_and_mul": perf_model_extensions.aiter_silu_and_mul,
+        "sgl_kernel::silu_and_mul": perf_model_extensions.sgl_kernel_silu_and_mul,
         "aiter::gelu_and_mul": perf_model_extensions.aiter_gelu_and_mul,
         "aiter::gelu_tanh_and_mul": perf_model_extensions.aiter_gelu_tanh_and_mul,
         ## MoE ops
         ##"aiter::moe_sorting_fwd": perf_model_extensions.aiter_moe_sorting_fwd,
         ## RMSNorm ops
         "aiter::rms_norm": rmsnorm_perf_model_extensions.aiter_rms_norm,
+        "aiter::rmsnorm": rmsnorm_perf_model_extensions.aiter_rmsnorm,
         "aiter::rmsnorm2d_fwd_ck": rmsnorm_perf_model_extensions.aiter_rms_norm,
         "aiter::rmsnorm2d_fwd_with_add_ck": rmsnorm_perf_model_extensions.aiter_rmsnorm2d_fwd_with_add_ck,
+        "aiter::add_rmsnorm": rmsnorm_perf_model_extensions.aiter_rmsnorm2d_fwd_with_add_ck,
         "aiter::rmsnorm2d_fwd_with_dynamicquant_ck": rmsnorm_perf_model_extensions.aiter_rmsnorm2d_fwd_with_dynamicquant_ck,
         "vllm::rocm_aiter_rmsnorm_fp8_group_quant": rmsnorm_perf_model_extensions.vllm_rocm_aiter_rmsnorm_fp8_group_quant,
         "vllm::rocm_aiter_rmsnorm_with_add_fp8_group_quant": rmsnorm_perf_model_extensions.vllm_rocm_aiter_rmsnorm_with_add_fp8_group_quant,
+        "vllm::rocm_aiter_triton_add_rmsnorm_pad": rmsnorm_perf_model_extensions.vllm_rocm_aiter_triton_add_rmsnorm_pad,
         ## Collective ops
         "aiter::fused_allreduce_rmsnorm": custom_collectives_perf_model_extensions.aiter_fused_allreduce_rmsnorm,
         "_C_custom_ar::all_reduce": custom_collectives_perf_model_extensions.custom_ar_all_reduce,
         "aiter::reduce_scatter": custom_collectives_perf_model_extensions.aiter_reduce_scatter,
         "aiter::all_gather_reg": custom_collectives_perf_model_extensions.aiter_all_gather_reg,
+        "sgl_kernel::all_reduce_reg": custom_collectives_perf_model_extensions.sgl_kernel_all_reduce_reg,
+        "sgl_kernel::qr_all_reduce": custom_collectives_perf_model_extensions.sgl_kernel_qr_all_reduce,
+        "sglang::reg_all_gather_into_tensor": custom_collectives_perf_model_extensions.sgl_kernel_reg_all_gather_into_tensor,
+        "_C_custom_ar::qr_all_reduce": custom_collectives_perf_model_extensions.custom_ar_qr_all_reduce,
         ## GDN attention ops
         "vllm::gdn_attention_core": attention_perf_model_extensions.gdn_attention_core,
     }
@@ -114,6 +123,7 @@ def get_pseudo_op_categories():
         perf_model_extensions.batched_gemm_a8w8: "GEMM",
         rmsnorm_perf_model_extensions.RMSNorm: "RMSNorm",
         custom_collectives_perf_model_extensions.CustomCollective: "CustomCollective",
+        custom_collectives_perf_model_extensions.custom_ar_all_reduce: "CustomCollective",
         perf_model_extensions.aiter_silu_and_mul: "UnaryElementwise",
     }
 

--- a/TraceLens/PerfModel/extensions/rmsnorm_perf_model_extensions.py
+++ b/TraceLens/PerfModel/extensions/rmsnorm_perf_model_extensions.py
@@ -52,6 +52,52 @@ class aiter_rms_norm(RMSNorm):
         }
 
 
+class aiter_rmsnorm(RMSNorm):
+    """
+    Performance model for aiter::rmsnorm.
+
+    Same roofline as aiter_rms_norm and RMSNorm, but a different bound op and profiler layout:
+    explicit out tensor first (see aiter_rms_norm for aiter::rms_norm).
+
+    RMSNorm with separate output tensor (HIP rmsnorm; AITER rmsnorm2d_fwd uses this when
+    hidden_dim <= 8192 and use_model_sensitive_rmsnorm == 0).
+
+    Signature: rmsnorm(out, input, weight, epsilon)
+        out      — shape [M, N], dtype BFloat16
+        input    — shape [M, N], dtype BFloat16
+        weight   — shape [N],    dtype BFloat16 (affine scale)
+        epsilon  — float scalar
+
+    Expected Input Dims from trace:
+        [out_shape, input_shape, weight_shape, eps_scalar]
+        e.g. [(4, 7168), (4, 7168), (7168,), ()]
+
+    Expected Input type from trace:
+        [dtype_out, dtype_input, dtype_weight, 'Scalar']
+
+    flops/bytes are inherited from RMSNorm (affine=True, training=False).
+
+    get_param_details uses input at index [1] and weight length at [2][0].
+    """
+
+    @staticmethod
+    def get_param_details(event):
+        op_shape = tuple(event["args"]["Input Dims"][1])  # input: [M, N]
+        dtype_in = event["args"]["Input type"][1]
+        stride_input = tuple(event["args"]["Input Strides"][1])
+        num_channels = event["args"]["Input Dims"][2][0]  # weight.shape[0] = N
+        return {
+            "op_shape": op_shape,
+            "dtype_in_out": (dtype_in, None),
+            "stride_input": stride_input,
+            "stride_output": None,
+            "num_channels": num_channels,
+            "has_bias": False,
+            "is_affine": True,
+            "is_training": False,
+        }
+
+
 class aiter_rmsnorm2d_fwd_with_dynamicquant_ck(RMSNorm):
     """
     Performance model for aiter::rmsnorm2d_fwd_with_dynamicquant_ck.
@@ -213,6 +259,35 @@ class aiter_rmsnorm2d_fwd_with_add_ck(RMSNorm):
         return bytes_read + bytes_write
 
 
+class aiter_add_rmsnorm(aiter_rmsnorm2d_fwd_with_add_ck):
+    """
+    Performance model for aiter::add_rmsnorm.
+
+    Fused residual-add + RMSNorm (HIP add_rmsnorm). AITER rmsnorm2d_fwd_with_add uses this
+    when hidden_dim <= 8192 and use_model_sensitive_rmsnorm == 0; otherwise it uses CK
+    rmsnorm2d_fwd_with_add_ck (see aiter_rmsnorm2d_fwd_with_add_ck).
+
+    Signature: add_rmsnorm(out, input, residual_in, residual_out, weight, epsilon)
+        out           — shape [M, N], dtype BFloat16 (RMSNorm output)
+        input         — shape [M, N], dtype BFloat16
+        residual_in   — shape [M, N], dtype BFloat16
+        residual_out  — shape [M, N], dtype BFloat16 (input + residual_in)
+        weight        — shape [N],    dtype BFloat16 (affine scale)
+        epsilon       — float scalar
+
+    Expected Input Dims from trace:
+        [out_shape, input_shape, residual_in_shape, residual_out_shape, weight_shape, eps_scalar]
+        e.g. [(4, 7168), (4, 7168), (4, 7168), (4, 7168), (7168,), ()]
+
+    FLOPs: residual-add (num_elems) + RMSNorm (inherited from RMSNorm.flops()).
+    Bytes: HBM traffic per GPU (read input+residual_in+weight, write out+residual_out).
+
+    get_param_details, flops, and bytes are inherited from aiter_rmsnorm2d_fwd_with_add_ck.
+    """
+
+    pass
+
+
 class vllm_rocm_aiter_rmsnorm_with_add_fp8_group_quant(RMSNorm):
     """
     Performance model for vllm::rocm_aiter_rmsnorm_with_add_fp8_group_quant.
@@ -280,3 +355,82 @@ class vllm_rocm_aiter_rmsnorm_with_add_fp8_group_quant(RMSNorm):
             + bytes_write_res
             + bytes_write_scales
         )
+
+
+class vllm_rocm_aiter_triton_add_rmsnorm_pad(RMSNorm):
+    """
+    Performance model for vllm::rocm_aiter_triton_add_rmsnorm_pad.
+
+    Fused residual-add + RMSNorm + zero-pad on hidden dim. The compiler fusion
+    pass replaces separate add + RMSNorm + pad nodes with this single Triton kernel.
+    Padding aligns hidden_dim to a multiple of x_pad_to_multiple for downstream
+    AITER MoE GEMMs.
+
+    Signature: rocm_aiter_triton_add_rmsnorm_pad(x, weight, variance_epsilon,
+               residual, x_pad_to_multiple) -> (out, residual_out)
+        x                  — shape [M, N],     dtype BFloat16
+        weight             — shape [N],        dtype BFloat16  (affine RMSNorm scale)
+        variance_epsilon   — float scalar      (e.g. 1e-5)
+        residual           — shape [M, N],     dtype BFloat16
+        x_pad_to_multiple  — int scalar        (e.g. 256)
+        out                — shape [M, N_out], dtype BFloat16  (N_out = ceil(N / pad) * pad)
+        residual_out       — shape [M, N],     dtype BFloat16  (x + residual, pre-norm)
+
+    Expected Input Dims from trace:
+        [x_shape, weight_shape, eps_scalar, residual_shape, pad_scalar]
+        e.g. [(64, 2880), (2880,), (), (64, 2880), ()]
+
+    Expected Input type from trace:
+        ['c10::BFloat16', 'c10::BFloat16', 'Scalar', 'c10::BFloat16', 'Scalar']
+
+    Concrete Inputs[2] = variance_epsilon (e.g. '1e-05')
+    Concrete Inputs[4] = x_pad_to_multiple (e.g. '256')
+
+    Roofline -- FLOPs:
+        residual_add + rmsnorm (inherited from RMSNorm.flops() + num_elems for add).
+
+    Roofline -- bytes moved:
+        Read x + residual + weight; write padded output + updated residual.
+    """
+
+    def __init__(self, event, arch=None, python_path=None):
+        self.x_pad_to_multiple = int(event["args"]["Concrete Inputs"][4])
+        super().__init__(event, arch, python_path)
+
+        N = self.num_channels
+        if self.x_pad_to_multiple > 0:
+            self.n_out = (
+                (N + self.x_pad_to_multiple - 1)
+                // self.x_pad_to_multiple
+                * self.x_pad_to_multiple
+            )
+        else:
+            self.n_out = N
+
+    @staticmethod
+    def get_param_details(event):
+        op_shape = tuple(event["args"]["Input Dims"][0])
+        dtype_in = event["args"]["Input type"][0]
+        stride_input = tuple(event["args"]["Input Strides"][0])
+        num_channels = event["args"]["Input Dims"][1][0]
+        return {
+            "op_shape": op_shape,
+            "dtype_in_out": (dtype_in, None),
+            "stride_input": stride_input,
+            "stride_output": None,
+            "num_channels": num_channels,
+            "has_bias": False,
+            "is_affine": True,
+            "is_training": False,
+        }
+
+    def flops(self):
+        return self.num_elems + super().flops()
+
+    def bytes(self):
+        M = self.num_elems // self.num_channels
+        N = self.num_channels
+        bytes_read = 2 * self.num_elems * self.bpe_in + N * self.bpe_in
+        bytes_write_out = M * self.n_out * self.bpe_in
+        bytes_write_res = M * N * self.bpe_in
+        return bytes_read + bytes_write_out + bytes_write_res

--- a/TraceLens/PerfModel/extensions/rmsnorm_perf_model_extensions.py
+++ b/TraceLens/PerfModel/extensions/rmsnorm_perf_model_extensions.py
@@ -59,8 +59,7 @@ class aiter_rmsnorm(RMSNorm):
     Same roofline as aiter_rms_norm and RMSNorm, but a different bound op and profiler layout:
     explicit out tensor first (see aiter_rms_norm for aiter::rms_norm).
 
-    RMSNorm with separate output tensor (HIP rmsnorm; AITER rmsnorm2d_fwd uses this when
-    hidden_dim <= 8192 and use_model_sensitive_rmsnorm == 0).
+    RMSNorm with separate output tensor.
 
     Signature: rmsnorm(out, input, weight, epsilon)
         out      — shape [M, N], dtype BFloat16
@@ -263,9 +262,7 @@ class aiter_add_rmsnorm(aiter_rmsnorm2d_fwd_with_add_ck):
     """
     Performance model for aiter::add_rmsnorm.
 
-    Fused residual-add + RMSNorm (HIP add_rmsnorm). AITER rmsnorm2d_fwd_with_add uses this
-    when hidden_dim <= 8192 and use_model_sensitive_rmsnorm == 0; otherwise it uses CK
-    rmsnorm2d_fwd_with_add_ck (see aiter_rmsnorm2d_fwd_with_add_ck).
+    Fused residual-add + RMSNorm (HIP add_rmsnorm).
 
     Signature: add_rmsnorm(out, input, residual_in, residual_out, weight, epsilon)
         out           — shape [M, N], dtype BFloat16 (RMSNorm output)

--- a/TraceLens/Reporting/generate_perf_report_pytorch_inference.py
+++ b/TraceLens/Reporting/generate_perf_report_pytorch_inference.py
@@ -576,7 +576,7 @@ def generate_perf_report_pytorch(
             "aiter::mha_varlen_fwd",
             "pseudo_mla_decode_fwd",
             "vllm::gdn_attention_core",
-            "aiter::fmha_fav3_varlen_fwd",
+            "aiter::fmha_v3_varlen_fwd",
             "sglang_profiler::tilelang_kernel_tilelang_sparse_fwd",
         ]
     )


### PR DESCRIPTION
This pull request expands the performance modeling capabilities of the `TraceLens/PerfModel/extensions` module. The main changes include improved error handling and fallback logic for attention models, the addition of new performance model classes for various SGLang and vLLM operations (especially collective communication and attention ops), and enhancements to MoE (Mixture of Experts) modeling to handle output dtype correctly. These updates improve both robustness and coverage for modern inference and distributed training workloads.

**Performance model improvements and new classes:**

* Added new performance model classes for SGLang and vLLM collective ops: `sgl_kernel_all_reduce_reg`, `sgl_kernel_qr_all_reduce`, `custom_ar_qr_all_reduce`, and `sgl_kernel_reg_all_gather_into_tensor`, as well as the elementwise op `sgl_kernel_silu_and_mul`. These models cover registered-buffer all-reduce, quick all-reduce, and all-gather operations, capturing their FLOPs and HBM traffic. [[1]](diffhunk://#diff-bec4fe3fd36d6029cc9269812e58de6601dfe32785b31eb676e677acf83398c9R127-R232) [[2]](diffhunk://#diff-bec4fe3fd36d6029cc9269812e58de6601dfe32785b31eb676e677acf83398c9R326-R388) [[3]](diffhunk://#diff-72be722051ad4c0218d52e1b465917a833aae6d12690879134155cddb58ab6f0R601-R627)
* Added `aiter_fmha_v3_varlen_fwd` attention performance model for SGLang/vLLM, with logic to correctly handle differing Q/K and V head dimensions. [[1]](diffhunk://#diff-11bbfa67e2e4b8f4659996548738b078a104b114c0644e4d3935ffd46b61a345R279-R302) [[2]](diffhunk://#diff-e03d1c0a173269db65bf1bfc351afb58495b3f719c6eac8d35a0664ac43d7e9eR24) [[3]](diffhunk://#diff-9b10af80cc8b96cbbddd8ac221c1f69ee7c428aef4c3b9675d4be086fc6ee2cfR48)

**Robustness and error handling:**

* Improved error handling in `InferenceAttention` and its subclasses: if annotation parsing fails, a special "no perf" param dict is returned, causing FLOPs, bytes, and compute precision methods to return `None` instead of raising errors. This prevents crashes on malformed or missing annotations and ensures subclasses check for the `_no_perf` flag. [[1]](diffhunk://#diff-11bbfa67e2e4b8f4659996548738b078a104b114c0644e4d3935ffd46b61a345R25-R30) [[2]](diffhunk://#diff-11bbfa67e2e4b8f4659996548738b078a104b114c0644e4d3935ffd46b61a345R64-R92) [[3]](diffhunk://#diff-11bbfa67e2e4b8f4659996548738b078a104b114c0644e4d3935ffd46b61a345R154-R155) [[4]](diffhunk://#diff-11bbfa67e2e4b8f4659996548738b078a104b114c0644e4d3935ffd46b61a345R219-R220) [[5]](diffhunk://#diff-11bbfa67e2e4b8f4659996548738b078a104b114c0644e4d3935ffd46b61a345L197-R239) [[6]](diffhunk://#diff-11bbfa67e2e4b8f4659996548738b078a104b114c0644e4d3935ffd46b61a345L208-R250) [[7]](diffhunk://#diff-11bbfa67e2e4b8f4659996548738b078a104b114c0644e4d3935ffd46b61a345R260-R261) [[8]](diffhunk://#diff-11bbfa67e2e4b8f4659996548738b078a104b114c0644e4d3935ffd46b61a345R312-R313)

**MoE model enhancements:**

* MoE (Mixture of Experts) performance models now correctly extract and use the output dtype from traces, ensuring accurate byte calculations even when output dtype differs from input. [[1]](diffhunk://#diff-bbd7dd8b7937bd2539fa07abdcc2d00cd9a4b5443bd5a29508536b2c7d3ffb3aR864) [[2]](diffhunk://#diff-bbd7dd8b7937bd2539fa07abdcc2d00cd9a4b5443bd5a29508536b2c7d3ffb3aR874) [[3]](diffhunk://#diff-bbd7dd8b7937bd2539fa07abdcc2d00cd9a4b5443bd5a29508536b2c7d3ffb3aL895-R899) [[4]](diffhunk://#diff-bbd7dd8b7937bd2539fa07abdcc2d00cd9a4b5443bd5a29508536b2c7d3ffb3aR971) [[5]](diffhunk://#diff-bbd7dd8b7937bd2539fa07abdcc2d00cd9a4b5443bd5a29508536b2c7d3ffb3aR981) [[6]](diffhunk://#diff-bbd7dd8b7937bd2539fa07abdcc2d00cd9a4b5443bd5a29508536b2c7d3ffb3aL997-R1005)

**API and registry updates:**

* Registered all new performance model classes in the `__init__.py` exports and the pseudo-op mapping registry, making them available for auto-dispatch and summary reporting. [[1]](diffhunk://#diff-e03d1c0a173269db65bf1bfc351afb58495b3f719c6eac8d35a0664ac43d7e9eR36-R42) [[2]](diffhunk://#diff-e03d1c0a173269db65bf1bfc351afb58495b3f719c6eac8d35a0664ac43d7e9eR65-R88) [[3]](diffhunk://#diff-9b10af80cc8b96cbbddd8ac221c1f69ee7c428aef4c3b9675d4be086fc6ee2cfR48)

These changes collectively make the performance modeling more robust, accurate, and comprehensive for a broader range of inference and distributed compute scenarios.
<!--
Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.

See LICENSE for license information.
-->

