### PR TITLE
Added option to include callstack in unified perf report; minor bug fix

### DIFF
--- a/TraceLens/Reporting/generate_perf_report_pytorch.py
+++ b/TraceLens/Reporting/generate_perf_report_pytorch.py
@@ -256,6 +256,7 @@ def generate_perf_report_pytorch(
     enable_origami: bool = False,
     # activation recompute detection
     detect_recompute: bool = False,
+    include_call_stack: bool = False,
 ) -> Dict[str, pd.DataFrame]:
     if gpu_arch_json_path:
         with open(gpu_arch_json_path, "r") as f:
@@ -605,6 +606,8 @@ def generate_perf_report_pytorch(
                 agg_metrics=agg_metrics,
                 include_pct=True,
                 group_by_num_kernels=group_by_num_kernels,
+                include_call_stack=include_call_stack,
+                tree=perf_analyzer.tree,
             )
             if not df_unified_perf_summary.empty:
                 df_unified_perf_summary = add_truncated_kernel_details(
@@ -612,6 +615,25 @@ def generate_perf_report_pytorch(
                     source_col="kernel_details_summary",
                     new_col_name="trunc_kernel_details",
                 )
+                if "call_stack" in df_unified_perf_summary.columns:
+                    df_callstacks = df_unified_perf_summary[
+                        ["name", "op category", "call_stack"]
+                    ].copy()
+                    df_callstacks.insert(0, "row_id", range(len(df_callstacks)))
+                    dict_name2df["unified_perf_callstacks"] = df_callstacks
+
+                    n_frames = 4  # op name + 3 parent frames
+                    cs_col = df_unified_perf_summary.columns.get_loc("call_stack")
+                    df_unified_perf_summary.insert(
+                        cs_col,
+                        "trunc_call_stack",
+                        df_unified_perf_summary["call_stack"].apply(
+                            lambda s: " => ".join(str(s).split(" => ")[:n_frames])
+                        ),
+                    )
+                    df_unified_perf_summary = df_unified_perf_summary.drop(
+                        columns=["call_stack"]
+                    )
                 dict_name2df["unified_perf_summary"] = df_unified_perf_summary
 
             if include_overlap_info:
@@ -941,6 +963,12 @@ def main():
         "when overlap sheets are enabled): earliest launcher timestamp per group, "
         "relative to the minimum in the table.",
     )
+    parser.add_argument(
+        "--include_call_stack",
+        action="store_true",
+        default=False,
+        help="Add trunc_call_stack to unified_perf_summary and write unified_perf_callstacks with full call stacks.",
+    )
 
     args = parser.parse_args()
     generate_perf_report_pytorch(
@@ -966,6 +994,7 @@ def main():
         group_by_num_kernels=args.group_by_num_kernels,
         enable_origami=args.enable_origami,
         detect_recompute=args.detect_recompute,
+        include_call_stack=args.include_call_stack,
     )
 
 

