### PR TITLE
Separate P-item by efficiency range

### DIFF
--- a/TraceLens/Agent/Analysis/.cursor/agents/kernel-fusion-analyzer.md
+++ b/TraceLens/Agent/Analysis/.cursor/agents/kernel-fusion-analyzer.md
@@ -76,7 +76,7 @@ Then read `<output_dir>/category_data/kernel_fusion_metrics.json`. The `impact_e
 - `time_ms`: Total candidate time across all instances
 - `warning`: Present when some kernels lack perf models
 
-If `impact_estimates` is empty, skip Steps 2-3 entirely and write the "No fusion opportunities detected" template (see Step 4 fallback).
+If `impact_estimates` is empty (or `status` is `NO_DATA`), skip Steps 2-4 entirely. Write **only** the three-line fallback file shown at the end of Step 4 — no P-item cards, no Detailed Analysis blocks, no Impact Summary table. Just the `# heading`, blank line, and the single sentence "No kernel fusion opportunities detected."
 
 For each entry in `impact_estimates`, look up the matching candidate in `<output_dir>/category_data/fusion_candidates.json` by `base_name == operation` to pull the descriptive fields used in Steps 2-4:
 
@@ -251,12 +251,15 @@ Found N kernel fusion opportunities across M module types.
 |---------------|------|----------------------|-------------------------------|------------|
 ```
 
-If no fusion opportunities detected:
+**If `impact_estimates` is empty or `status` is `NO_DATA`:** write exactly this file and nothing else — no P-item cards, no `## Recommendations`, no `## Detailed Analysis`, no `## Impact Summary`:
+
 ```markdown
 # Kernel Fusion Analysis Summary (Experimental)
 
 No kernel fusion opportunities detected.
 ```
+
+Then proceed directly to Step 4.1 validation.
 
 ### Step 4.1: Validate Findings
 

--- a/TraceLens/Agent/Analysis/category_analyses/analysis_utils.py
+++ b/TraceLens/Agent/Analysis/category_analyses/analysis_utils.py
@@ -36,6 +36,7 @@ TARGET_MID = 87.5
 MIN_PITEM_IMPACT_SCORE = (
     0.5  # Group-sum (% E2E) below which a finding is dropped from priority_data.json.
 )
