### PR TITLE
Require TraceLens code owner review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,6 @@
 # Default — every file requires project-team approval
 *                            @AMD-AGI/perf-opt
 # Stricter paths — leads must approve
+
+# TraceLens package changes require Adeem or Gabe review
+/TraceLens/                   @ajassani @gabeweisz

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,6 +8,10 @@
 # TraceLens package changes require Adeem or Gabe review
 /TraceLens/                   @ajassani @gabeweisz
 
+# TraceDiff module and docs require Spandoe review
+/TraceLens/TraceDiff/         @spandoesai
+/docs/TraceDiff.md            @spandoesai
+
 # Inference reporting, docs, tests, and workflows require Deval review
 /TraceLens/Reporting/generate_perf_report_pytorch_inference.py @devalshahamd
 /TraceLens/TraceUtils/split_inference_trace_annotation.py      @devalshahamd

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,6 +8,10 @@
 # TraceLens package changes require Adeem or Gabe review
 /TraceLens/                   @ajassani @gabeweisz
 
-# Inference reporting and workflows require Deval review
+# Inference reporting, docs, tests, and workflows require Deval review
 /TraceLens/Reporting/generate_perf_report_pytorch_inference.py @devalshahamd
+/TraceLens/TraceUtils/split_inference_trace_annotation.py      @devalshahamd
 /examples/custom_workflows/inference_analysis/               @devalshahamd
+/docs/Inference_analysis.md                                  @devalshahamd
+/tests/test_inference_perf_report.py                         @devalshahamd
+/tests/traces/inference/                                     @devalshahamd

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,3 +7,7 @@
 
 # TraceLens package changes require Adeem or Gabe review
 /TraceLens/                   @ajassani @gabeweisz
+
+# Inference reporting and workflows require Deval review
+/TraceLens/Reporting/generate_perf_report_pytorch_inference.py @devalshahamd
+/examples/custom_workflows/inference_analysis/               @devalshahamd

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@
 # TraceLens package changes require Adeem or Gabe review
 /TraceLens/                   @ajassani @gabeweisz
 
-# TraceDiff module and docs require Spandoe review
+# TraceDiff module and docs require Spandan review
 /TraceLens/TraceDiff/         @spandoesai
 /docs/TraceDiff.md            @spandoesai
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,6 +12,11 @@
 /TraceLens/TraceDiff/         @spandoesai
 /docs/TraceDiff.md            @spandoesai
 
+# Extensions and experimental trace merge require Deval review
+/TraceLens/PerfModel/extensions/                         @devalshahamd
+/TraceLens/Trace2Tree/extensions/                        @devalshahamd
+/TraceLens/Trace2Tree/trace_capture_merge_experimental.py @devalshahamd
+
 # Inference reporting, docs, tests, and workflows require Deval review
 /TraceLens/Reporting/generate_perf_report_pytorch_inference.py @devalshahamd
 /TraceLens/TraceUtils/split_inference_trace_annotation.py      @devalshahamd


### PR DESCRIPTION
## Summary
- Add a CODEOWNERS rule so changes under `TraceLens/` request review from `@ajassani` or `@gabeweisz`.
- Add `@devalshahamd` ownership for inference reporting, docs, tests, trace fixtures, and inference custom workflow examples.
- Add `@devalshahamd` ownership for PerfModel extensions, Trace2Tree extensions, and the experimental trace capture merge script.
- Add `@spandoesai` ownership for the TraceDiff module and docs.
- Prepare for incoming large TraceLens PRs so changes do not skip targeted review.

## Test plan
- Not run; CODEOWNERS-only configuration change.