--- a/TraceLens/Reporting/generate_perf_report_pytorch.py
+++ b/TraceLens/Reporting/generate_perf_report_pytorch.py
@@ -263,13 +263,14 @@ def generate_perf_report_pytorch(
             gpu_arch_json = json.load(f)
     else:
         gpu_arch_json = None
-
+    add_python_func = True if include_call_stack else False
     perf_analyzer = TreePerfAnalyzer.from_file(
         profile_filepath=profile_json_path,
         arch=gpu_arch_json,
         python_path=python_path,
         include_unlinked_kernels=include_unlinked_kernels,
         enable_pseudo_ops=enable_pseudo_ops,
+        add_python_func=add_python_func,
         detect_recompute=detect_recompute,
         enable_origami=enable_origami,
     )

--- a/TraceLens/Reporting/generate_perf_report_pytorch_inference.py
+++ b/TraceLens/Reporting/generate_perf_report_pytorch_inference.py
@@ -538,7 +538,9 @@ def generate_perf_report_pytorch(
             gpu_arch_json = json.load(f)
     else:
         gpu_arch_json = None
-    add_python_func = True if group_by_parent_module else False
+    add_python_func = (
+        True if (group_by_parent_module or include_call_stack is True) else False
+    )
     if augmented_tree is not None:
         perf_analyzer = TreePerfAnalyzer(
             tree=augmented_tree,

--- a/TraceLens/Reporting/generate_perf_report_pytorch_inference.py
+++ b/TraceLens/Reporting/generate_perf_report_pytorch_inference.py
@@ -531,6 +531,7 @@ def generate_perf_report_pytorch(
     enable_origami: bool = False,
     group_by_parent_module: bool = False,
     group_by_num_kernels: bool = False,
+    include_call_stack: bool = False,
 ) -> Dict[str, pd.DataFrame]:
     if gpu_arch_json_path:
         with open(gpu_arch_json_path, "r") as f:
@@ -888,6 +889,8 @@ def generate_perf_report_pytorch(
                 agg_metrics=agg_metrics,
                 include_pct=True,
                 group_by_num_kernels=group_by_num_kernels,
+                include_call_stack=include_call_stack,
+                tree=perf_analyzer.tree,
             )
             if not df_unified_perf_summary.empty:
                 df_unified_perf_summary = add_truncated_kernel_details(
@@ -895,6 +898,25 @@ def generate_perf_report_pytorch(
                     source_col="kernel_details_summary",
                     new_col_name="trunc_kernel_details",
                 )
+                if "call_stack" in df_unified_perf_summary.columns:
+                    df_callstacks = df_unified_perf_summary[
+                        ["name", "op category", "call_stack"]
+                    ].copy()
+                    df_callstacks.insert(0, "row_id", range(len(df_callstacks)))
+                    dict_name2df["unified_perf_callstacks"] = df_callstacks
+
+                    n_frames = 4  # op name + 3 parent frames
+                    cs_col = df_unified_perf_summary.columns.get_loc("call_stack")
+                    df_unified_perf_summary.insert(
+                        cs_col,
+                        "trunc_call_stack",
+                        df_unified_perf_summary["call_stack"].apply(
+                            lambda s: " => ".join(str(s).split(" => ")[:n_frames])
+                        ),
+                    )
+                    df_unified_perf_summary = df_unified_perf_summary.drop(
+                        columns=["call_stack"]
+                    )
                 dict_name2df["unified_perf_summary"] = df_unified_perf_summary
 
             if include_overlap_info:
@@ -1225,6 +1247,12 @@ def main():
         help="Group by number of kernels in summary tables.",
     )
     parser.add_argument(
+        "--include_call_stack",
+        action="store_true",
+        default=False,
+        help="Include callstack in the report.",
+    )
+    parser.add_argument(
         "--include_overlap_info",
         action="store_true",
         default=False,
@@ -1265,6 +1293,7 @@ def main():
         enable_origami=args.enable_origami,
         group_by_parent_module=args.group_by_parent_module,
         group_by_num_kernels=args.group_by_num_kernels,
+        include_call_stack=args.include_call_stack,
     )
 
 

--- a/TraceLens/Trace2Tree/extensions/pseudo_ops_utils.py
+++ b/TraceLens/Trace2Tree/extensions/pseudo_ops_utils.py
@@ -93,6 +93,7 @@ def inject_pseudo_op(
 
     set_bookkeeping_attr(tree, pseudo_evt)
 
+    pseudo_evt["parent"] = orig_cpu_evt["UID"]
     children = orig_cpu_evt["children"]
     children.remove(launcher_evt["UID"])
     children.append(pseudo_evt["UID"])

--- a/TraceLens/TreePerf/tree_perf.py
+++ b/TraceLens/TreePerf/tree_perf.py
@@ -2111,7 +2111,9 @@ class TreePerfAnalyzer:
         agg_metrics=["mean", "std"],
         include_pct=True,
         group_by_num_kernels=False,
+        include_call_stack=False,
         include_overlapping_kernels=False,
+        tree=None,
     ):
         """
         Summarize unified perf table by unique (name, Input Dims, Input type, etc.).
@@ -2126,6 +2128,8 @@ class TreePerfAnalyzer:
             include_pct (bool): Include percentage and cumulative percentage columns.
             include_overlapping_kernels (bool): If True, group by overlapping_kernel_names
                 and aggregate overlapping_kernels_details.
+            tree: Required when include_call_stack=True; used to look up call stacks
+                post-aggregation via ex_UID.
 
         Returns:
             pd.DataFrame: Summarized DataFrame grouped by unique args.
@@ -2291,6 +2295,22 @@ class TreePerfAnalyzer:
                 rename_map[col] = "overlapping_kernels_details_summary"
 
         df_summary = df_summary.rename(columns=rename_map)
+
+        if include_call_stack and tree is not None and "ex_UID" in df_summary.columns:
+            def _get_call_stack(ex_uid):
+                try:
+                    event = tree.get_UID2event(int(ex_uid))
+                    cs = tree.traverse_parents_and_get_callstack(
+                        event, filter=["nn.Module", "::", "/"]
+                    )
+                    return re.sub(r"_\d+", "", cs)
+                except Exception:
+                    return ""
+            df_summary["call_stack"] = df_summary["ex_UID"].apply(_get_call_stack)
+        elif include_call_stack and tree is None:
+            warnings.warn(
+                "include_call_stack=True but tree=None; skipping call stack column."
+            )
 
         # Sort: overlap mode matches grouped ordering; otherwise by kernel time / duration
         if include_overlapping_kernels:

--- a/TraceLens/TreePerf/tree_perf.py
+++ b/TraceLens/TreePerf/tree_perf.py
@@ -2297,6 +2297,7 @@ class TreePerfAnalyzer:
         df_summary = df_summary.rename(columns=rename_map)
 
         if include_call_stack and tree is not None and "ex_UID" in df_summary.columns:
+
             def _get_call_stack(ex_uid):
                 try:
                     event = tree.get_UID2event(int(ex_uid))
@@ -2306,6 +2307,7 @@ class TreePerfAnalyzer:
                     return re.sub(r"_\d+", "", cs)
                 except Exception:
                     return ""
+
             df_summary["call_stack"] = df_summary["ex_UID"].apply(_get_call_stack)
         elif include_call_stack and tree is None:
             warnings.warn(

--- a/TraceLens/TreePerf/tree_perf.py
+++ b/TraceLens/TreePerf/tree_perf.py
@@ -2306,7 +2306,7 @@ class TreePerfAnalyzer:
                     )
                     return re.sub(r"_\d+", "", cs)
                 except Exception:
-                    return ""
+                    return "Not found"
 
             df_summary["call_stack"] = df_summary["ex_UID"].apply(_get_call_stack)
         elif include_call_stack and tree is None:


### PR DESCRIPTION
### Add call stack support to unified perf report

Adds an `--include_call_stack` flag to both reporters that annotates `unified_perf_summary` with call stack information for downstream analysis. The key design choice is that call stacks are computed **post-aggregation** in `summarize_df_unified_perf_table` rather than per-event — this ensures call stack differences never influence grouping.

**Design**

Call stacks are computed after aggregation using `ex_UID` to look up one representative event per row. This avoids ops with trivially different stacks (e.g. the same op dispatched from different TorchInductor compiled graph files or through different paths in `compiler_interface.py`) splitting into separate rows despite being the same logical operation.

**Changes**

`tree_perf.py` — `summarize_df_unified_perf_table`:
- Added `include_call_stack=False` and `tree=None` parameters.
- After aggregation, uses `ex_UID` to look up one representative event per row and fetch its call stack via `tree.traverse_parents_and_get_callstack()`. Emits a warning if `include_call_stack=True` but `tree=None`.

Both reporters (`generate_perf_report_pytorch.py`, `generate_perf_report_pytorch_inference.py`):
- Added `include_call_stack: bool = False` function parameter and `--include_call_stack` CLI flag.
- Pass `include_call_stack` and `tree=perf_analyzer.tree` to the main `summarize_df_unified_perf_table` call.
- The overlap summary variant (`include_overlapping_kernels=True`) deliberately omits call stacks — it is used for concurrent kernel analysis, not call site attribution.
- When `include_call_stack=True`: writes `unified_perf_callstacks` (full call stacks, one row per summary row) as a separate sheet/CSV, and inserts `trunc_call_stack` (first 4 frames) into `unified_perf_summary`.


Example output:
When --include_call_stack used,

- A new column trunc_call_stack is included in the unified_perf_summary.csv (4 levels up)
- 
<img width="1141" height="92" alt="image" src="https://github.com/user-attachments/assets/b0f76847-e31b-4470-8da9-a75a55e9fb98" />

- A new sheet unified_perf_callstack is added with full callstack, correlated with unified_perf_summary though row_id



<!--
Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.

See LICENSE for license information.
-->