+_EFF_BUCKET_BOUNDARIES = (30, 60)
 
 _OP_NAME_LIBRARY_RULES = [
     ("aiter::", "AITER"),
@@ -59,6 +60,17 @@ _KERNEL_NAME_LIBRARY_RULES = [
 ]
 _COMPARATIVE_SPEEDUP_COL = "speedup (trace2/trace1)"
 _COMPARATIVE_DELTA_COL = "delta_us (trace2 - trace1)"
+
+
+def _eff_bucket(pct):
+    """Classify roofline efficiency into a coarse band for P-item grouping."""
+    if pct is None:
+        return "unknown"
+    if pct < _EFF_BUCKET_BOUNDARIES[0]:
+        return "0-30"
+    if pct < _EFF_BUCKET_BOUNDARIES[1]:
+        return "30-60"
+    return "60-100"
 
 
 def perf_report_csv_dir(output_dir: str) -> str:
@@ -685,8 +697,15 @@ def compute_impact_estimates(
     return sorted(estimates, key=lambda x: x["impact_score"], reverse=True)
 
 
-def build_category_findings(estimates: List[dict]) -> List[dict]:
-    """Group one category's per-op impact estimates by (bound_type, library).
+def build_category_findings(
+    estimates: List[dict], comparison_scope: str = "standalone"
+) -> List[dict]:
+    """Group one category's per-op impact estimates into P-item findings.
+
+    Standalone mode groups by ``(bound_type, library, eff_bucket)`` so
+    kernels at different roofline-efficiency levels get separate P-items.
+    Comparative mode groups by ``(bound_type, library)`` only because
+    ``efficiency_pct`` represents a trace-time ratio, not roofline utilization.
 
     Sums impact across members, drops groups below ``MIN_PITEM_IMPACT_SCORE``,
     sorts by ``impact_score`` desc, attaches intra-category ``rank``. Each
@@ -694,6 +713,7 @@ def build_category_findings(estimates: List[dict]) -> List[dict]:
     later concatenates these arrays across categories to derive the global
     ``priority_data.json::findings[]`` ranking.
     """
+    use_eff_bucket = comparison_scope == "standalone"
     groups: dict = defaultdict(
         lambda: {
             "members": [],
@@ -703,7 +723,10 @@ def build_category_findings(estimates: List[dict]) -> List[dict]:
         }
     )
     for e in estimates:
-        key = (e.get("bound_type") or "unknown", e.get("library") or "Unknown")
+        bound = e.get("bound_type") or "unknown"
+        lib = e.get("library") or "Unknown"
+        bucket = _eff_bucket(e.get("efficiency_pct")) if use_eff_bucket else "all"
+        key = (bound, lib, bucket)
         g = groups[key]
         g["members"].append(e)
         g["impact_score"] += e.get("impact_score", 0)
@@ -711,13 +734,14 @@ def build_category_findings(estimates: List[dict]) -> List[dict]:
         g["impact_score_high"] += e.get("impact_score_high", 0)
 
     findings = []
-    for (bound, lib), g in groups.items():
+    for (bound, lib, bucket), g in groups.items():
         if g["impact_score"] < MIN_PITEM_IMPACT_SCORE:
             continue
         findings.append(
             {
                 "bound_type": bound,
                 "library": lib,
+                "eff_bucket": bucket,
                 "impact_score": round(g["impact_score"], 2),
                 "impact_score_low": round(g["impact_score_low"], 2),
                 "impact_score_high": round(g["impact_score_high"], 2),
@@ -909,7 +933,7 @@ def run_category_analysis(
     else:
         impact_estimates = []
 
-    category_findings = build_category_findings(impact_estimates)
+    category_findings = build_category_findings(impact_estimates, comparison_scope=comparison_scope)
 
     metrics = {
         "category": category,

--- a/TraceLens/Agent/Analysis/category_analyses/other_analysis.py
+++ b/TraceLens/Agent/Analysis/category_analyses/other_analysis.py
@@ -164,7 +164,7 @@ def main():
         category,
         baseline_ms=baseline_ms,
     )
-    category_findings = build_category_findings(impact_estimates)
+    category_findings = build_category_findings(impact_estimates, comparison_scope=args.comparison_scope)
 
     metrics = {
         "category": category,

--- a/TraceLens/Agent/Analysis/utils/report_utils.py
+++ b/TraceLens/Agent/Analysis/utils/report_utils.py
@@ -188,9 +188,8 @@ def generate_priority_data(output_dir: str, max_recommendations: int = 6) -> str
     table, and the optional detailed extension plot.
 
     Produces four top-level arrays:
-      - ``findings``: per-(category, bound_type, library) groups, concatenated
-        from each ``_metrics.json::category_findings`` (already grouped and
-        gated by ``MIN_PITEM_IMPACT_SCORE`` in the analyzer script). Sorted
+      - ``findings``: per-(category, bound_type, library, eff_bucket) groups
+        from each ``_metrics.json::category_findings``. Sorted
         globally by ``impact_score`` with ``global_rank`` / ``category_rank``
         attached. Drives the report's flat P-numbering.
       - ``priorities``: ranked category list. Quantified categories are a

--- a/TraceLens/Agent/Analysis/utils/templates/sub_agent_spec.md
+++ b/TraceLens/Agent/Analysis/utils/templates/sub_agent_spec.md
@@ -226,7 +226,7 @@ Do not look up peaks independently from the metadata dict.
 
 ## Impact estimate rendering
 
-Compute-tier sub-agents READ their P-items from `category_data/<category>_metrics.json::category_findings[]`, one card per entry ordered by `rank`. The analyzer script has already grouped per-op estimates by `(bound_type, library)`, summed impact, and dropped sub-threshold groups; the sub-agent renders one card per surviving entry.
+Compute-tier sub-agents READ their P-items from `category_data/<category>_metrics.json::category_findings[]`, one card per entry ordered by `rank`. The analyzer script has already grouped per-op estimates by `(bound_type, library, eff_bucket)` in standalone mode (or `(bound_type, library)` in comparative mode), summed impact, and dropped sub-threshold groups; the sub-agent renders one card per surviving entry.
 
 The set of P-items is decided by `category_findings[]` alone — `MIN_PITEM_IMPACT_SCORE` already gated upstream. **Per-category efficiency tables, expected-band thresholds, and Common Patterns in analyzer files are interpretation context for the prose** (cite in **Reasoning for Slowdown** when a member matches the band/symptom); they MUST NOT be used to add or drop P-items.
 
@@ -237,6 +237,7 @@ The set of P-items is decided by `category_findings[]` alone — `MIN_PITEM_IMPA
 | `rank` | Card order within your category (1 = highest impact). Also the `rank=` value in `<!-- reasoning-candidate -->`. |
 | `bound_type` | `compute` \| `memory`. Selects the matching Action Prose Guidance row. |
 | `library` | One per finding. Drives the `(<Library>)` title suffix. |
+| `eff_bucket` | Roofline-efficiency band: `"0-30"`, `"30-60"`, `"60-100"`, or `"unknown"` (standalone); `"all"` (comparative). Members within a finding share the same band. |
 | `impact_score` / `_low` / `_high` | Group-summed % of E2E. Render verbatim into `kind=p_item` and `kind=detail_estimate` markers. |
 | `member_count`, `members[]` | Underlying per-op estimate rows (operation, time_ms, efficiency_pct, …) — rows of the `**Data:**` table. |
 


### PR DESCRIPTION
## Summary

Adds `eff_bucket` as a third grouping key to standalone-mode P-item aggregation so kernels at different roofline-efficiency levels (0-30%, 30-60%, 60-100%) get separate P-items instead of being lumped into one card. Comparative mode is unaffected — `efficiency_pct` there is a trace-time ratio, not roofline utilization. 

5 files changed, +39 insertions, −12 deletions.

## What changed

### Python (2 files)

| File | Change |
|---|---|
| `category_analyses/analysis_utils.py` | Add `_EFF_BUCKET_BOUNDARIES`, `_eff_bucket()`. `build_category_findings()` gains `comparison_scope`; standalone groups by `(bound_type, library, eff_bucket)`, comparative by `(bound_type, library, "all")`. |
| `category_analyses/other_analysis.py` | Thread `comparison_scope` to `build_category_findings()`. |

### Templates (2 files)

| File | Change |
|---|---|
| `utils/report_utils.py` | Docstring updated to reflect `eff_bucket` in grouping key. |
| `utils/templates/sub_agent_spec.md` | `eff_bucket` row added to "Reading category_findings[]" table; grouping description updated. |

### Sub-agent .md files (1)

| File | Change |
|---|---|
| `.cursor/agents/kernel-fusion-analyzer.md` | Strengthen empty-`impact_estimates` gate to explicitly forbid P-item cards, Detailed Analysis, and Impact Summary when no candidates exist. |

## Net diff

```
5 files changed, 39 insertions(+), 12 deletions(-)
```
