### PR TITLE
feat(perfmodel): add primus_turbo FP8 GEMM and quantize perf models (#626)

### DIFF
--- a/TraceLens/PerfModel/perf_model.py
+++ b/TraceLens/PerfModel/perf_model.py
@@ -5368,3 +5368,117 @@ class mamba_ssd_fwd(MambaSSD):
     """MambaSplitConv1dScanCombinedFn forward pass."""
 
     pass
+
+
+# ---------------------------------------------------------------------------
+# primus_turbo FP8 ops (#626)
+# ---------------------------------------------------------------------------
+
+
+class hipblaslt_gemm_fp8(GEMM):
+    """
+    primus_turbo_cpp_extension::hipblaslt_gemm_fp8 — FP8 GEMM via hipBLASLt.
+
+    9-slot input layout (from Primus-Turbo C++ binding):
+      hipblaslt_gemm_fp8(A, scaleA_inv, B, scaleB_inv,
+                         out_dtype, transA, transB, transC, granularity)
+
+    Trace event layout:
+      Input Dims:  ((A0, A1), (), (B0, B1), (), (), (), (), (), ())
+      Input type:  (fp8, float, fp8, float, Scalar, ...)
+      Concrete Inputs: ('', '', '', '', '<dtype_enum>', '<transA>', '<transB>', '<transC>', '')
+    """
+
+    @staticmethod
+    def get_param_details(event):
+        input_dims = event["args"]["Input Dims"]
+        concrete = event["args"].get("Concrete Inputs", [])
+
+        A_shape = list(input_dims[0])
+        B_shape = list(input_dims[2])
+
+        trans_a = (concrete[5] == "True") if len(concrete) > 5 else False
+        trans_b = (concrete[6] == "True") if len(concrete) > 6 else False
+        trans_c = (concrete[7] == "True") if len(concrete) > 7 else False
+
+        # Replicate C++ transC swap (hipblaslt_gemm.cpp)
+        if trans_c:
+            A_shape, B_shape = B_shape, A_shape
+            trans_a, trans_b = not trans_b, not trans_a
+
+        M = A_shape[1] if trans_a else A_shape[0]
+        K = A_shape[0] if trans_a else A_shape[1]
+        N = B_shape[0] if trans_b else B_shape[1]
+
+        dtype_A_B = (event["args"]["Input type"][0], event["args"]["Input type"][2])
+
+        try:
+            stride_A = tuple(event["args"]["Input Strides"][0])
+            stride_B = tuple(event["args"]["Input Strides"][2])
+        except (KeyError, IndexError):
+            stride_A = stride_B = None
+
+        return {
+            "M": M,
+            "N": N,
+            "K": K,
+            "bias": False,
+            "stride_A": stride_A,
+            "stride_B": stride_B,
+            "dtype_A_B": dtype_A_B,
+        }
+
+    def bytes(self):
+        dtype_A_B = self.param_details["dtype_A_B"]
+        bpeA = name2bpe(dtype_A_B[0])
+        bpeB = name2bpe(dtype_A_B[1])
+        assert (
+            bpeA is not None and bpeB is not None
+        ), f"Data types of A and B are not supported: {dtype_A_B}"
+        self.bpe = bpeA
+        # FP8 inputs (1 byte), BF16/FP16 output (2 bytes)
+        out_bpe = 2 if self.bpe == 1 else self.bpe
+        return super().bytes(
+            bpe_mat1=self.bpe,
+            bpe_mat2=bpeB,
+            bpe_bias=self.bpe,
+            bpe_output=out_bpe,
+        )
+
+    def flops_bwd(self):
+        raise NotImplementedError(
+            "Backward pass for hipblaslt_gemm_fp8 is not defined."
+        )
+
+    def bytes_bwd(self, bytes_per_element):
+        raise NotImplementedError(
+            "Backward pass for hipblaslt_gemm_fp8 is not defined."
+        )
+
+
+class primus_turbo_quantize_fp8(UnaryElementwise):
+    """
+    primus_turbo_cpp_extension::quantize_fp8_tensorwise
+
+    BF16 → FP8 per-tensor quantize for delayed-scaling tensorwise recipe.
+    Trace arg layout: (tensor, scale_inv, amax) where tensor is BF16 2-D,
+    scale_inv and amax are scalars.
+
+    Memory-bandwidth bound: reads 2·M·N bytes (BF16), writes M·N bytes (FP8).
+    """
+
+    @staticmethod
+    def get_param_details(event):
+        args_input_dims = event["args"]["Input Dims"]
+        op_shape = tuple(args_input_dims[0])
+        dtype_in = event["args"]["Input type"][0]
+        try:
+            stride_input = tuple(event["args"]["Input Strides"][0])
+        except (KeyError, IndexError):
+            stride_input = None
+        return {
+            "op_shape": op_shape,
+            "dtype_in_out": (dtype_in, "c10::Float8_e4m3fnuz"),
+            "stride_input": stride_input,
+            "stride_output": None,
+        }

--- a/TraceLens/PerfModel/perf_model.py
+++ b/TraceLens/PerfModel/perf_model.py
@@ -5392,7 +5392,9 @@ class hipblaslt_gemm_fp8(GEMM):
     @staticmethod
     def get_param_details(event):
         input_dims = event["args"]["Input Dims"]
-        concrete = event["args"].get("Concrete Inputs", [])
+        # Concrete Inputs may be missing (older traces) or present-but-None
+        # (some kineto exporters); normalize to [] for both cases.
+        concrete = event["args"].get("Concrete Inputs") or []
 
         A_shape = list(input_dims[0])
         B_shape = list(input_dims[2])

--- a/TraceLens/PerfModel/torch_op_mapping.py
+++ b/TraceLens/PerfModel/torch_op_mapping.py
@@ -70,6 +70,11 @@ op_to_perf_model_class_map = {
     "CrossEntropyFunction": perf_model.cross_entropy_fwd,
     # Mamba SSD (fused conv1d + selective scan, issue #552)
     "MambaSplitConv1dScanCombinedFn": perf_model.mamba_ssd_fwd,
+    # Primus FP8 ops (hipBLASLt GEMM + quantize, issue #626)
+    "primus_turbo_cpp_extension::hipblaslt_gemm_fp8": perf_model.hipblaslt_gemm_fp8,
+    "primus_turbo::hipblaslt_gemm_fp8": perf_model.hipblaslt_gemm_fp8,
+    "primus_turbo_cpp_extension::quantize_fp8_tensorwise": perf_model.primus_turbo_quantize_fp8,
+    "primus_turbo::quantize_fp8_tensorwise": perf_model.primus_turbo_quantize_fp8,
 }
 
 # Add pseudo-op extension mappings

--- a/TraceLens/TreePerf/gpu_event_analyser.py
+++ b/TraceLens/TreePerf/gpu_event_analyser.py
@@ -167,7 +167,7 @@ class GPUEventAnalyser:
 
             for _, point_type, uid in points:
                 if point_type == 0:
-                    active_uids.remove(uid)
+                    active_uids.discard(uid)
                 else:
                     event = event_map[uid]
                     my_cpu_op = uid_to_cpu_op[uid]

--- a/tests/test_primus_fp8_gemm_quantize.py
+++ b/tests/test_primus_fp8_gemm_quantize.py
@@ -199,6 +199,31 @@ def test_hipblaslt_gemm_fp8_missing_concrete_inputs_defaults_to_no_transpose():
     assert (model.M, model.N, model.K) == (M, N, K)
 
 
+def test_hipblaslt_gemm_fp8_null_concrete_inputs_defaults_to_no_transpose():
+    """Some kineto exporters write Concrete Inputs as None (not absent); must not raise."""
+    M, K, N = 1024, 512, 768
+    event = {
+        "name": "primus_turbo_cpp_extension::hipblaslt_gemm_fp8",
+        "args": {
+            "Input Dims": [(M, K), (), (K, N), (), (), (), (), (), ()],
+            "Input type": [
+                "c10::Float8_e4m3fnuz",
+                "float",
+                "c10::Float8_e4m3fnuz",
+                "float",
+                "Scalar",
+                "Scalar",
+                "Scalar",
+                "Scalar",
+                "",
+            ],
+            "Concrete Inputs": None,
+        },
+    }
+    model = hipblaslt_gemm_fp8(event)
+    assert (model.M, model.N, model.K) == (M, N, K)
+
+
 # ===========================================================================
 # quantize_fp8_tensorwise
 # ===========================================================================

--- a/tests/test_primus_fp8_gemm_quantize.py
+++ b/tests/test_primus_fp8_gemm_quantize.py
@@ -1,0 +1,241 @@
+###############################################################################
+# Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Tests for primus_turbo FP8 ops (#626):
+  - primus_turbo_cpp_extension::hipblaslt_gemm_fp8 -> GEMM
+  - primus_turbo_cpp_extension::quantize_fp8_tensorwise -> UnaryElementwise
+"""
+
+from TraceLens.PerfModel.perf_model import (
+    hipblaslt_gemm_fp8,
+    primus_turbo_quantize_fp8,
+    GEMM,
+    UnaryElementwise,
+)
+from TraceLens.PerfModel.torch_op_mapping import (
+    categorize_torch_op,
+    op_to_perf_model_class_map,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fp8_gemm_event(
+    A_shape,
+    B_shape,
+    trans_a=False,
+    trans_b=True,
+    trans_c=False,
+    dtype="c10::Float8_e4m3fnuz",
+):
+    """
+    Build a hipblaslt_gemm_fp8 event with explicit transpose flags.
+
+    Defaults reflect the typical Flux 12B weight layout:
+      A is row-major (M,K), B is stored as (N,K) so transB=True logically
+      means B is treated as (K,N) by the kernel.
+    """
+    return {
+        "name": "primus_turbo_cpp_extension::hipblaslt_gemm_fp8",
+        "args": {
+            "Input Dims": [A_shape, (), B_shape, (), (), (), (), (), ()],
+            "Input type": [
+                dtype,
+                "float",
+                dtype,
+                "float",
+                "Scalar",
+                "Scalar",
+                "Scalar",
+                "Scalar",
+                "",
+            ],
+            "Concrete Inputs": [
+                "",
+                "",
+                "",
+                "",
+                "8",
+                "True" if trans_a else "False",
+                "True" if trans_b else "False",
+                "True" if trans_c else "False",
+                "",
+            ],
+        },
+    }
+
+
+def _quantize_event(M=20480, N=12288, dtype_in="c10::BFloat16"):
+    return {
+        "name": "primus_turbo_cpp_extension::quantize_fp8_tensorwise",
+        "args": {
+            "Input Dims": [(M, N), (), ()],
+            "Input type": [dtype_in, "Scalar", ""],
+        },
+    }
+
+
+# ===========================================================================
+# hipblaslt_gemm_fp8
+# ===========================================================================
+
+
+def test_hipblaslt_gemm_fp8_mapping():
+    ops = [
+        "primus_turbo_cpp_extension::hipblaslt_gemm_fp8",
+        "primus_turbo::hipblaslt_gemm_fp8",
+    ]
+    for op in ops:
+        assert op in op_to_perf_model_class_map, op
+        assert op_to_perf_model_class_map[op] is hipblaslt_gemm_fp8, op
+
+
+def test_hipblaslt_gemm_fp8_categorizes_as_gemm():
+    for op in [
+        "primus_turbo_cpp_extension::hipblaslt_gemm_fp8",
+        "primus_turbo::hipblaslt_gemm_fp8",
+    ]:
+        row = {"name": op, "kernel_details": []}
+        assert categorize_torch_op(row) == "GEMM", op
+
+
+def test_hipblaslt_gemm_fp8_inherits_gemm():
+    assert issubclass(hipblaslt_gemm_fp8, GEMM)
+
+
+def test_hipblaslt_gemm_fp8_flops_double_stream_mlp_up_proj():
+    """Flux 12B double-stream MLP up-proj: A=(20480,3072) x B=(12288,3072), transB=True."""
+    M, K, N = 20480, 3072, 12288
+    model = hipblaslt_gemm_fp8(_fp8_gemm_event((M, K), (N, K), trans_b=True))
+    assert (model.M, model.N, model.K) == (M, N, K)
+    assert model.flops() == 2 * M * N * K
+
+
+def test_hipblaslt_gemm_fp8_bytes_double_stream_mlp_up_proj():
+    M, K, N = 20480, 3072, 12288
+    model = hipblaslt_gemm_fp8(_fp8_gemm_event((M, K), (N, K), trans_b=True))
+    bpe_in = 1  # FP8
+    bpe_out = 2  # FP16 output for FP8 input
+    expected = M * K * bpe_in + K * N * bpe_in + M * N * bpe_out
+    assert model.bytes() == expected
+
+
+def test_hipblaslt_gemm_fp8_single_stream_attn_out_proj():
+    """Flux 12B single-stream attn out-proj: A=(10240,3072) x B=(3072,3072)."""
+    M, K, N = 10240, 3072, 3072
+    model = hipblaslt_gemm_fp8(_fp8_gemm_event((M, K), (N, K), trans_b=True))
+    assert (model.M, model.N, model.K) == (M, N, K)
+    assert model.flops() == 2 * M * N * K
+    assert model.bytes() == M * K * 1 + K * N * 1 + M * N * 2
+
+
+def test_hipblaslt_gemm_fp8_weight_grad_shape():
+    """NT layout weight grad: (3072, 20480) x (12288, 20480), transB=True."""
+    M, K, N = 3072, 20480, 12288
+    model = hipblaslt_gemm_fp8(_fp8_gemm_event((M, K), (N, K), trans_b=True))
+    assert (model.M, model.N, model.K) == (M, N, K)
+    assert model.flops() == 2 * M * N * K
+
+
+def test_hipblaslt_gemm_fp8_no_transpose():
+    """A=(M,K), B=(K,N), no transpose flags - A and B both row-major."""
+    M, K, N = 1024, 512, 768
+    model = hipblaslt_gemm_fp8(
+        _fp8_gemm_event((M, K), (K, N), trans_a=False, trans_b=False)
+    )
+    assert (model.M, model.N, model.K) == (M, N, K)
+    assert model.flops() == 2 * M * N * K
+
+
+def test_hipblaslt_gemm_fp8_trans_a():
+    """transA=True: A is stored as (K,M), kernel reads M from A_shape[1]."""
+    M, K, N = 1024, 512, 768
+    model = hipblaslt_gemm_fp8(
+        _fp8_gemm_event((K, M), (K, N), trans_a=True, trans_b=False)
+    )
+    assert (model.M, model.N, model.K) == (M, N, K)
+    assert model.flops() == 2 * M * N * K
+
+
+def test_hipblaslt_gemm_fp8_trans_c_swap():
+    """transC=True swaps A/B and inverts transA/transB (mirrors the C++ binding)."""
+    M, K, N = 1024, 512, 768
+    base = hipblaslt_gemm_fp8(
+        _fp8_gemm_event((M, K), (K, N), trans_a=False, trans_b=False, trans_c=False)
+    )
+    swapped = hipblaslt_gemm_fp8(
+        _fp8_gemm_event((K, N), (M, K), trans_a=True, trans_b=True, trans_c=True)
+    )
+    assert (base.M, base.N, base.K) == (swapped.M, swapped.N, swapped.K)
+
+
+def test_hipblaslt_gemm_fp8_missing_concrete_inputs_defaults_to_no_transpose():
+    """Older traces without Concrete Inputs default to transA=transB=False."""
+    M, K, N = 1024, 512, 768
+    event = {
+        "name": "primus_turbo_cpp_extension::hipblaslt_gemm_fp8",
+        "args": {
+            "Input Dims": [(M, K), (), (K, N), (), (), (), (), (), ()],
+            "Input type": [
+                "c10::Float8_e4m3fnuz",
+                "float",
+                "c10::Float8_e4m3fnuz",
+                "float",
+                "Scalar",
+                "Scalar",
+                "Scalar",
+                "Scalar",
+                "",
+            ],
+        },
+    }
+    model = hipblaslt_gemm_fp8(event)
+    assert (model.M, model.N, model.K) == (M, N, K)
+
+
+# ===========================================================================
+# quantize_fp8_tensorwise
+# ===========================================================================
+
+
+def test_quantize_fp8_mapping():
+    ops = [
+        "primus_turbo_cpp_extension::quantize_fp8_tensorwise",
+        "primus_turbo::quantize_fp8_tensorwise",
+    ]
+    for op in ops:
+        assert op in op_to_perf_model_class_map, op
+        assert op_to_perf_model_class_map[op] is primus_turbo_quantize_fp8, op
+
+
+def test_quantize_fp8_categorizes_as_elementwise():
+    row = {
+        "name": "primus_turbo_cpp_extension::quantize_fp8_tensorwise",
+        "kernel_details": [],
+    }
+    assert categorize_torch_op(row) == "elementwise"
+
+
+def test_quantize_fp8_inherits_unary():
+    assert issubclass(primus_turbo_quantize_fp8, UnaryElementwise)
+
+
+def test_quantize_fp8_bytes():
+    M, N = 20480, 12288
+    model = primus_turbo_quantize_fp8(_quantize_event(M=M, N=N))
+    bpe_in = 2  # BF16
+    bpe_out = 1  # FP8
+    expected = M * N * bpe_in + M * N * bpe_out
+    assert model.bytes() == expected
+
+
+def test_quantize_fp8_flops():
+    M, N = 20480, 12288
+    model = primus_turbo_quantize_fp8(_quantize_event(M=M, N=N))
+    assert model.flops() == M * N


### PR DESCRIPTION
## Summary

Closes #626 (sub-issue of #516)

Add roofline support for two new ops introduced by Primus's FP8-on-`torch.compile` recipe (`primus_turbo` Float8 linear + tensorwise scaling, e4m3fnuz):

- **`primus_turbo_cpp_extension::hipblaslt_gemm_fp8`** → `GEMM` category, **new subclass** (not `aten_scaled_mm`). Parses the 9-slot trace layout: A/B shapes from `Input Dims[0]` and `Input Dims[2]`, reads `transA/transB/transC` from `Concrete Inputs[5:8]`, replicates the C++ binding's `transC` swap (A↔B + flip transA/transB) before deriving M/N/K. Allows `bpe_A ≠ bpe_B` for future mixed-precision recipes. FLOPs = 2·M·N·K, bytes = bpe_A·M·K + bpe_B·K·N + bpe_out·M·N (FP8 in → BF16/FP16 out). Falls back to `transA=transB=transC=False` when `Concrete Inputs` is missing (older traces). Covers **~53 %** of FP8 GPU time on Flux 12B traces.
- **`primus_turbo_cpp_extension::quantize_fp8_tensorwise`** → `UnaryElementwise` category. BF16→FP8 per-tensor quantize (delayed-scaling tensorwise recipe). Bytes = 2·M·N (BF16 read) + M·N (FP8 write). Covers **~6 %** of FP8 GPU time.

Also fixes a defensive issue in `gpu_event_analyser.py`: change `active_uids.remove(uid)` to `active_uids.discard(uid)` so zero-duration GPU events in some Flux traces don't raise `KeyError`.

### Why a new GEMM subclass instead of subclassing `aten_scaled_mm`

`aten::_scaled_mm` takes 6 positional args with implicit `(M,K) × (K,N) → (M,N)` layout. `primus_turbo_cpp_extension::hipblaslt_gemm_fp8` takes 9 positional args including explicit `transA/transB/transC` flags at slots 5/6/7, and the C++ binding does an A↔B swap when `transC=True`. Subclassing `aten_scaled_mm` would silently produce wrong M/N/K on `transA=True` weight-grad calls (very common in Flux 12B). The new class handles both layouts correctly and falls back gracefully on older traces without `Concrete Inputs`.

## Test plan

- [x] 16 unit tests in `tests/test_primus_fp8_gemm_quantize.py`: mapping, categorization, inheritance, FLOPs, bytes, plus explicit transpose-flag coverage (no-transpose, `transA`, `transC` swap, missing `Concrete Inputs` fallback)
- [x] `black` formatting verified
- [x] Test suite (excluding pre-existing torch-dependent and regression CSV tests): 342 passed, 2 skipped, 1 pre-existing failure (`test_origami_time_in_unified_perf_summary` — Origami integration, unrelated)
- [x] Trace-validated on Flux 12B FP8 traces:
  - **Trace B (FP8 mbs=40 + L1)**: GEMM mass 0.89 % → 54.10 % (+53.21 pp); elementwise 0.76 % → 6.63 % (+5.88 pp); **"other" 67.15 % → 1.57 % (−65.59 pp)**
  - **Trace R3 (FP8 + selective recompute)**: GEMM 0.82 % → 50.34 %; **"other" 62.64 % → 1.46 % (−61.18 pp)**
  - Per-op landings match #626 evidence to within rounding (53.21 % / 5.88 % vs claimed 53.2 % / 5.9 %)

Replaces the FP8 half of the now-closed #628.
