### PR TITLE
Align impact score labels across classes

### DIFF
--- a/TraceLens/Agent/Analysis/utils/templates/analysis_template.md
+++ b/TraceLens/Agent/Analysis/utils/templates/analysis_template.md
@@ -49,7 +49,7 @@ section that has STANDALONE / COMPARATIVE variants. Delete the unused variant.
    OPTIMIZATION CARDS (§Compute Kernel Optimizations, §Kernel Fusion, §System-Level):
    - Compute Kernel P-items: **Insight** / **Action** / **Impact**
    - Kernel Fusion P-items:  **Insight** / **Action** / **Impact** / **Confidence**
-   - System-Level P-items:   **Insight** / **Action**
+   - System-Level P-items:   **Insight** / **Action** / **Impact**
 
    DETAILED ANALYSIS (§Detailed Analysis only):
    - Compute / System blocks: **Identification:** / **Data:** / **Reasoning for Slowdown:** / **Resolution:** / **Impact estimate:**
@@ -278,7 +278,7 @@ communication/compute overlap). These affect the GPU pipeline as a whole.
 <!-- Otherwise, number priorities sequentially: CPU/Idle first (if idle > 15%), then multi-kernel issues by severity. -->
 <!-- Icon mapping by PRIORITY NUMBER (not severity): P1=🔴, P2=🟡, P3+=🟢 -->
 <!-- Title format: Descriptive name only. -->
-<!-- System-level recommendations have NO **Impact** field -- impact is not quantifiable for system-level issues. -->
+<!-- System-level recommendations always include **Impact**: "Not quantifiable from trace data" with null markers. -->
 
 <!-- === TEMPLATE A: No actionable system-level issues === -->
 <!-- Use this when idle <= 15% and all multi-kernel assessments have flagged: false -->
@@ -294,6 +294,10 @@ communication/compute overlap). These affect the GPU pipeline as a whole.
 
 **Action**: [1-2 sentences - what to do]
 
+<!-- impact-begin kind=p_item low=null mid=null high=null -->
+**Impact**: Not quantifiable from trace data
+<!-- impact-end -->
+
 → *See [Detailed Analysis: System-level insights > P1](#detailed-analysis-system-p1) for details*
 
 ---
@@ -304,6 +308,10 @@ communication/compute overlap). These affect the GPU pipeline as a whole.
 
 **Action**: [1-2 sentences - what to do]
 
+<!-- impact-begin kind=p_item low=null mid=null high=null -->
+**Impact**: Not quantifiable from trace data
+<!-- impact-end -->
+
 → *See [Detailed Analysis: System-level insights > P2](#detailed-analysis-system-p2) for details*
 
 ---
@@ -313,6 +321,10 @@ communication/compute overlap). These affect the GPU pipeline as a whole.
 **Insight**: [1 sentence]
 
 **Action**: [1-2 sentences]
