### PR TITLE
feat(perfmodel): add primus::fused_ln_modulate{,_backward} for MM-DiT (#627)

### DIFF
--- a/TraceLens/PerfModel/perf_model.py
+++ b/TraceLens/PerfModel/perf_model.py
@@ -5484,3 +5484,131 @@ class primus_turbo_quantize_fp8(UnaryElementwise):
             "stride_input": stride_input,
             "stride_output": None,
         }
+
+
+# ---------------------------------------------------------------------------
+# primus fused_ln_modulate (#627)
+# ---------------------------------------------------------------------------
+
+
+class FusedLnModulate(Normalization):
+    """
+    primus::fused_ln_modulate — forward
+
+    Fused LayerNorm + scale/shift modulation for MM-DiT / DiT blocks.
+    Input: x:(T,B,H), scale:(B,H), shift:(B,H), eps (scalar).
+
+    Memory-bandwidth bound:
+      fwd bytes = 2·T·B·H·bpe (read x, write y) + 2·B·H·bpe (read scale, shift)
+                  + 2·T·B·4 (write mean, rstd as float32, one per row)
+      flops ≈ T·B·H·12 (LN: subtract mean, square, sum, rsqrt, normalize ≈ 8;
+              modulate: scale + shift ≈ 2; residual: 2)
+    """
+
+    @staticmethod
+    def get_param_details(event):
+        args_input_dims = event["args"]["Input Dims"]
+        x_shape = tuple(args_input_dims[0])
+        dtype_in = event["args"]["Input type"][0]
+        try:
+            stride_input = tuple(event["args"]["Input Strides"][0])
+        except (KeyError, IndexError):
+            stride_input = None
+
+        T, B, H = x_shape[0], x_shape[1], x_shape[2]
+        return {
+            "op_shape": x_shape,
+            "dtype_in_out": (dtype_in, None),
+            "stride_input": stride_input,
+            "stride_output": None,
+            "num_channels": H,
+            "has_bias": True,
+            "is_affine": True,
+            "is_training": True,
+        }
+
+    def flops(self):
+        return self.num_elems * 12
+
+    def bytes(self):
+        bpe = self.bpe_in
+        T = self.param_details["op_shape"][0]
+        B = self.param_details["op_shape"][1]
+        H = self.num_channels
+        T_B_H = self.num_elems
+        read_x = T_B_H * bpe
+        write_y = T_B_H * bpe
+        read_scale_shift = 2 * B * H * bpe
+        write_mean_rstd = 2 * T * B * 4
+        return read_x + write_y + read_scale_shift + write_mean_rstd
+
+    def flops_bwd(self):
+        raise NotImplementedError("Use FusedLnModulateBackward for the backward pass.")
+
+    def bytes_bwd(self):
+        raise NotImplementedError("Use FusedLnModulateBackward for the backward pass.")
+
+
+class FusedLnModulateBackward(Normalization):
+    """
+    primus::fused_ln_modulate_backward
+
+    Backward pass of the fused LN+modulate kernel.
+    Input: grad_out:(T,B,H), x_norm:(T,B,H), mean:(B*T,), rstd:(B*T,), mod_grad:(B,H)
+
+    Memory-bandwidth bound:
+      bwd bytes = 2·T·B·H·bpe (read grad_out, x_norm) + 2·T·B·4 (read mean, rstd)
+                  + T·B·H·bpe (write x_grad) + 2·B·H·bpe (write scale_grad, shift_grad)
+                  + B·H·bpe (read modulation_grad)
+    """
+
+    @staticmethod
+    def get_param_details(event):
+        args_input_dims = event["args"]["Input Dims"]
+        grad_shape = tuple(args_input_dims[0])
+        dtype_in = event["args"]["Input type"][0]
+        try:
+            stride_input = tuple(event["args"]["Input Strides"][0])
+        except (KeyError, IndexError):
+            stride_input = None
+
+        T, B, H = grad_shape[0], grad_shape[1], grad_shape[2]
+        return {
+            "op_shape": grad_shape,
+            "dtype_in_out": (dtype_in, None),
+            "stride_input": stride_input,
+            "stride_output": None,
+            "num_channels": H,
+            "has_bias": True,
+            "is_affine": True,
+            "is_training": True,
+            "output_mask": [True, True, True],
+        }
+
+    def flops(self):
+        return self.num_elems * 15
+
+    def bytes(self):
+        bpe = self.bpe_in
+        T_B_H = self.num_elems
+        B = self.param_details["op_shape"][1]
+        T = self.param_details["op_shape"][0]
+        H = self.num_channels
+        read_grad_x_norm = 2 * T_B_H * bpe
+        read_mean_rstd = 2 * B * T * 4
+        write_x_grad = T_B_H * bpe
+        write_scale_shift_grad = 2 * B * H * bpe
+        read_mod_grad = B * H * bpe
+        return (
+            read_grad_x_norm
+            + read_mean_rstd
+            + write_x_grad
+            + write_scale_shift_grad
+            + read_mod_grad
+        )
+
+    def flops_bwd(self):
+        raise NotImplementedError
+
+    def bytes_bwd(self):
+        raise NotImplementedError

