### PR TITLE
feat(treeperf): rebucket ROCm 7.1 legacy rocclr copy/fill kernels

### DIFF
--- a/TraceLens/TreePerf/gpu_event_analyser.py
+++ b/TraceLens/TreePerf/gpu_event_analyser.py
@@ -15,7 +15,7 @@ from TraceLens.util import TraceEventUtils
 # __amd_rocclr_fillBuffer*). ROCm 7.2 corrected this to cat=gpu_memcpy /
 # cat=gpu_memset matching the CUDA convention. These patterns rebucket
 # legacy traces so cross-version reports compare like-for-like.
-# See: AMD-AGI/TraceLens-internal#182
+# See: AMD-AGI/TraceLens-internal#357
 _ROCM_LEGACY_MEMCPY_NAMES = re.compile(
     r"^("
     r"MEMORY_COPY_(HOST_TO_DEVICE|DEVICE_TO_HOST|DEVICE_TO_DEVICE)"
@@ -140,7 +140,7 @@ class GPUEventAnalyser:
                     # Reroute ROCm 7.1 legacy rocclr copy kernels to the memcpy
                     # bucket so cross-version (7.1 vs 7.2) reports compare
                     # like-for-like; rocclr fill kernels follow gpu_memset's
-                    # existing home (comp_events). See AMD-AGI/TraceLens-internal#182.
+                    # existing home (comp_events). See AMD-AGI/TraceLens-internal#357.
                     if category == "kernel" and _ROCM_LEGACY_MEMCPY_NAMES.match(name):
                         memcpy_events.append(event)
                     elif category == "kernel" and _ROCM_LEGACY_MEMSET_NAMES.match(name):

--- a/TraceLens/TreePerf/gpu_event_analyser.py
+++ b/TraceLens/TreePerf/gpu_event_analyser.py
@@ -6,23 +6,8 @@
 
 import pandas as pd
 import itertools
-import re
 import tqdm
 from TraceLens.util import TraceEventUtils
-
-# ROCm 7.1 / older Primus images label memory copies and fills as cat=kernel
-# with rocclr-internal names (MEMORY_COPY_*, __amd_rocclr_copyBuffer*,
-# __amd_rocclr_fillBuffer*). ROCm 7.2 corrected this to cat=gpu_memcpy /
-# cat=gpu_memset matching the CUDA convention. These patterns rebucket
-# legacy traces so cross-version reports compare like-for-like.
-# See: AMD-AGI/TraceLens-internal#357
-_ROCM_LEGACY_MEMCPY_NAMES = re.compile(
-    r"^("
-    r"MEMORY_COPY_(HOST_TO_DEVICE|DEVICE_TO_HOST|DEVICE_TO_DEVICE)"
-    r"|__amd_rocclr_copyBuffer(Rect)?(Aligned)?"
-    r")(\.kd)?$"
-)
-_ROCM_LEGACY_MEMSET_NAMES = re.compile(r"^__amd_rocclr_fillBuffer(Aligned)?(\.kd)?$")
 
 
 class GPUEventAnalyser:
@@ -141,9 +126,13 @@ class GPUEventAnalyser:
                     # bucket so cross-version (7.1 vs 7.2) reports compare
                     # like-for-like; rocclr fill kernels follow gpu_memset's
                     # existing home (comp_events). See AMD-AGI/TraceLens-internal#357.
-                    if category == "kernel" and _ROCM_LEGACY_MEMCPY_NAMES.match(name):
+                    if category == "kernel" and TraceEventUtils.is_rocm_legacy_memcpy(
+                        name
+                    ):
                         memcpy_events.append(event)
-                    elif category == "kernel" and _ROCM_LEGACY_MEMSET_NAMES.match(name):
+                    elif category == "kernel" and TraceEventUtils.is_rocm_legacy_memset(
+                        name
+                    ):
                         comp_events.append(event)
                     elif TraceEventUtils.is_communication_string(name):
                         comm_events.append(event)

--- a/TraceLens/TreePerf/gpu_event_analyser.py
+++ b/TraceLens/TreePerf/gpu_event_analyser.py
@@ -6,8 +6,23 @@
 
 import pandas as pd
 import itertools
+import re
 import tqdm
 from TraceLens.util import TraceEventUtils
+
+# ROCm 7.1 / older Primus images label memory copies and fills as cat=kernel
+# with rocclr-internal names (MEMORY_COPY_*, __amd_rocclr_copyBuffer*,
+# __amd_rocclr_fillBuffer*). ROCm 7.2 corrected this to cat=gpu_memcpy /
+# cat=gpu_memset matching the CUDA convention. These patterns rebucket
+# legacy traces so cross-version reports compare like-for-like.
+# See: AMD-AGI/TraceLens-internal#182
+_ROCM_LEGACY_MEMCPY_NAMES = re.compile(
+    r"^("
+    r"MEMORY_COPY_(HOST_TO_DEVICE|DEVICE_TO_HOST|DEVICE_TO_DEVICE)"
+    r"|__amd_rocclr_copyBuffer(Rect)?(Aligned)?"
+    r")(\.kd)?$"
+)
+_ROCM_LEGACY_MEMSET_NAMES = re.compile(r"^__amd_rocclr_fillBuffer(Aligned)?(\.kd)?$")
 
 
 class GPUEventAnalyser:
@@ -121,7 +136,16 @@ class GPUEventAnalyser:
                 if category == "gpu_memcpy":
                     memcpy_events.append(event)
                 elif category in {"kernel", "gpu_memset"}:
-                    if TraceEventUtils.is_communication_string(event.get("name")):
+                    name = event.get("name") or ""
+                    # Reroute ROCm 7.1 legacy rocclr copy kernels to the memcpy
+                    # bucket so cross-version (7.1 vs 7.2) reports compare
+                    # like-for-like; rocclr fill kernels follow gpu_memset's
+                    # existing home (comp_events). See AMD-AGI/TraceLens-internal#182.
+                    if category == "kernel" and _ROCM_LEGACY_MEMCPY_NAMES.match(name):
+                        memcpy_events.append(event)
+                    elif category == "kernel" and _ROCM_LEGACY_MEMSET_NAMES.match(name):
+                        comp_events.append(event)
+                    elif TraceEventUtils.is_communication_string(name):
                         comm_events.append(event)
                     else:
                         comp_events.append(event)

--- a/TraceLens/util.py
+++ b/TraceLens/util.py
@@ -647,6 +647,32 @@ class TraceEventUtils:
         """Return True if *text* case-insensitively indicates a collective operation."""
         return any(x.match(text) for x in TraceEventUtils.get_communication_regexes())
 
+    # ROCm 7.1 / older Primus images label memory copies and fills as cat=kernel
+    # with rocclr-internal names (MEMORY_COPY_*, __amd_rocclr_copyBuffer*,
+    # __amd_rocclr_fillBuffer*). ROCm 7.2 corrected this to cat=gpu_memcpy /
+    # cat=gpu_memset matching the CUDA convention. These patterns rebucket
+    # legacy traces so cross-version reports compare like-for-like.
+    # See: AMD-AGI/TraceLens-internal#357
+    _ROCM_LEGACY_MEMCPY_NAMES = re.compile(
+        r"^("
+        r"MEMORY_COPY_(HOST_TO_DEVICE|DEVICE_TO_HOST|DEVICE_TO_DEVICE)"
+        r"|__amd_rocclr_copyBuffer(Rect)?(Aligned)?"
+        r")(\.kd)?$"
+    )
+    _ROCM_LEGACY_MEMSET_NAMES = re.compile(
+        r"^__amd_rocclr_fillBuffer(Aligned)?(\.kd)?$"
+    )
+
+    @staticmethod
+    def is_rocm_legacy_memcpy(text: str) -> bool:
+        """Return True if *text* is a rocclr legacy copy kernel name (ROCm 7.1)."""
+        return bool(text and TraceEventUtils._ROCM_LEGACY_MEMCPY_NAMES.match(text))
+
+    @staticmethod
+    def is_rocm_legacy_memset(text: str) -> bool:
+        """Return True if *text* is a rocclr legacy fill kernel name (ROCm 7.1)."""
+        return bool(text and TraceEventUtils._ROCM_LEGACY_MEMSET_NAMES.match(text))
+
 
 class RocprofParser:
     """Parser for rocprofiler-sdk JSON format (rocprofv3)"""

--- a/tests/test_gpu_event_overlapping_uids.py
+++ b/tests/test_gpu_event_overlapping_uids.py
@@ -27,6 +27,10 @@ overlapping_uids computation (GPUEventAnalyser):
 - Zero-duration GPU events do not raise (TraceLens-internal#182 regression):
     same-UID end (0) sorts before start (1) at equal timestamps; the sweep-line
     must skip zero-measure intervals from active_uids tracking.
+- ROCm legacy rocclr copy/fill kernels (cat=kernel with rocclr-internal names
+    used by ROCm 7.1) are rerouted to memcpy_events / comp_events to match
+    ROCm 7.2's cat=gpu_memcpy / cat=gpu_memset bucketing for cross-version
+    report comparability.
 
 overlap_pct computation (via kernel launchers and DataFrames):
 - Partial overlap between kernels from different cpu_ops
@@ -406,6 +410,82 @@ def test_only_zero_duration_events_does_not_raise():
     by_uid = _get_overlapping_uids_by_uid(result)
     assert by_uid[1] == set()
     assert by_uid[2] == set()
+
+
+# ── ROCm legacy rocclr kernel rerouting (7.1 → 7.2 categorization parity) ───
+#
+# In ROCm 7.1 / older Primus images, the trace producer labels memory copies
+# as cat=kernel with rocclr-internal names (MEMORY_COPY_*,
+# __amd_rocclr_copyBuffer*, __amd_rocclr_fillBuffer*). ROCm 7.2 uses
+# cat=gpu_memcpy / cat=gpu_memset matching the CUDA convention. These tests
+# pin the rerouting so a 7.1 trace's gpu_timeline buckets compute / memcpy /
+# memset the same way a 7.2 trace would. See AMD-AGI/TraceLens-internal#182.
+
+
+def test_rocm_legacy_copy_kernels_routed_to_memcpy():
+    """ROCm 7.1 names every flavour of copy lands in memcpy_events, not comp."""
+    cases = [
+        (1, "MEMORY_COPY_HOST_TO_DEVICE"),
+        (2, "MEMORY_COPY_DEVICE_TO_HOST"),
+        (3, "MEMORY_COPY_DEVICE_TO_DEVICE"),
+        (4, "__amd_rocclr_copyBuffer.kd"),
+        (5, "__amd_rocclr_copyBuffer"),  # tolerate missing .kd suffix
+        (6, "__amd_rocclr_copyBufferRect.kd"),
+        (7, "__amd_rocclr_copyBufferRectAligned.kd"),
+    ]
+    events = [_make_event(uid, uid * 100, 10, "kernel", n) for uid, n in cases]
+    analyser = GPUEventAnalyser(events)
+    result = analyser.get_gpu_event_lists()
+
+    memcpy_uids = {e["UID"] for e in result[GPUEventAnalyser.memcpy_key]}
+    comp_uids = {e["UID"] for e in result[GPUEventAnalyser.computation_key]}
+    expected = {uid for uid, _ in cases}
+    assert memcpy_uids == expected, (
+        f"All rocclr copy kernels must route to memcpy_events; "
+        f"got memcpy={memcpy_uids}, comp={comp_uids}"
+    )
+    assert not (comp_uids & expected), "rocclr copy kernels must not stay in comp"
+
+
+def test_rocm_legacy_fill_kernels_stay_in_comp():
+    """ROCm 7.1 fill kernels stay in comp_events (matches ROCm 7.2 gpu_memset
+    bucketing — gpu_memset is dispatched to comp_events too in this file)."""
+    cases = [
+        (1, "__amd_rocclr_fillBufferAligned.kd"),
+        (2, "__amd_rocclr_fillBuffer.kd"),
+        (3, "__amd_rocclr_fillBuffer"),  # tolerate missing .kd suffix
+    ]
+    events = [_make_event(uid, uid * 100, 10, "kernel", n) for uid, n in cases]
+    analyser = GPUEventAnalyser(events)
+    result = analyser.get_gpu_event_lists()
+
+    memcpy_uids = {e["UID"] for e in result[GPUEventAnalyser.memcpy_key]}
+    comp_uids = {e["UID"] for e in result[GPUEventAnalyser.computation_key]}
+    expected = {uid for uid, _ in cases}
+    assert comp_uids == expected, "rocclr fill kernels must stay in comp_events"
+    assert not (memcpy_uids & expected), "rocclr fill kernels must not route to memcpy"
+
+
+def test_normal_kernel_with_copy_in_name_not_rerouted():
+    """Triton kernels with '_to_copy_' or 'copy' in the name (e.g.
+    triton_per_fused__to_copy_sum_2) must NOT be misclassified — they are
+    real compute kernels. The legacy patterns are anchored to rocclr names
+    only (MEMORY_COPY_* and __amd_rocclr_*Buffer*)."""
+    benign = [
+        (1, "triton_per_fused__to_copy_sum_2.kd"),
+        (2, "at::native::detail::split_with_sizes_copy_out_contiguous_no_cast_kernel"),
+        (3, "MyCustomCopyKernel"),
+        (4, "memcpy_my_thing"),
+    ]
+    events = [_make_event(uid, uid * 100, 10, "kernel", n) for uid, n in benign]
+    analyser = GPUEventAnalyser(events)
+    result = analyser.get_gpu_event_lists()
+
+    memcpy_uids = {e["UID"] for e in result[GPUEventAnalyser.memcpy_key]}
+    comp_uids = {e["UID"] for e in result[GPUEventAnalyser.computation_key]}
+    expected = {uid for uid, _ in benign}
+    assert comp_uids == expected, "benign copy-named kernels must stay in comp"
+    assert not memcpy_uids, "no benign kernel should leak into memcpy_events"
 
 
 def _mk_event(cat, name, ts, dur, pid, tid, args=None):

--- a/tests/test_gpu_event_overlapping_uids.py
+++ b/tests/test_gpu_event_overlapping_uids.py
@@ -419,7 +419,7 @@ def test_only_zero_duration_events_does_not_raise():
 # __amd_rocclr_copyBuffer*, __amd_rocclr_fillBuffer*). ROCm 7.2 uses
 # cat=gpu_memcpy / cat=gpu_memset matching the CUDA convention. These tests
 # pin the rerouting so a 7.1 trace's gpu_timeline buckets compute / memcpy /
-# memset the same way a 7.2 trace would. See AMD-AGI/TraceLens-internal#182.
+# memset the same way a 7.2 trace would. See AMD-AGI/TraceLens-internal#357.
 
 
 def test_rocm_legacy_copy_kernels_routed_to_memcpy():


### PR DESCRIPTION
## Summary

Closes AMD-AGI/TraceLens-internal#357
Sub-issue of AMD-AGI/TraceLens-internal#182

PyTorch profile traces from ROCm 7.1 (Primus 26.1) and ROCm 7.2 (Primus 26.2) categorize GPU memory operations differently. ROCm 7.1 emits memory copies and buffer fills as `cat=kernel` events with rocclr-internal names; ROCm 7.2 corrected this to `cat=gpu_memcpy` / `cat=gpu_memset`, matching the CUDA convention TraceLens already assumes. As a result, every TraceLens report from a ROCm 7.1 trace silently shows `total_memcpy_time = 0 ms` and inflates `computation_time` by the actual copy time, breaking cross-version comparison.

This PR teaches `GPUEventAnalyser.get_gpu_event_lists()` to recognise the legacy rocclr names and route them to the correct buckets, so 7.1 and 7.2 reports of the same workload are structurally comparable.

_Independent of and additive to AMD-AGI/TraceLens#610 (zero-duration sweep-line fix); the two patches touch different lines of the same function and were prepared as separate commits for that reason._

### Bug

`GPUEventAnalyser.get_gpu_event_lists()` dispatches GPU events purely on `event["cat"]`:

```python
if category == "gpu_memcpy":
    memcpy_events.append(event)
elif category in {"kernel", "gpu_memset"}:
    if TraceEventUtils.is_communication_string(event.get("name")):
        comm_events.append(event)
    else:
        comp_events.append(event)
```

On the same workload (`flux_schnell_fsdp2_mock_mbs_64_gbs_512_compile`) profiled under both Primus images, the trace producer emits the following labels:

| Operation | ROCm 7.1 (Primus 26.1) | ROCm 7.2 (Primus 26.2) |
|---|---|---|
| Host→Device copy | `cat=kernel`, `name=MEMORY_COPY_HOST_TO_DEVICE`  (×234) | `cat=gpu_memcpy`, `name=Memcpy HtoD (Host -> Device)`  (×252) |
| Other-direction copy | `cat=kernel`, `name=__amd_rocclr_copyBuffer.kd`  (×126) | `cat=gpu_memcpy`, `name=Memcpy DtoD (...)`  (×102) + `Memcpy DtoH (...)`  (×6) |
| Buffer fill | `cat=kernel`, `name=__amd_rocclr_fillBufferAligned.kd`  (×154) | `cat=gpu_memset`, `name=Memset (Device)`  (×306) |
| **Total copies** | **360** | **360** |

The copy counts match exactly across versions (360 vs 360), confirming this is a pure labelling change in the trace producer, not a workload difference. ROCm 7.2's bucketing is technically more sound — rocclr copy/fill primitives are async DMA / fill ops dispatched through the runtime, not GPU compute kernels.

### Fix

`TraceLens/TreePerf/gpu_event_analyser.py`:

- Add two anchored regexes for rocclr copy and fill names:

  ```python
  _ROCM_LEGACY_MEMCPY_NAMES = re.compile(
      r"^("
      r"MEMORY_COPY_(HOST_TO_DEVICE|DEVICE_TO_HOST|DEVICE_TO_DEVICE)"
      r"|__amd_rocclr_copyBuffer(Rect)?(Aligned)?"
      r")(\.kd)?$"
  )
  _ROCM_LEGACY_MEMSET_NAMES = re.compile(
      r"^__amd_rocclr_fillBuffer(Aligned)?(\.kd)?$"
  )
  ```

- In the `cat == "kernel"` branch of the dispatch, route matches accordingly:
    - copy patterns → `memcpy_events`
    - fill patterns → `comp_events` (matching `gpu_memset`'s existing home in this dispatch)
    - everything else → unchanged (communication / compute as before)

- Patterns are anchored to rocclr-internal prefixes only, so benign Triton / ATen kernels containing "copy" in their name (e.g. `triton_per_fused__to_copy_sum_2.kd`, `at::native::detail::split_with_sizes_copy_out_*`) are unaffected. Both trace versions contain ~30 such kernels; all stay in `comp_events` — covered by a regression test.

- Patterns are slightly broader than what fires in the validation traces — they also match `__amd_rocclr_copyBufferRect(Aligned)?` and the unaligned `__amd_rocclr_fillBuffer` variant. These are documented rocclr API surface that did not appear in this particular workload but are included defensively so the patch covers the full rocclr copy/fill API.

Comment in the patched block names AMD-AGI/TraceLens-internal#357 for traceability.

### Impact

`gpu_timeline` numbers before vs after this patch, on the validation traces:

| `gpu_timeline` (ms) | 26.1 pre | 26.1 POST | 26.2 (unchanged) |
|---|---:|---:|---:|
| `computation_time` | 2870.288 | **2864.573** (−5.715) | 2855.164 |
| `exposed_memcpy_time` | 0.000 | **5.715** (+5.715) | 5.428 |
| `total_memcpy_time` | 0.000 | **5.724** (+5.724) | 5.436 |
| `busy_time` / `idle_time` / `total_time` | unchanged | unchanged | unchanged |

Two sanities:

1. The 26.1 shift is exactly the predicted ~5.7 ms moving from compute → memcpy bucket; no other column moves, confirming this is pure relabeling and not a runtime change.
2. The 26.2 trace columns are completely unchanged — patterns only match `cat=kernel` events with rocclr names, of which 26.2 has none. No risk of double-counting.

Post-normalization, cross-version `total_memcpy_time` is 5.72 vs 5.44 ms (was 0 vs 5.44) — structurally comparable; residual ~0.3 ms is real run-to-run noise.

**Blast radius**: every historical ROCm 7.1 trace re-rendered with this version of TraceLens will show the equivalent shift (compute → memcpy). `busy_time`, `idle_time`, `total_time` are unaffected, so high-level wall-clock conclusions from prior 7.1 reports remain valid; only the compute-vs-memcpy decomposition changes. ROCm 7.2+ traces are unaffected.

## Test plan

- [x] 3 new regression tests in `tests/test_gpu_event_overlapping_uids.py`:
    - `test_rocm_legacy_copy_kernels_routed_to_memcpy` — 7 name variants (all `MEMORY_COPY_*` directions, `__amd_rocclr_copyBuffer{,Rect,RectAligned}.kd`, with and without the `.kd` suffix)
    - `test_rocm_legacy_fill_kernels_stay_in_comp` — 3 fill name variants
    - `test_normal_kernel_with_copy_in_name_not_rerouted` — Triton/ATen kernels with "copy"/"memcpy" in the name stay in `comp_events`, never leak into `memcpy_events`
- [x] All 40 tests in `tests/test_gpu_event_overlapping_uids.py` pass (37 pre-existing including the 4 from #610 + 3 new)
- [x] `black==26.1.0 --check` clean on both edited files
- [x] End-to-end re-run on the failing-then-fixed trace from #610 (Primus 26.2): all `gpu_timeline` columns unchanged from #610 baseline (no false positives — confirms patterns don't fire on 7.2)
- [x] End-to-end re-run on the working baseline trace (Primus 26.1): `computation_time` −5.715 ms, `exposed_memcpy_time` +5.715 ms, `total_memcpy_time` 0 → 5.724 ms; `busy_time` / `idle_time` / `total_time` byte-identical (confirms no runtime change, only relabeling)
