### PR TITLE
Route agent code reviews to area owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,7 +10,7 @@
 
 # Agent code and evals require area owner review
 /TraceLens/Agent/             @tsrikris
-/agent_evals/                 @Ahmedhasssan-aig
+/agent_evals/                 @Ahmedhasssan-aig @tsrikris
 
 # TraceDiff module and docs require Spandan review
 /TraceLens/TraceDiff/         @spandoesai

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,6 +8,10 @@
 # TraceLens package changes require Adeem or Gabe review
 /TraceLens/                   @ajassani @gabeweisz
 
+# Agent code and evals require area owner review
+/TraceLens/Agent/             @tsrikris
+/agent_evals/                 @Ahmedhasssan-aig
+
 # TraceDiff module and docs require Spandan review
 /TraceLens/TraceDiff/         @spandoesai
 /docs/TraceDiff.md            @spandoesai


### PR DESCRIPTION
## Summary
- Adds CODEOWNERS coverage for `/TraceLens/Agent/` to route agent code changes to `@tsrikris`.
- Adds CODEOWNERS coverage for `/agent_evals/` to route agent eval changes to `@Ahmedhasssan-aig`.

## Test plan
- Not run; CODEOWNERS-only change.