--- a/TraceLens/PerfModel/torch_op_mapping.py
+++ b/TraceLens/PerfModel/torch_op_mapping.py
@@ -149,6 +149,9 @@ norm_ops = {
     "aten::miopen_rms_norm_backward": perf_model.RMSNormBwd,
     "aten::cudnn_rms_norm_backward": perf_model.RMSNormBwd,
     "aten::_fused_rms_norm_backward": perf_model.RMSNormBwd,
+    # Primus fused LN+modulate for MM-DiT (issue #627)
+    "primus::fused_ln_modulate": perf_model.FusedLnModulate,
+    "primus::fused_ln_modulate_backward": perf_model.FusedLnModulateBackward,
 }
 
 

--- a/tests/test_dit_fused_ln_modulate.py
+++ b/tests/test_dit_fused_ln_modulate.py
@@ -1,0 +1,178 @@
+###############################################################################
+# Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Tests for primus::fused_ln_modulate{,_backward} (#627):
+  Fused LayerNorm + scale/shift modulation for MM-DiT / DiT-family blocks.
+"""
+
+from TraceLens.PerfModel.perf_model import (
+    FusedLnModulate,
+    FusedLnModulateBackward,
+    Normalization,
+)
+from TraceLens.PerfModel.torch_op_mapping import (
+    categorize_torch_op,
+    op_to_perf_model_class_map,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fused_ln_fwd_event(T=256, B=40, H=3072, dtype="c10::BFloat16"):
+    """
+    Build a fused_ln_modulate forward event.
+    Inputs: x:(T,B,H), scale:(B,H), shift:(B,H), eps (scalar).
+    """
+    return {
+        "name": "primus::fused_ln_modulate",
+        "args": {
+            "Input Dims": [(T, B, H), (B, H), (B, H), ()],
+            "Input type": [dtype, dtype, dtype, "Scalar"],
+        },
+    }
+
+
+def _fused_ln_bwd_event(T=256, B=40, H=3072, dtype="c10::BFloat16"):
+    """
+    Build a fused_ln_modulate_backward event.
+    Inputs: grad_out:(T,B,H), x_norm:(T,B,H), mean:(T*B,), rstd:(T*B,), mod_grad:(B,H).
+    Note: mean/rstd are per-row (one per (t,b) sample), stored as fp32.
+    """
+    return {
+        "name": "primus::fused_ln_modulate_backward",
+        "args": {
+            "Input Dims": [
+                (T, B, H),
+                (T, B, H),
+                (B * T,),
+                (B * T,),
+                (B, H),
+            ],
+            "Input type": [dtype, dtype, "float", "float", dtype],
+        },
+    }
+
+
+# ===========================================================================
+# fused_ln_modulate forward
+# ===========================================================================
+
+
+def test_fused_ln_modulate_mapping():
+    assert "primus::fused_ln_modulate" in op_to_perf_model_class_map
+    assert op_to_perf_model_class_map["primus::fused_ln_modulate"] is FusedLnModulate
+
+
+def test_fused_ln_modulate_categorizes_as_norm_fwd():
+    row = {"name": "primus::fused_ln_modulate", "kernel_details": []}
+    assert categorize_torch_op(row) == "NORM_fwd"
+
+
+def test_fused_ln_modulate_inherits_normalization():
+    assert issubclass(FusedLnModulate, Normalization)
+
+
+def test_fused_ln_modulate_flops():
+    T, B, H = 256, 40, 3072
+    model = FusedLnModulate(_fused_ln_fwd_event(T=T, B=B, H=H))
+    assert model.flops() == T * B * H * 12
+
+
+def test_fused_ln_modulate_bytes():
+    """
+    fwd bytes = read_x + write_y + read_scale_shift + write_mean_rstd
+              = 2*T*B*H*bpe + 2*B*H*bpe + 2*T*B*4
+    Mean/rstd are per-row (one per (t,b) sample), stored as fp32.
+    """
+    T, B, H = 256, 40, 3072
+    bpe = 2  # BF16
+    model = FusedLnModulate(_fused_ln_fwd_event(T=T, B=B, H=H))
+    read_x = T * B * H * bpe
+    write_y = T * B * H * bpe
+    read_scale_shift = 2 * B * H * bpe
+    write_mean_rstd = 2 * T * B * 4
+    expected = read_x + write_y + read_scale_shift + write_mean_rstd
+    assert model.bytes() == expected
+
+
+def test_fused_ln_modulate_double_stream():
+    """T=512 double-stream MM-DiT block."""
+    T, B, H = 512, 40, 3072
+    bpe = 2
+    model = FusedLnModulate(_fused_ln_fwd_event(T=T, B=B, H=H))
+    assert model.flops() == T * B * H * 12
+    expected_bytes = 2 * T * B * H * bpe + 2 * B * H * bpe + 2 * T * B * 4
+    assert model.bytes() == expected_bytes
+
+
+# ===========================================================================
+# fused_ln_modulate_backward
+# ===========================================================================
+
+
+def test_fused_ln_modulate_bwd_mapping():
+    assert "primus::fused_ln_modulate_backward" in op_to_perf_model_class_map
+    assert (
+        op_to_perf_model_class_map["primus::fused_ln_modulate_backward"]
+        is FusedLnModulateBackward
+    )
+
+
+def test_fused_ln_modulate_bwd_categorizes_as_norm_bwd():
+    row = {"name": "primus::fused_ln_modulate_backward", "kernel_details": []}
+    assert categorize_torch_op(row) == "NORM_bwd"
+
+
+def test_fused_ln_modulate_bwd_inherits_normalization():
+    assert issubclass(FusedLnModulateBackward, Normalization)
+
+
+def test_fused_ln_modulate_bwd_flops():
+    T, B, H = 256, 40, 3072
+    model = FusedLnModulateBackward(_fused_ln_bwd_event(T=T, B=B, H=H))
+    assert model.flops() == T * B * H * 15
+
+
+def test_fused_ln_modulate_bwd_bytes():
+    """
+    bwd bytes = read_grad_x_norm + read_mean_rstd + write_x_grad
+              + write_scale_shift_grad + read_mod_grad
+    """
+    T, B, H = 256, 40, 3072
+    bpe = 2
+    model = FusedLnModulateBackward(_fused_ln_bwd_event(T=T, B=B, H=H))
+    read_grad_x_norm = 2 * T * B * H * bpe
+    read_mean_rstd = 2 * B * T * 4  # fp32, per row
+    write_x_grad = T * B * H * bpe
+    write_scale_shift_grad = 2 * B * H * bpe
+    read_mod_grad = B * H * bpe
+    expected = (
+        read_grad_x_norm
+        + read_mean_rstd
+        + write_x_grad
+        + write_scale_shift_grad
+        + read_mod_grad
+    )
+    assert model.bytes() == expected
+
+
+def test_fused_ln_modulate_bwd_double_stream():
+    """T=512 double-stream block, BF16."""
+    T, B, H = 512, 40, 3072
+    bpe = 2
+    model = FusedLnModulateBackward(_fused_ln_bwd_event(T=T, B=B, H=H))
+    assert model.flops() == T * B * H * 15
+    expected = (
+        2 * T * B * H * bpe
+        + 2 * B * T * 4
+        + T * B * H * bpe
+        + 2 * B * H * bpe
+        + B * H * bpe
+    )
+    assert model.bytes() == expected


### PR DESCRIPTION
## Summary

Closes #627 (sub-issue of #516)

Add roofline support for the dominant **non-FP8** uncovered ops in Primus diffusion-model traces:

- **`primus::fused_ln_modulate`** → `Normalization` (NORM_fwd). Fused LayerNorm + scale/shift modulation for MM-DiT / DiT-family blocks in a single kernel, so it doesn't fall under `aten::layer_norm`. Input shape `(T, B, H)` with T ∈ {256, 512} (single/double-stream blocks). Memory-bandwidth bound. Bytes formula accounts for `(mean, rstd)` saved as fp32 **per row** (`2·T·B·4`), not per batch.
- **`primus::fused_ln_modulate_backward`** → `Normalization` (NORM_bwd). Backward pass with grad_out, x_norm, mean, rstd, modulation_grad inputs. Same per-row mean/rstd convention.

This pair appears across **all three** validation traces (FP8 B, FP8+selective R3, BF16 R1) with near-identical absolute cost — it's MM-DiT architectural overhead, not precision-pipeline overhead. **Closing this single gap improves coverage on every diffusion-model trace** (Flux, Wan, SDXL, future MM-DiT variants) regardless of FP8 or BF16.

### Note on the `mean`/`rstd` bytes formula

Original issue draft used `2·B` for mean/rstd reads/writes, but the trace evidence in the same issue body shows `mean:(T·B,)` and `rstd:(T·B,)` — i.e. one (mean, rstd) per row, not per batch. This PR uses the corrected `2·T·B·4` formula (fp32, per row). Issue #627 body has been updated to reflect this.

## Test plan

- [x] 12 unit tests in `tests/test_dit_fused_ln_modulate.py`: mapping, categorization, inheritance, FLOPs, bytes for both fwd and bwd across single-stream (T=256) and double-stream (T=512) shapes
- [x] `black` formatting verified
- [x] Test suite (excluding pre-existing torch-dependent and regression CSV tests): 338 passed, 2 skipped, 1 pre-existing failure (`test_origami_time_in_unified_perf_summary` — Origami integration, unrelated)
- [x] Trace-validated on 3 Flux 12B traces:
  - **BF16 mbs=24**: NORM_bwd 0 % → 6.78 % (+6.78 pp); NORM_fwd 0 % → 0.39 %; **"other" 9.39 % → 2.22 % (−7.17 pp)**
  - **FP8 mbs=40+L1**: NORM_bwd 0 % → 6.03 % (matches issue claim 6.0 %); NORM_fwd 0 % → 0.47 % (matches 0.5 %)
  - **FP8 + selective recompute**: NORM_bwd 5.48 %; NORM_fwd 0.43 %
  - New `Normalization` sheet appears in all 3 reports

Replaces the DiT half of the now-closed #628.
