### PR TITLE
Additional consistency around communication processing

### DIFF
--- a/TraceLens/NcclAnalyser/nccl_analyser.py
+++ b/TraceLens/NcclAnalyser/nccl_analyser.py
@@ -8,13 +8,14 @@ import ast
 import gzip
 import os
 import json
-import pandas as pd
-import warnings
-import gzip
 import logging
+import warnings
+
+import pandas as pd
 from concurrent.futures import ProcessPoolExecutor, as_completed
 
 from ..util import DataLoader
+from ..util import DEFAULT_CUSTOM_COLLECTIVE_PATTERNS
 from ..util import TraceEventUtils
 
 
@@ -49,31 +50,7 @@ def _parse_split_sizes(value):
     return None
 
 
-import re
-
-DEFAULT_CUSTOM_COLLECTIVE_PATTERNS = [
-    (r"cross_device_reduce", "allreduce"),
-]
-
-_DEFAULT_FILTER_PATTERNS = TraceEventUtils.get_communication_regexes() + [
-    re.compile(p, re.IGNORECASE) for p, _ in DEFAULT_CUSTOM_COLLECTIVE_PATTERNS
-]
-
-_DEFAULT_INFERENCE_RULES = [
-    (re.compile(p, re.IGNORECASE), collective)
-    for p, collective in DEFAULT_CUSTOM_COLLECTIVE_PATTERNS
-]
-
-
-def _build_filter_and_inference_rules(custom_patterns):
-    """Build compiled regex lists from user-provided (pattern, collective) tuples."""
-    filter_patterns = TraceEventUtils.get_communication_regexes()
-    inference_rules = []
-    for pattern, collective in custom_patterns:
-        compiled = re.compile(pattern, re.IGNORECASE)
-        filter_patterns.append(compiled)
-        inference_rules.append((compiled, collective))
-    return filter_patterns, inference_rules
+_DEFAULT_FILTER_PATTERNS = TraceEventUtils.get_communication_regexes()
 
 
 def _infer_collective_name(kernel_name, inference_rules):