+
+<!-- impact-begin kind=p_item low=null mid=null high=null -->
+**Impact**: Not quantifiable from trace data
+<!-- impact-end -->
 
 → *See [Detailed Analysis: System-level insights > P3](#detailed-analysis-system-p3) for details*
 

--- a/TraceLens/Agent/Analysis/utils/templates/sub_agent_spec.md
+++ b/TraceLens/Agent/Analysis/utils/templates/sub_agent_spec.md
@@ -46,13 +46,13 @@ Each P-item maps 1:1 to a `## Detailed Analysis` reasoning candidate at the same
 **Insight**: [1 sentence — what's wrong]
 **Action**: [1-2 sentences — what to do]
 <!-- impact-begin kind=p_item low=<impact_score_low> mid=<impact_score> high=<impact_score_high> -->
-**Impact**: [impact_score: X.X, OR "Not quantifiable from trace data"]   <!-- compute tier only -->
+**Impact**: [impact_score: X.X, OR "Not quantifiable from trace data"]
 <!-- impact-end -->
 ```
 
 - **Compute tier**: include all three fields. Pull `**Impact**` from `category_data/<category>_metrics.json::category_findings[i]`, ordered by `rank` (one card per entry).
-- **System tier**: omit `**Impact**` and the `(<Library>)` title suffix. System-tier P-items still wrap `**Impact**` in `kind=p_item` markers when they choose to emit one (typically as `Not quantifiable from trace data`); see § Impact markers (REQUIRED) below.
-- **Field labels are exact** — always `**Insight**`, `**Action**`, `**Impact**`.
+- **System tier**: omit the `(<Library>)` title suffix. Always emit `**Impact**: Not quantifiable from trace data` wrapped in `kind=p_item` markers with `low=null mid=null high=null`.
+- **Field labels are exact** — `**Insight**`, `**Action**`, `**Impact**`.
 - **`(<Library>)` suffix**: the single `category_findings[i].library` for this card (one library per finding by construction). Omit the parenthetical when the value is `Unknown`.
 - **Marker required** — see § Impact markers (REQUIRED). The `low`/`mid`/`high` attributes carry the raw `impact_score_low/impact_score/impact_score_high` values from `category_findings[i]`. For non-quantifiable cards (system tier) use `low=null mid=null high=null`.
 
@@ -224,7 +224,7 @@ Do not look up peaks independently from the metadata dict.
 
 ---
 
-## Impact Estimates
+## Impact estimate rendering
 
 Compute-tier sub-agents READ their P-items from `category_data/<category>_metrics.json::category_findings[]`, one card per entry ordered by `rank`. The analyzer script has already grouped per-op estimates by `(bound_type, library)`, summed impact, and dropped sub-threshold groups; the sub-agent renders one card per surviving entry.
 

--- a/TraceLens/Agent/Analysis/utils/validation_utils.py
+++ b/TraceLens/Agent/Analysis/utils/validation_utils.py
@@ -32,7 +32,7 @@ from .report_utils import load_manifest, _scan_findings_dir
 
 _REQUIRED_FINDINGS_HEADERS = ["## Recommendations", "## Detailed Analysis"]
 _COMPUTE_P_ITEM_LABELS = ["**Insight**", "**Action**", "**Impact**"]
-_SYSTEM_P_ITEM_LABELS = ["**Insight**", "**Action**"]
+_SYSTEM_P_ITEM_LABELS = ["**Insight**", "**Action**", "**Impact**"]
 _KERNEL_FUSION_FINDINGS = "kernel_fusion_findings.md"
 # Optional icon / prefix before P<N> (e.g. kernel fusion `### 🟢 P1:`).
 _P_ITEM_RE = re.compile(r"^### .*?P(\d+)\s*:", re.MULTILINE)
@@ -132,7 +132,7 @@ def validate_findings_file(filepath, tier, comparison_scope=None):
 
     Checks:
     - Required ## headers present and in correct order
-    - P-item labels match tier (compute: Insight/Action/Impact; system: Insight/Action)
+    - P-item labels match tier (all tiers: Insight/Action/Impact)
     - At least one reasoning-candidate block in Detailed Analysis
       (unless compute tier and ``category_findings`` is ``[]`` in ``*_metrics.json``)
     - P-item count matches reasoning-candidate count
@@ -194,16 +194,6 @@ def validate_findings_file(filepath, tier, comparison_scope=None):
                         f"Missing label {label} in ## Recommendations "
                         f"(required for {tier} tier)"
                     )
-
-        # Kernel fusion (system_findings) uses roofline-backed **Impact** on P-items.
-        if (
-            tier == "system"
-            and "**Impact**" in rec_section
-            and os.path.basename(filepath) != _KERNEL_FUSION_FINDINGS
-        ):
-            errors.append(
-                "System-tier ## Recommendations must not contain **Impact** labels"
-            )
 
     candidates = []
     if da_start >= 0:

--- a/agent_evals/Analysis/eval_utils/report_section_rules.yaml
+++ b/agent_evals/Analysis/eval_utils/report_section_rules.yaml
@@ -47,7 +47,7 @@ standalone_section_rules:
 failure_mode_rules:
   - match_regex: "(?i)not\\s+quantifiable|impact\\s+estimate"
     likely_cause: "Impact estimate data exists but is not consistently rendered into final cards."
-    suggested_fix: "Add a guardrail to prefer pre-computed impact estimates from metadata before falling back to non-quantifiable text."
+    suggested_fix: "Verify the sub-agent emitted impact markers with correct low/high values from category_findings[]."
   - match_regex: "(?i)efficiency|alignment"
     likely_cause: "Generated reasoning drifts from metrics JSON or reference wording."
     suggested_fix: "Add a final consistency pass that checks efficiency, shapes, and gains against metrics artifacts."


### PR DESCRIPTION
## Summary

Resolves contradicting instructions about the `**Impact**` label on system-tier P-item cards. Templates, validator, and eval guidance disagreed on whether system-level recommendations should emit `**Impact**` (sub_agent_spec said "omit" and "always" in consecutive bullets; analysis_template said "NO **Impact** field"; the validator rejected it). This PR makes all three tiers (compute, kernel-fusion, system) consistently emit `**Impact**` on every card, with system tier always using `Not quantifiable from trace data` inside `kind=p_item` markers with `low=null mid=null high=null`. Also renames the `## Impact Estimates` section heading in the sub-agent spec to `## Impact estimate rendering` to eliminate naming confusion with the `**Impact estimate:**` field label, and updates a stale eval rule.

4 files changed, +21 insertions, −19 deletions.

## Why

| Pain point | Old | New |
|---|---|---|
| Two consecutive bullets in `sub_agent_spec.md` contradicted each other for system tier | L42 said "omit `**Impact**`" while L43 said "Field labels are exact — **always** `**Insight**`, `**Action**`, `**Impact**`". Sub-agents receiving both instructions produced inconsistent output — sometimes emitting Impact, sometimes omitting it. | L42 rewritten: "Always emit `**Impact**: Not quantifiable from trace data` wrapped in `kind=p_item` markers with `low=null mid=null high=null`." L43 drops "always" since the rule is now simply true. |
| Orchestrator template forbade the label that the sub-agent spec sometimes told agents to emit | `analysis_template.md` L281: `<!-- System-level recommendations have NO **Impact** field -->` and rule 9 listed system labels as `**Insight** / **Action**` only — no `**Impact**`. The validator enforced this by rejecting `**Impact**` in system-tier Recommendations. | Rule 9 updated to `**Insight** / **Action** / **Impact**` for system tier. L281 comment flipped. All three system card skeletons (P1/P2/P3) now include `<!-- impact-begin kind=p_item low=null mid=null high=null -->` markers around the Impact line. |
| Eval checklist card-vs-detail consistency check was undefined for system tier | "Card **Impact** range is consistent with Detailed Analysis **Impact estimate** bullets" — but system cards had no `**Impact**` while Detailed Analysis always had `**Impact estimate:**`. Evaluators couldn't apply the check. | Now universally applicable: system cards emit `**Impact**: Not quantifiable from trace data` and Detailed Analysis emits `**Impact estimate:** Impact estimate is not quantifiable from trace data.` — both say "not quantifiable". |
| Section heading `## Impact Estimates` confused the LLM about the `**Impact estimate:**` field label | The heading (plural, title-case) governed a rendering-rules section but looked like it could be a report section the LLM should emit. | Renamed to `## Impact estimate rendering` to disambiguate from the field label. |
| Eval rule suggested a guardrail that already exists | `report_section_rules.yaml` L50: "Add a guardrail to prefer pre-computed impact estimates from metadata before falling back to non-quantifiable text" — this is exactly what the marker pipeline does. | Updated to: "Verify the sub-agent emitted impact markers with correct low/high values from category_findings[]." |

## What changed

### Python (1 file)

| File | Change |
|---|---|
| `TraceLens/Agent/Analysis/utils/validation_utils.py` | `_SYSTEM_P_ITEM_LABELS` updated from `["**Insight**", "**Action**"]` to `["**Insight**", "**Action**", "**Impact**"]`. Deleted the 8-line block that rejected `**Impact**` in system-tier `## Recommendations` (with its kernel-fusion exemption). Docstring updated to reflect all tiers requiring Insight/Action/Impact. |

### Templates (2 files)

| File | Change |
|---|---|
| `TraceLens/Agent/Analysis/utils/templates/analysis_template.md` | Rule 9: system-level card labels changed from `**Insight** / **Action**` to `**Insight** / **Action** / **Impact**`. L281 comment flipped from "have NO **Impact** field" to "always include **Impact**". System card skeletons P1/P2/P3 each gain a `<!-- impact-begin kind=p_item low=null mid=null high=null -->` / `**Impact**: Not quantifiable from trace data` / `<!-- impact-end -->` block between `**Action**` and the Detailed Analysis link. |
| `TraceLens/Agent/Analysis/utils/templates/sub_agent_spec.md` | L42: "omit `**Impact**`" rewritten to "Always emit `**Impact**: Not quantifiable from trace data`". L43: "always" dropped from field-labels bullet. L49: `<!-- compute tier only -->` comment removed from the code-block example. Section heading `## Impact Estimates` renamed to `## Impact estimate rendering`. |

### Eval rules (1 file)

| File | Change |
|---|---|
| `agent_evals/Analysis/eval_utils/report_section_rules.yaml` | L50: stale `suggested_fix` replaced from "Add a guardrail…" to "Verify the sub-agent emitted impact markers…". |

## Net diff

```
4 files changed, 21 insertions(+), 19 deletions(-)
```
