### PR TITLE
Improving categorization and perf models for megatron extension

### DIFF
--- a/TraceLens/PerfModel/perf_model.py
+++ b/TraceLens/PerfModel/perf_model.py
@@ -3698,6 +3698,15 @@ class GroupedGemm:
             self.M, self.K, self.N, self.G, self.bpe_in, self.bpe_out
         )
 
+    def get_compute_precision(self):
+        """Return the compute precision for this operation."""
+        dtype = self.event.get("args", {}).get("Input type", [None])[0]
+        return torch_dtype_map(dtype) if dtype else None
+
+    def get_maf_type(self):
+        """Return the MAF type for this operation (matrix for grouped GEMM)."""
+        return "matrix"
+
 
 def _collect_2d_shapes(obj):
     """Recursively extract all (rows, cols) int pairs from nested lists/tuples."""

--- a/TraceLens/PerfModel/torch_op_mapping.py
+++ b/TraceLens/PerfModel/torch_op_mapping.py
@@ -270,6 +270,11 @@ def categorize_torch_op(row):
             return "SDPA_bwd"
         else:
             return "SDPA_fwd"
+    elif row["name"] in dict_cat2names.get("GroupedGEMM", []):
+        if row["name"].endswith("Backward"):
+            return "GroupedGEMM_bwd"
+        else:
+            return "GroupedGEMM_fwd"
     elif row["name"] in dict_cat2names.get("MoE_fused", []):
         return "MoE_fused"
     elif row["name"] in dict_cat2names.get("MoE_unfused", []):

--- a/TraceLens/Trace2Tree/trace_capture_merge_experimental.py
+++ b/TraceLens/Trace2Tree/trace_capture_merge_experimental.py
@@ -28,8 +28,11 @@ import TraceLens
 UID = TraceLens.util.TraceEventUtils.TraceKeys.UID
 from .trace_to_tree import TraceToTree
 
-EXECUTE_CONTEXT_PATTERN = re.compile(
-    r"execute_\d+_context_\d+\(sq\d+sk\d+sqsq\d+sqsk\d+\)_generation_\d+\(sq\d+sk\d+sqsq\d+sqsk\d+\)"
+EXECUTE_CONTEXT_PATTERNS = (
+    re.compile(
+        r"execute_\d+_context_\d+\(sq\d+sk\d+sqsq\d+sqsk\d+\)_generation_\d+\(sq\d+sk\d+sqsq\d+sqsk\d+\)"
+    ),
+    re.compile(r"execute_context_\d+\(\d+\)_generation_\d+\(\d+\)"),
 )
 
 
@@ -340,7 +343,7 @@ def find_execution_roots(graph_tree):
     roots = [
         event
         for event in graph_tree.events
-        if EXECUTE_CONTEXT_PATTERN.match(event.get("name", ""))
+        if any(p.match(event.get("name", "")) for p in EXECUTE_CONTEXT_PATTERNS)
         and event.get("cat") == "user_annotation"
     ]
     roots.sort(key=lambda x: x.get("ts", 0))
@@ -450,8 +453,11 @@ def find_closest_batch_size(
 
 
 def find_execution_details(execution_root):
-    name = execution_root["name"].split("_")[1]
-    return name
+    name = execution_root["name"]
+    if name.startswith("execute_context_"):
+        paren_values = re.findall(r"\((\d+)\)", name)
+        return str(sum(int(v) for v in paren_values))
+    return name.split("_")[1]
 
 
 def merge_capture_trace_into_graph(

--- a/examples/example_megatron_extension.py
+++ b/examples/example_megatron_extension.py
@@ -487,6 +487,8 @@ class transformer_engine_attention(SDPA):
         # ref TransformerEngine/transformer_engine/pytorch/cpp_extensions/fused_attn.py
         # https://github.com/NVIDIA/TransformerEngine/blob/51cd441501e8e6dee18c00056f008e1b53b89ebd/transformer_engine/pytorch/attention/dot_product_attention/backends.py#L881
         input_dims = event["args"]["Input Dims"]
+        input_types = event["args"]["Input type"]
+
         q_idx, k_idx, v_idx = 9, 10, 11  # this is the idx in the args list
         q_shape, k_shape, v_shape = (
             input_dims[q_idx],
@@ -508,6 +510,7 @@ class transformer_engine_attention(SDPA):
             tuple(k_strides),
             tuple(v_strides),
         )
+        dtype_A_B = (input_types[q_idx], input_types[k_idx])
 
         is_causal = True
         dropout_p = 0.0
@@ -526,6 +529,7 @@ class transformer_engine_attention(SDPA):
             "dropout": dropout_p,
             "causal": is_causal,
             "flash_impl": flash_impl,
+            "dtype_A_B": dtype_A_B,
         }
 
 

--- a/examples/example_megatron_extension.py
+++ b/examples/example_megatron_extension.py
@@ -676,6 +676,6 @@ dict_cat2names_extension = {
         "_LayerNormLinearBackward_wgrad_mm",
     ],
     "SDPA": ["FusedAttnFunc", "FusedAttnFuncBackward"],
-    "GroupedGEMM": ["GroupedGemm"],
+    "GroupedGEMM": ["GroupedGemm", "GroupedGemmBackward"],
     "Normalization": ["LayerNormFn", "LayerNormFnBackward"],
 }


### PR DESCRIPTION
This pull request introduces improvements and fixes to the performance modeling and trace processing code, with a focus on better handling of grouped GEMM operations and more robust execution context parsing. 

* Added support for categorizing both forward and backward passes of grouped GEMM operations in `categorize_torch_op`, and updated the mapping to include `"GroupedGemmBackward"` in `dict_cat2names["GroupedGEMM"]`. [[1]](diffhunk://#diff-53515390e9042657b0333bda4082f8ae890c9bbe0c5409bd77023891c022a26bR273-R277) [[2]](diffhunk://#diff-c769ab73c41d15a48768d53456a3bc3582225d57a1a4a53371aceb798b95a749L679-R683)
* Added `get_compute_precision` and `get_maf_type` methods to the performance model for retrieving compute precision and MAF type for operations, improving the extensibility and introspection of the `PerfModel`.

* Updated execution context matching to use multiple regex patterns for more robust identification of execution roots, and modified the logic in `find_execution_roots` to check all patterns. [[1]](diffhunk://#diff-a361820c09001fd17b2d09215e178075fa4e355e907c434103b7f0bd0a40041cL31-R35) [[2]](diffhunk://#diff-a361820c09001fd17b2d09215e178075fa4e355e907c434103b7f0bd0a40041cL343-R346)

* Enhanced `get_param_details` to extract input types for Q, K, V tensors, return them as `dtype_A_B`, and include this information in the returned parameter dictionary. 
<!--
Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.

See LICENSE for license information.
-->

