### PR TITLE
fix(treeperf): handle zero-duration GPU events in sweep-line

### DIFF
--- a/TraceLens/TreePerf/gpu_event_analyser.py
+++ b/TraceLens/TreePerf/gpu_event_analyser.py
@@ -101,12 +101,21 @@ class GPUEventAnalyser:
                 if "t_end" not in event:
                     event["t_end"] = event["ts"] + event["dur"]
                 if "overlapping_uids" not in event:
-                    compute_overlapping_uids = True
-                    points.append(
-                        (event["ts"], 1, event["UID"])
-                    )  # 1 for start, 0 for end (end sorts first so boundary-touching != overlapping)
-                    points.append((event["t_end"], 0, event["UID"]))
                     event["overlapping_uids"] = set()
+                    # Skip zero-duration GPU events from the sweep-line below.
+                    # A zero-measure interval cannot overlap anything, and the
+                    # (ts, point_type) sort ordering puts end (0) before start
+                    # (1) at equal timestamps. For a zero-dur event, ts == t_end,
+                    # so its own end-point would be processed before its
+                    # start-point and raise KeyError on active_uids.remove(uid).
+                    # Observed on ROCm 7.2 traces (gpu_memcpy events with
+                    # dur=0); see TraceLens-internal#182.
+                    if event["t_end"] > event["ts"]:
+                        compute_overlapping_uids = True
+                        points.append(
+                            (event["ts"], 1, event["UID"])
+                        )  # 1 for start, 0 for end (end sorts first so boundary-touching != overlapping)
+                        points.append((event["t_end"], 0, event["UID"]))
                 gpu_events.append(event)
 
                 if category == "gpu_memcpy":

--- a/tests/test_gpu_event_overlapping_uids.py
+++ b/tests/test_gpu_event_overlapping_uids.py
@@ -24,6 +24,9 @@ overlapping_uids computation (GPUEventAnalyser):
 - Sub-microsecond overlap (<1µs) filtered as timestamp noise (Bug 1 regression)
 - Exactly 1µs overlap meets threshold and IS marked (strict < 1.0 check)
 - Above-threshold overlap (>1µs) correctly marked
