### PR TITLE
Include atleast one prefill step in the split if available (Bug fix)

### DIFF
--- a/TraceLens/TraceUtils/split_inference_trace_annotation.py
+++ b/TraceLens/TraceUtils/split_inference_trace_annotation.py
@@ -386,7 +386,6 @@ def get_iter_details_from_name(name: str, prefix: str = "annotation_iteration") 
             iter_details[11],
             iter_details[13],
         )
-    # print(name,iter_details,ctx_req,ctx_sum,gen_req,gen_sum)
     return {
         "batch_size": int(ctx_sum) + int(gen_sum),
         "num_requests": int(ctx_req) + int(gen_req),
@@ -472,19 +471,34 @@ def extract_and_save(
         iter_trace, batch_list, num_gpu_events, gpu_dur, gpu_busy = extract_iteration(
             root, events, trace_json, gpu_corr_map, flow_corr_map, meta_events
         )
-        if "annotation_iteration" in prefix and len(root) == 1:
+        is_annotation = "annotation_iteration" in prefix
+        # Use the structured phase-aware name for any annotation extraction
+        # produced by the steady-state code paths (output_label is set), and
+        # for any multi-step annotation window. Single-step annotations from
+        # --store-single-iteration keep their literal step name.
+        is_structured = is_annotation and (output_label is not None or len(root) > 1)
+
+        if is_structured or not is_annotation:
+            if len(batch_list) == len(iter_details):
+                for bs, iteration in zip(batch_list, iter_details):
+                    iteration["batch_size"] = bs
+
+        phase_details = find_phase_from_window(iter_details)
+
+        if is_structured:
+            name_append = (
+                f"prefill_{phase_details['num_prefill']}"
+                f"_prefilldecode_{phase_details['num_prefilldecode']}"
+                f"_decode_{phase_details['num_decode']}"
+                f"_bs{phase_details['avg_bs']}_conc{phase_details['avg_conc']}"
+            )
+        elif is_annotation and len(root) == 1:
             name_append = root[0]["name"].replace("(", "_").replace(")", "")
         else:
             if len(batch_list) == len(iter_details):
                 name_append = f"batch{int(sum(batch_list)/len(batch_list))}_gpu{prefix}"
-                for bs, iteration in zip(batch_list, iter_details):
-                    iteration["batch_size"] = bs
             else:
                 name_append = f"batch_NA_gpu{prefix}"
-
-        phase_details = find_phase_from_window(iter_details)
-        if "annotation_iteration" in prefix and len(root) > 1:
-            name_append = f"prefilldecode_{phase_details['num_prefilldecode']}_decode_{phase_details['num_decode']}_bs{phase_details['avg_bs']}_conc{phase_details['avg_conc']}"
 
         if output_label is not None:
             out_path = os.path.join(
@@ -930,6 +944,15 @@ def find_steady_state_window(
     # Build candidate sub-windows from the largest region
     candidates = []
     s, e = largest_start, largest_end
+
+    def _count_mixed(window: List[dict]) -> int:
+        """Count truly-mixed steps (both context and generation requests > 0)."""
+        return sum(
+            1
+            for t in window
+            if t.get("context_requests", 0) > 0 and t.get("generation_requests", 0) > 0
+        )
+
     if (e - s) >= num_steps:
         for s1 in range(s, e - num_steps + 1, step):
             window = iter_details[s1 : s1 + num_steps]
@@ -940,6 +963,7 @@ def find_steady_state_window(
                     "end": s1 + num_steps,
                     "pd_count": pd_count,
                     "pd_ratio": pd_count / num_steps,
+                    "mixed_count": _count_mixed(window),
                     "avg_requests": mean(t["num_requests"] for t in window),
                 }
             )
@@ -953,6 +977,7 @@ def find_steady_state_window(
                 "end": e,
                 "pd_count": pd_count,
                 "pd_ratio": pd_count / len(window) if window else 0.0,
+                "mixed_count": _count_mixed(window),
                 "avg_requests": (
                     mean(t["num_requests"] for t in window) if window else 0
                 ),
@@ -960,14 +985,34 @@ def find_steady_state_window(
         )
 
     if mode == "mixed":
+        # Prefer candidate windows that contain at least one prefill-bearing
+        # step (pure prefill OR truly mixed, i.e. context_requests > 0). Fall
+        # back to all candidates only when no window contains any prefill
+        # activity at all.
+        pd_candidates = [c for c in candidates if c["pd_count"] > 0]
+        if pd_candidates:
+            print(
+                f"[mixed] Filtering to {len(pd_candidates)}/{len(candidates)} "
+                f"candidate windows that contain at least one prefill or "
+                f"prefill-decode step."
+            )
+            selection_pool = pd_candidates
+        else:
+            print(
+                "[mixed] No candidate window contains a prefill or prefill-decode "
+                "step; falling back to the full candidate set."
+            )
+            selection_pool = candidates
+
         best = min(
-            candidates,
+            selection_pool,
             key=lambda c: (abs(c["pd_ratio"] - reference_ratio), -c["avg_requests"]),
         )
         print(
             f"[mixed] Selected window [{best['start']}, {best['end']}): "
             f"prefilldecodemix_to_totalsteps_ratio={best['pd_ratio']:.3f} (target={reference_ratio:.3f}), "
-            f"avg_requests={best['avg_requests']:.1f}"
+            f"avg_requests={best['avg_requests']:.1f}, "
+            f"pd_count={best['pd_count']}, mixed_count={best['mixed_count']}"
         )
 
     elif mode == "decode_only":


### PR DESCRIPTION
### Fix mixed steady-state window selection and naming in `split_inference_trace_annotation.py`

- **Mixed-window selection**: filter candidate windows to those containing at least one prefill-bearing step (`context_requests > 0`, i.e. pure prefill or truly-mixed). Previously the selection's `pd_count` definition (any context > 0) and the naming's `num_prefilldecode` definition (context AND generation > 0) were inconsistent, so on traces where prefill steps are sparse the `mixed_steady_state_*` window was often selected with zero prefill activity. Falls back to the full candidate pool only when no window in the largest steady-state region contains any prefill step.
- **Steady-state filename format**: unify all `--find-steady-state` outputs (mixed / decode_only / prefilldecode) on `prefill_X_prefilldecode_Y_decode_Z_bsA_concB`, including 1-step max-PD windows that previously fell back to the literal step name. The new `prefill_X_` prefix surfaces pure-prefill counts that were previously hidden under `num_prefilldecode = 0` in the filename.
- `--store-single-iteration` and `--dummy` outputs are unchanged.
<!--
Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.

See LICENSE for license information.
-->

