### PR TITLE
fix: handle FP8 damax tuple outputs and /*index=N*/ operand refs in process_gemm_ops

### DIFF
--- a/TraceLens/util.py
+++ b/TraceLens/util.py
@@ -313,18 +313,26 @@ class JaxProfileProcessor:
                 if outputs.startswith("("):
                     if not outputs.endswith(")"):
                         raise ValueError("Mistmatched parens in outputs in ", outputs)
-                    output_list = outputs[1:-2].split("},")
-                    # this code assumes that the first output is the one we care about
-                    # we should be able to make this an RE
-                    sizes_string = [
-                        [i, d] for i in output_list for d in dtypes if i.startswith(d)
+                    # Extract all tensor tokens from the tuple using regex so that
+                    # scalars (e.g. f32[]) and workspace buffers (e.g. s8[N]{0})
+                    # don't corrupt the split. Handles damax_output=true tuples like
+                    # (f8e5m2[M,N]{1,0}, f32[], s8[W]{0}).
+                    inner = outputs[1:-1]
+                    tokens = re.findall(
+                        r"[a-z0-9]+\[[^\]]*\]\{[^}]*\}|[a-z0-9]+\[[^\]]*\]", inner
+                    )
+                    tensor_tokens = [
+                        t
+                        for t in tokens
+                        if any(t.startswith(d) for d in dtypes) and not t.endswith("[]")
                     ]
-                    if len(sizes_string) != 1:
+                    if len(tensor_tokens) == 0:
                         raise ValueError("Did not find wide output ", op)
-                    sizes_string = sizes_string[0]
-                    sizes_string[0] = (
-                        sizes_string[0] + "}"
-                    )  # restore the } that was removed
+                    # Take the first tensor output; for FP8 GEMMs this is the result.
+                    sizes_string = [
+                        tensor_tokens[0],
+                        next(d for d in dtypes if tensor_tokens[0].startswith(d)),
+                    ]
                 else:
                     sizes_string = outputs
                 operand_list = []
@@ -332,12 +340,16 @@ class JaxProfileProcessor:
                     if "[" in opid and "]" in opid:
                         # pb format, shapes in operand list
                         operand_list.append(opid)
-                    else:
-                        output = hlo_ops[opid]["output"]
+                    elif "[" not in opid:
+                        # Strip /*index=N*/ prefix that appears in some FP8 operand refs
+                        hlo_key = re.sub(r"^/\*index=\d+\*/", "", opid).strip()
+                        if hlo_key not in hlo_ops:
+                            continue
+                        output = hlo_ops[hlo_key]["output"]
                         if any(
                             output.startswith(d) for d in dtypes + ["f8"]
                         ) and not output.endswith("[]"):
-                            operand_list.append(hlo_ops[opid]["output"])
+                            operand_list.append(hlo_ops[hlo_key]["output"])
                 if int(beta) == 1 and len(operand_list) < 3:
                     print(
                         "Bias is set, however onLy two operands found!", op


### PR DESCRIPTION
### Problem 
End-to-end xlsx report generation with a mixtral 8x7B FP8 Jax profile (B300, JAX 26.04, FP8) crashed at `process_gemm_ops`.

### Summary 
FP8 GEMMs with `damax_output=true` return a tuple output rather than a single tensor: `(f8e5m2[M,N]{1,0}, f32[], s8[W]{0})`: the result tensor, an amax scalar, and a workspace buffer. The existing
  parser split on `}`, assuming all tuple elements have `{}` layout annotations, but scalars like `f32[]` have none. This caused the split to lump multiple elements together, producing more than one
  `dtype` match and raising `ValueError: Did not find wide output`.

  Fixed by replacing the split with a regex tokeniser that extracts all `dtype[shape]{layout}` and `dtype[shape]` tokens from the tuple, filters out scalars, and takes the first non-scalar tensor as the result.

  Also fixed a related `KeyError`: some operand references in these FP8 GEMMs carry a `/*index=N*/` tuple-element prefix (e.g. `/*index=5*/%gte.remat.13`). The prefix wasn't being stripped before the `hlo_ops` dict lookup. The fix strips it with a regex and skips the operand gracefully if the base name still isn't present.

### Files Changed

`TraceLens/util.py`,  `JaxProfileProcessor.process_gemm_ops()`  specifically 

  ---
 ### Fix 1: Tuple output parsing (`damax_output=true`)
```
  ## Before
  output_list = outputs[1:-2].split("},")
  # this code assumes that the first output is the one we care about
  # we should be able to make this an RE
  sizes_string = [
      [i, d] for i in output_list for d in dtypes if i.startswith(d)
  ]
  if len(sizes_string) != 1:
      raise ValueError("Did not find wide output ", op)
  sizes_string = sizes_string[0]
  sizes_string[0] = (
      sizes_string[0] + "}"
  )  # restore the } that was removed

  ## After
  # Extract all tensor tokens from the tuple using regex so that
  # scalars (e.g. f32[]) and workspace buffers (e.g. s8[N]{0})
  # don't corrupt the split. Handles damax_output=true tuples like
  # (f8e5m2[M,N]{1,0}, f32[], s8[W]{0}).
  inner = outputs[1:-1]
  tokens = re.findall(
      r"[a-z0-9]+\[[^\]]*\]\{[^}]*\}|[a-z0-9]+\[[^\]]*\]", inner
  )
  tensor_tokens = [
      t
      for t in tokens
      if any(t.startswith(d) for d in dtypes) and not t.endswith("[]")
  ]
  if len(tensor_tokens) == 0:
      raise ValueError("Did not find wide output ", op)
  # Take the first tensor output; for FP8 GEMMs this is the result.
  sizes_string = [
      tensor_tokens[0],
      next(d for d in dtypes if tensor_tokens[0].startswith(d)),
  ]
```
  ---
  ### Fix 2: `/*index=N*/` operand reference prefix
 
```                                                                                                                                                                                                   
  ### Before
  elif "[" not in opid:                                                                                                                                                                             
      output = hlo_ops[opid]["output"]                                                                                                                                                              
      if any(                                                                                                                                                                                       
          output.startswith(d) for d in dtypes + ["f8"]                                                                                                                                             
      ) and not output.endswith("[]"):                                                                                                                                                              
          operand_list.append(hlo_ops[opid]["output"])                                                                                                                                              
                  
  ### After                                                                                                                                                                                           
  elif "[" not in opid:
      # Strip /*index=N*/ prefix that appears in some FP8 operand refs                                                                                                                              
      hlo_key = re.sub(r"^/\*index=\d+\*/", "", opid).strip()         
      if hlo_key not in hlo_ops:                             
          continue                                                                                                                                                                                  
      output = hlo_ops[hlo_key]["output"]
      if any(                                                                                                                                                                                       
          output.startswith(d) for d in dtypes + ["f8"]                                                                                                                                             
      ) and not output.endswith("[]"):                 
          operand_list.append(hlo_ops[hlo_key]["output"])   
```
### Tests
Verified end-to-end xlsx report generation with a mixtral 8x7B FP8 Jax profile (B300, JAX 26.04, FP8). Previously crashed at `process_gemm_ops`, now produces complete report. 

<!--
Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.

See LICENSE for license information.
-->

# Pull Request Template

> **Note to AMDers:**  
> This is a public repository. Please do **not** upload any confidential or customer data. Make sure all such data has been anonymized or removed before making this PR. If you need to attach any private files or links, please insert a Internal OneDrive Link or a Jira Ticket Link instead.