+- Zero-duration GPU events do not raise (TraceLens-internal#182 regression):
+    same-UID end (0) sorts before start (1) at equal timestamps; the sweep-line
+    must skip zero-measure intervals from active_uids tracking.
 
 overlap_pct computation (via kernel launchers and DataFrames):
 - Partial overlap between kernels from different cpu_ops
@@ -338,6 +341,71 @@ def test_above_threshold_overlap_is_marked():
     by_uid = _get_overlapping_uids_by_uid(result)
     assert by_uid[1] == {2}, "2.0µs overlap should be marked"
     assert by_uid[2] == {1}, "2.0µs overlap should be marked"
+
+
+# ── Zero-duration GPU events (TraceLens-internal#182 regression) ────────
+
+
+def test_zero_duration_memcpy_does_not_raise():
+    """Reproduces TraceLens-internal#182: ROCm 7.2 emits gpu_memcpy events
+    with dur=0 (HtoD transfers reported as zero-duration). The sweep-line
+    sort key (ts, point_type) puts end (0) before start (1) at equal ts,
+    so a same-UID end-point would be processed before its start-point and
+    raise KeyError on active_uids.remove(uid)."""
+    # Mix of normal kernels and a zero-dur memcpy (matches the bad trace shape)
+    k1 = _make_event(1, 100, 50, "kernel")
+    memcpy = _make_event(2, 200, 0, "gpu_memcpy", name="Memcpy HtoD (Host -> Device)")
+    k2 = _make_event(3, 300, 50, "kernel")
+    analyser = GPUEventAnalyser([k1, memcpy, k2])
+    # Must not raise
+    result = analyser.get_gpu_event_lists()
+    by_uid = _get_overlapping_uids_by_uid(result)
+    # Zero-dur event present but has empty overlaps
+    assert by_uid[2] == set()
+    # Zero-dur event is still included in the all_gpu and memcpy lists
+    assert any(e["UID"] == 2 for e in result[GPUEventAnalyser.all_gpu_key])
+    assert any(e["UID"] == 2 for e in result[GPUEventAnalyser.memcpy_key])
+
+
+def test_zero_duration_kernel_does_not_raise():
+    """Same regression but for cat==kernel; covers any future case where
+    a sub-microsecond Triton / HIP graph kernel is reported with dur=0."""
+    k1 = _make_event(1, 100, 50, "kernel")
+    zero_dur = _make_event(2, 200, 0, "kernel", name="zero_dur_triton")
+    k2 = _make_event(3, 300, 50, "kernel")
+    analyser = GPUEventAnalyser([k1, zero_dur, k2])
+    result = analyser.get_gpu_event_lists()
+    by_uid = _get_overlapping_uids_by_uid(result)
+    assert by_uid[2] == set()
+    assert any(e["UID"] == 2 for e in result[GPUEventAnalyser.computation_key])
+
+
+def test_zero_duration_does_not_break_other_overlaps():
+    """A zero-dur event in the middle of a stream of overlapping events
+    must not perturb overlap detection between the other events."""
+    a = _make_event(1, 0, 100, "kernel")  # [0, 100]
+    zero = _make_event(2, 50, 0, "gpu_memcpy", name="Memcpy HtoD")  # zero-dur at t=50
+    b = _make_event(3, 50, 100, "kernel")  # [50, 150] - overlaps a
+    analyser = GPUEventAnalyser([a, zero, b])
+    result = analyser.get_gpu_event_lists()
+    by_uid = _get_overlapping_uids_by_uid(result)
+    # a and b still detected as overlapping despite the zero-dur in between
+    assert by_uid[1] == {3}
+    assert by_uid[3] == {1}
+    # zero-dur event has no overlaps (zero-measure cannot overlap anything)
+    assert by_uid[2] == set()
+
+
+def test_only_zero_duration_events_does_not_raise():
+    """Edge case: trace contains only zero-duration events. Sweep-line
+    must short-circuit cleanly without entering the active_uids loop."""
+    z1 = _make_event(1, 100, 0, "gpu_memcpy", name="Memcpy HtoD")
+    z2 = _make_event(2, 200, 0, "gpu_memcpy", name="Memcpy HtoD")
+    analyser = GPUEventAnalyser([z1, z2])
+    result = analyser.get_gpu_event_lists()
+    by_uid = _get_overlapping_uids_by_uid(result)
+    assert by_uid[1] == set()
+    assert by_uid[2] == set()
 
 
 def _mk_event(cat, name, ts, dur, pid, tid, args=None):


### PR DESCRIPTION
## Summary

Closes AMD-AGI/TraceLens-internal#356
Sub-issue of AMD-AGI/TraceLens-internal#182

`GPUEventAnalyser.get_gpu_event_lists()` raises `KeyError` when a PyTorch profile trace contains any GPU event with `dur == 0`. Fix is to skip zero-measure intervals from the sweep-line that computes `overlapping_uids` (they cannot overlap anything by construction). All 4 GPU event categories (`kernel`, `gpu_memcpy`, `gpu_memset`) are still included in the returned lists; only the overlap computation skips them.

### Bug

`get_gpu_event_lists()` builds two sweep-line points per GPU event and sorts by `(timestamp, point_type)`:

```python
points.append((event["ts"],   1, event["UID"]))   # start
points.append((event["t_end"], 0, event["UID"]))  # end
points.sort(key=lambda x: (x[0], x[1]))           # end (0) < start (1) at ties
```

The end-before-start tie-break is intentional: it prevents two events touching at a boundary from being flagged as overlapping. But for a single event with `dur == 0`, `t_end == ts`, so its **own** end-point is processed before its start-point and `active_uids.remove(uid)` raises:

```
File ".../TraceLens/TreePerf/gpu_event_analyser.py", line 148, in get_gpu_event_lists
    active_uids.remove(uid)
KeyError: 1821686
```

The reporter's failing trace (newer profiler image, Primus 26.2) contains exactly this shape; quick `jq` probe over the raw trace:

| Trace | Zero-duration GPU events |
|---|---|
| Working baseline | 0 |
| Failing trace | 2 × `gpu_memcpy` HtoD with `dur=0` |

The two events are 4 MB HtoD transfers reported with `dur=0` µs (visible in the trace's own `args.memory bandwidth (GB/s)` field as ~`2.27e-13`). The same algorithm trips on any zero-dur `kernel` / `gpu_memset` too — the bug is generic, just newly surfaced.

### Fix

`TraceLens/TreePerf/gpu_event_analyser.py`:

- Always initialise `event["overlapping_uids"] = set()` (so downstream readers do not NPE on skipped events).
- Only append `(start, end)` points to the sweep-line when `t_end > ts`. A zero-measure interval cannot overlap anything, so excluding it preserves the semantics of `overlapping_uids` exactly.
- Same caching behaviour preserved: a second call on a tree where `overlapping_uids` is already cached (zero-dur or not) is still a no-op.

Comment in the patched block names AMD-AGI/TraceLens-internal#182 so future readers can find the original report.

## Test plan

- [x] 4 new regression tests in `tests/test_gpu_event_overlapping_uids.py`:
    - `test_zero_duration_memcpy_does_not_raise` — direct repro shape (kernel + zero-dur memcpy + kernel)
    - `test_zero_duration_kernel_does_not_raise` — `cat=kernel` variant (future-proofs against sub-µs Triton / HIP-graph kernels)
    - `test_zero_duration_does_not_break_other_overlaps` — surrounding overlapping events still detected
    - `test_only_zero_duration_events_does_not_raise` — degenerate edge case
- [x] All 37 tests in `tests/test_gpu_event_overlapping_uids.py` pass (33 pre-existing + 4 new)
- [x] CI-relevant local test sweep passes: 123 tests across `test_subtract_intervals`, `test_graph_mode`, `test_kernel_launchers`, `test_perf_report_regression`, `test_compare_perf_reports`, `test_inference_perf_report`, `test_collective_analysis`, `test_all2allv_summary`, `test_detect_recompute`, `test_copyright_headers`, `test_gpu_event_overlapping_uids`
- [x] `black==26.1.0 --check` clean on both edited files
- [x] End-to-end repro on the original failing trace via `TraceLens_generate_perf_report_pytorch --extension_file examples/example_megatron_extension.py`: previously raised `KeyError: 1821686`; now writes the perf-report `.xlsx` successfully (~258 KB output, same shape as the working baseline trace's report)
- [x] Sanity re-run on a known-good trace (no regression): same output size pre/post-fix