@@ -139,7 +116,8 @@ class NcclAnalyser:
             collective kernels (e.g. vLLM's ``cross_device_reduce``).
             When a kernel matches and has no ``Collective name`` in its
             trace metadata, *collective_name* is used as the inferred type.
-            Defaults to ``DEFAULT_CUSTOM_COLLECTIVE_PATTERNS``.
+            If omitted, uses ``DEFAULT_CUSTOM_COLLECTIVE_PATTERNS`` from
+            ``TraceLens.util`` (same list as :meth:`TraceEventUtils.build_collective_filter_and_inference_rules`).
         """
         self.logger = logging.getLogger(__name__)
         self.list_profile_filepaths = list_profile_filepaths
@@ -150,15 +128,12 @@ class NcclAnalyser:
             max_workers if max_workers is not None else (os.cpu_count() or 8)
         )
 
-        patterns = (
-            custom_collective_patterns
-            if custom_collective_patterns is not None
-            else DEFAULT_CUSTOM_COLLECTIVE_PATTERNS
-        )
         (
             self._filter_patterns,
             self._inference_rules,
-        ) = _build_filter_and_inference_rules(patterns)
+        ) = TraceEventUtils.build_collective_filter_and_inference_rules(
+            custom_collective_patterns
+        )
 
         # Byte sizes per dtype
         self.dtype2bytes = {

--- a/TraceLens/Reporting/generate_perf_report_pytorch_inference.py
+++ b/TraceLens/Reporting/generate_perf_report_pytorch_inference.py
@@ -24,6 +24,7 @@ import zipfile
 
 from TraceLens import NcclAnalyser, TraceToTree, TreePerfAnalyzer
 from TraceLens.Reporting.reporting_utils import request_install
+from TraceLens.util import TraceEventUtils
 from TraceLens.Trace2Tree.trace_capture_merge_experimental import (
     merge_capture_trace_into_graph,
 )
@@ -87,7 +88,10 @@ def perf_report_sanity_check(
             e["name"]
             for e in events
             if e.get("cat") in {"kernel", "gpu_memcpy", "gpu_memset"}
-            and ("nccl" not in e.get("name", "").lower() or include_nccl)
+            and (
+                not TraceEventUtils.is_communication_string(e.get("name", ""))
+                or include_nccl
+            )
         )
     )
 

--- a/TraceLens/TreePerf/tree_perf.py
+++ b/TraceLens/TreePerf/tree_perf.py
@@ -1823,7 +1823,9 @@ class TreePerfAnalyzer:
                 continue
             if evt["UID"] in collected_gpu_uids:
                 continue
-            if not include_nccl and "nccl" in evt.get("name", "").lower():
+            if not include_nccl and TraceEventUtils.is_communication_string(
+                evt.get("name", "")
+            ):
                 continue
 
             has_cpu_op = False

--- a/TraceLens/util.py
+++ b/TraceLens/util.py
@@ -20,7 +20,7 @@ except ImportError:
     # fallback for Python 3.10
     except ImportError:
         from strenum import StrEnum
-from typing import List, Dict, Callable, Iterable, Tuple
+from typing import List, Dict, Callable, Iterable, Tuple, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -392,6 +392,11 @@ class JaxProfileProcessor:
 # inside the nested JaxOpKeys class (outer class name is not bound yet during nested exec).
 COMMUNICATION_KEYS = ["rccl", "nccl"]
 
+# (kernel-name regex fragment, canonical collective name for inference)
+DEFAULT_CUSTOM_COLLECTIVE_PATTERNS: List[Tuple[str, str]] = [
+    (r"cross_device_reduce", "allreduce"),
+]
+
 
 class TraceEventUtils:
     class JaxOpKeys:
@@ -639,15 +644,58 @@ class TraceEventUtils:
             )
 
     @staticmethod
-    def get_communication_regexes() -> List[re.Pattern]:
-        return [re.compile(p, re.IGNORECASE) for p in COMMUNICATION_KEYS]
+    def get_communication_regexes(
+        custom_collective_patterns: Optional[List[Tuple[str, str]]] = None,
+    ) -> List[re.Pattern]:
+        """Return compiled patterns for NCCL/RCCL plus optional custom collectives.
+
+        When *custom_collective_patterns* is ``None``, built-in defaults from
+        ``DEFAULT_CUSTOM_COLLECTIVE_PATTERNS`` (e.g. vLLM ``cross_device_reduce``)
+        are included. Pass an explicit list (possibly empty) to override that
+        set while keeping NCCL/RCCL markers.
+        """
+        regexes = [re.compile(p, re.IGNORECASE) for p in COMMUNICATION_KEYS]
+        custom = (
+            DEFAULT_CUSTOM_COLLECTIVE_PATTERNS
+            if custom_collective_patterns is None
+            else custom_collective_patterns
+        )
+        for pattern, _ in custom:
+            regexes.append(re.compile(pattern, re.IGNORECASE))
+        return regexes
+
+    @staticmethod
+    def build_collective_filter_and_inference_rules(
+        custom_collective_patterns: Optional[List[Tuple[str, str]]] = None,
+    ) -> Tuple[List[re.Pattern], List[Tuple[re.Pattern, str]]]:
+        """Compile NCCL/RCCL/custom kernel match patterns and collective inference rules.
+
+        Same *custom_collective_patterns* semantics as
+        :meth:`get_communication_regexes`: ``None`` uses
+        ``DEFAULT_CUSTOM_COLLECTIVE_PATTERNS``; otherwise the given list
+        replaces that default set (use ``[]`` for no custom kernels).
+        """
+        effective = (
+            custom_collective_patterns
+            if custom_collective_patterns is not None
+            else DEFAULT_CUSTOM_COLLECTIVE_PATTERNS
+        )
+        filter_patterns = TraceEventUtils.get_communication_regexes(
+            custom_collective_patterns=effective
+        )
+        inference_rules = [
+            (re.compile(pattern, re.IGNORECASE), collective)
+            for pattern, collective in effective
+        ]
+        return filter_patterns, inference_rules
 
     @staticmethod
     def is_communication_string(text: str) -> bool:
-        """Return True if *text* case-insensitively contains an NCCL/RCCL marker.
+        """Return True if *text* matches NCCL/RCCL or default custom collective patterns.
 
         Uses substring search (``Pattern.search``), not start-anchored ``match``,
         so demangled names like ``void rcclGenericKernel<...>(...)`` match.
+        Custom kernels use the same defaults as :meth:`get_communication_regexes`.
         """
         if not text:
             return False

--- a/TraceLens/util.py
+++ b/TraceLens/util.py
@@ -644,8 +644,14 @@ class TraceEventUtils:
 
     @staticmethod
     def is_communication_string(text: str) -> bool:
-        """Return True if *text* case-insensitively indicates a collective operation."""
-        return any(x.match(text) for x in TraceEventUtils.get_communication_regexes())
+        """Return True if *text* case-insensitively contains an NCCL/RCCL marker.
+
+        Uses substring search (``Pattern.search``), not start-anchored ``match``,
+        so demangled names like ``void rcclGenericKernel<...>(...)`` match.
+        """
+        if not text:
+            return False
+        return any(x.search(text) for x in TraceEventUtils.get_communication_regexes())
 
 
 class RocprofParser:


### PR DESCRIPTION
More inconsistencies were found in how communication primitives were processed. This PR addresses these including:
- searches for NCCL or RCCL use search instead of match everywhere
- use "nccl" or "rccl" during orphan detection


Still TBD: should try_perf use GPU kernel name via UID lookup or event["name"]?
Should GPUEventAnalyzer/treeperf require correlation id or external id, or should we remove this from NCCL Analyser? Or leave this inconsistent?
Should GPUEventAnalyzer/treeperf allow or even include the custom patterns used by NCCLAnalyser?
