### PR TITLE
Add perfmodel for unfused moe (FlyDSL route)

### DIFF
--- a/TraceLens/PerfModel/extensions/__init__.py
+++ b/TraceLens/PerfModel/extensions/__init__.py
@@ -17,6 +17,8 @@ from .moe_perf_model_extensions import (
     moe_triton_unfused_down,
     moe_gptq_awq_up,
     moe_gptq_awq_down,
+    moe_flydsl_stage1,
+    moe_flydsl_stage2,
 )
 from .attention_perf_model_extensions import (
     InferenceAttention,
@@ -61,6 +63,8 @@ __all__ = [
     "moe_triton_unfused_down",
     "moe_gptq_awq_up",
     "moe_gptq_awq_down",
+    "moe_flydsl_stage1",
+    "moe_flydsl_stage2",
     "mha_varlen_fwd",
     "aiter_fmha_v3_varlen_fwd",
     "vllm_unified_attention_with_output",

--- a/TraceLens/PerfModel/extensions/moe_perf_model_extensions.py
+++ b/TraceLens/PerfModel/extensions/moe_perf_model_extensions.py
@@ -1225,6 +1225,181 @@ class moe_aiter_ck_stage2(UnfusedMoE_Down):
 
 
 # ==============================================================================
+# MoE flydsl Performance Models (aiter::fused_moe_ flydsl two-stage)
+# ==============================================================================
+
+
+def _flydsl_extract_param_details(event):
+    """
+    Shared shape/dtype extraction for flydsl stage1/stage2 pseudo ops.
+
+    Both pseudo ops inherit Input Dims / Input type from the parent
+    aiter::fused_moe_ event, whose layout matches moe_aiter_fused_1stage:
+
+    Expected Input Dims format:
+    [[tokens, hidden_dim], [experts, inter_dim*(gated+1), hidden_dim_packed],
+     [experts, hidden_dim, inter_dim_packed], [tokens, topk], ...]
+
+    Expected Input type format:
+    [dtype_input, dtype_w1, dtype_w2, ...]
+    """
+    args = event.get("args", {})
+
+    kernel_input_shape = args["Input Dims"]
+    input_shape = kernel_input_shape[0]
+    w1_shape = kernel_input_shape[1]
+    w2_shape = kernel_input_shape[2]
+    topk_weights_shape = kernel_input_shape[3]
+
+    num_tokens = input_shape[0]
+    E, _, hidden_dim = w1_shape
+    E, hidden_dim, inter_dim = w2_shape
+
+    # Account for FP4/INT4 weight packing: w1's K dim may be compressed
+    int4_war = hidden_dim // w1_shape[-1]
+    inter_dim *= int4_war
+    num_experts = w1_shape[0]
+    topk = topk_weights_shape[1]
+
+    gated = w1_shape[1] == 2 * inter_dim
+
+    input_dtype = args["Input type"][0]
+    weight_dtype = args["Input type"][1]
+
+    return {
+        "num_tokens": num_tokens,
+        "hidden_dim": hidden_dim,
+        "inter_dim": inter_dim,
+        "num_experts": num_experts,
+        "topk": topk,
+        "gated": gated,
+        "input_dtype": input_dtype,
+        "weight_dtype": weight_dtype,
+    }
+
+
+class moe_flydsl_stage1(UnfusedMoE_Up):
+    """
+    Performance model for pseudo_op::moe_flydsl_stage1 (up/gate projection).
+
+    Injected below the flydsl stage1 wrapper under each aiter::fused_moe_ event
+    (see TraceLens/Trace2Tree/extensions/moe_flydsl_pseudo_ops.py). Shapes are
+    inherited from the parent aiter::fused_moe_ op.
+    """
+
+    def __init__(self, event, arch=None, python_path=None):
+        self.event = event
+        self.arch = arch
+        self.python_path = python_path
+        self.param_details = self.get_param_details(event)
+
+    @staticmethod
+    def get_param_details(event):
+        return _flydsl_extract_param_details(event)
+
+    def flops(self):
+        return self.flops_func(
+            self.param_details["num_tokens"],
+            self.param_details["hidden_dim"],
+            self.param_details["inter_dim"],
+            self.param_details["topk"],
+            self.param_details["gated"],
+        )
+
+    def bytes(self):
+        input_bpe = DTYPE_TO_BYTES.get(self.param_details["input_dtype"], 2)
+        weight_bpe = DTYPE_TO_BYTES.get(self.param_details["weight_dtype"], 1)
+        output_bpe = input_bpe
+
+        return self.bytes_func(
+            self.param_details["num_tokens"],
+            self.param_details["hidden_dim"],
+            self.param_details["inter_dim"],
+            self.param_details["num_experts"],
+            self.param_details["topk"],
+            self.param_details["gated"],
+            input_bpe,
+            weight_bpe,
+            output_bpe,
+        )
+
+    def flops_bwd(self):
+        raise NotImplementedError("Backward pass for flydsl MoE is not defined.")
+
+    def bytes_bwd(self):
+        raise NotImplementedError("Backward pass for flydsl MoE is not defined.")
+
+    def get_compute_precision(self):
+        # flydsl A4W4 MoE GEMMs (moe_gemm1_0/moe_gemm2_0)
+        # consume FP4 activations + FP4 weights via native MXFP4 MFMA scaled
+        # instructions; the BF16 hidden_states are quantized to FP4 before the
+        # matmul. Roof against the FP4 matrix peak.
+        dtype = self.param_details.get("weight_dtype")
+        return torch_dtype_map(dtype) if dtype else None
+
+    def get_maf_type(self):
+        return "matrix"
+
+
+class moe_flydsl_stage2(UnfusedMoE_Down):
+    """
+    Performance model for pseudo_op::moe_flydsl_stage2 (down projection).
+
+    Injected below the flydsl stage2 wrapper under each aiter::fused_moe_ event
+    (see TraceLens/Trace2Tree/extensions/moe_flydsl_pseudo_ops.py). Shapes are
+    inherited from the parent aiter::fused_moe_ op.
+    """
+
+    def __init__(self, event, arch=None, python_path=None):
+        self.event = event
+        self.arch = arch
+        self.python_path = python_path
+        self.param_details = self.get_param_details(event)
+
+    @staticmethod
+    def get_param_details(event):
+        return _flydsl_extract_param_details(event)
+
+    def flops(self):
+        return self.flops_func(
+            self.param_details["num_tokens"],
+            self.param_details["hidden_dim"],
+            self.param_details["inter_dim"],
+            self.param_details["topk"],
+        )
+
+    def bytes(self):
+        input_bpe = DTYPE_TO_BYTES.get(self.param_details["input_dtype"], 2)
+        weight_bpe = DTYPE_TO_BYTES.get(self.param_details["weight_dtype"], 1)
+        output_bpe = input_bpe
+
+        return self.bytes_func(
+            self.param_details["num_tokens"],
+            self.param_details["hidden_dim"],
+            self.param_details["inter_dim"],
+            self.param_details["num_experts"],
+            self.param_details["topk"],
+            input_bpe,
+            weight_bpe,
+            output_bpe,
+        )
+
+    def flops_bwd(self):
+        raise NotImplementedError("Backward pass for flydsl MoE is not defined.")
+
+    def bytes_bwd(self):
+        raise NotImplementedError("Backward pass for flydsl MoE is not defined.")
+
+    def get_compute_precision(self):
+        # See moe_flydsl_stage1.get_compute_precision: FP4 MFMA on gfx950.
+        dtype = self.param_details.get("weight_dtype")
+        return torch_dtype_map(dtype) if dtype else None
+
+    def get_maf_type(self):
+        return "matrix"
+
+
+# ==============================================================================
 # MoE GPTQ/AWQ Performance Models (vllm::outplace_fused_experts)
 # ==============================================================================
 

--- a/TraceLens/PerfModel/extensions/pseudo_ops_perf_utils.py
+++ b/TraceLens/PerfModel/extensions/pseudo_ops_perf_utils.py
@@ -42,6 +42,9 @@ def get_pseudo_op_mappings():
         # MoE - GPTQ/AWQ quantized unfused implementation (vllm::outplace_fused_experts)
         "pseudo_op::moe_gptq_awq_up": moe_perf_model_extensions.moe_gptq_awq_up,
         "pseudo_op::moe_gptq_awq_down": moe_perf_model_extensions.moe_gptq_awq_down,
+        # MoE flydsl two-stage (under aiter::fused_moe_)
+        "pseudo_op::moe_flydsl_stage1": moe_perf_model_extensions.moe_flydsl_stage1,
+        "pseudo_op::moe_flydsl_stage2": moe_perf_model_extensions.moe_flydsl_stage2,
         # Attention pseudo ops
         "vllm::unified_attention_with_output": attention_perf_model_extensions.vllm_unified_attention_with_output,
         "aiter::mha_varlen_fwd": attention_perf_model_extensions.mha_varlen_fwd,

--- a/TraceLens/Trace2Tree/extensions/__init__.py
+++ b/TraceLens/Trace2Tree/extensions/__init__.py
@@ -7,11 +7,15 @@
 from .pseudo_ops_utils import (
     apply_pseudo_op_extensions,
     inject_pseudo_op,
+    inject_pseudo_op_above_event,
     set_bookkeeping_attr,
 )
+from .moe_flydsl_pseudo_ops import create_pseudo_ops_moe_flydsl
 
 __all__ = [
     "apply_pseudo_op_extensions",
     "inject_pseudo_op",
+    "inject_pseudo_op_above_event",
     "set_bookkeeping_attr",
+    "create_pseudo_ops_moe_flydsl",
 ]

--- a/TraceLens/Trace2Tree/extensions/moe_flydsl_pseudo_ops.py
+++ b/TraceLens/Trace2Tree/extensions/moe_flydsl_pseudo_ops.py
@@ -37,7 +37,7 @@ def create_pseudo_ops_moe_flydsl(trace_tree):
     if FUSED_MOE_PARENT not in trace_tree.name2event_uids:
         return
 
-    # Resolve full event names that contain each marker.  
+    # Resolve full event names that contain each marker.
     marker_to_event_names = {marker: [] for marker in STAGE_WRAPPERS.values()}
     for name in trace_tree.name2event_uids:
         for marker in marker_to_event_names:

--- a/TraceLens/Trace2Tree/extensions/moe_flydsl_pseudo_ops.py
+++ b/TraceLens/Trace2Tree/extensions/moe_flydsl_pseudo_ops.py
@@ -1,0 +1,91 @@
+###############################################################################
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+import logging
+
+from .pseudo_ops_utils import inject_pseudo_op_above_event
+
+logger = logging.getLogger(__name__)
+
+
+STAGE_WRAPPERS = {
+    "pseudo_op::moe_flydsl_stage1": "flydsl_moe_stage1",
+    "pseudo_op::moe_flydsl_stage2": "flydsl_moe_stage2",
+}
+
+FUSED_MOE_PARENT = "aiter::fused_moe_"
+_PYTHON_FUNC_CATS = {"python_func", "python_function"}
+
+
+def create_pseudo_ops_moe_flydsl(trace_tree):
+    """
+    Create pseudo ops for the two flydsl MoE stages.
+
+    Strategy: look up
+    each stage marker in the tree's name index, then walk up the parent chain
+    to confirm the stage event lives under an aiter::fused_moe_ ancestor. The
+    pseudo op is injected as the new parent of the stage event, inheriting
+    Input Dims / Input type / Input Strides / Concrete Inputs / Sequence number
+    from the aiter::fused_moe_ donor.
+
+    The extension is a no-op if aiter::fused_moe_ is not in the trace.
+    """
+
+    if FUSED_MOE_PARENT not in trace_tree.name2event_uids:
+        return
+
+    # Resolve full event names that contain each marker.  
+    marker_to_event_names = {marker: [] for marker in STAGE_WRAPPERS.values()}
+    for name in trace_tree.name2event_uids:
+        for marker in marker_to_event_names:
+            if name.endswith(": " + marker):
+                marker_to_event_names[marker].append(name)
+
+    for pseudo_name, marker in STAGE_WRAPPERS.items():
+        matched_names = marker_to_event_names[marker]
+        if not matched_names:
+            logger.debug(f"No events matching marker {marker!r}")
+            continue
+
+        injected = 0
+        for ev_name in matched_names:
+            for uid in trace_tree.name2event_uids[ev_name]:
+                stage_evt = trace_tree.get_UID2event(uid)
+                if stage_evt.get("cat") not in _PYTHON_FUNC_CATS:
+                    continue
+                fused_moe_evt = _find_fused_moe_ancestor(trace_tree, stage_evt)
+                if fused_moe_evt is None:
+                    continue
+                seq_num = fused_moe_evt.get("args", {}).get(
+                    "Sequence number", fused_moe_evt["UID"]
+                )
+                inject_pseudo_op_above_event(
+                    trace_tree,
+                    stage_evt,
+                    pseudo_name,
+                    shape_donor_evt=fused_moe_evt,
+                    extra_args={
+                        "Sequence number": seq_num,
+                        "MoE flydsl stage": marker,
+                    },
+                )
+                injected += 1
+
+        logger.info(f"Injected {injected} {pseudo_name} pseudo ops")
+
+
+def _find_fused_moe_ancestor(trace_tree, evt: dict):
+    """
+    Walk up the parent chain from evt and return the nearest aiter::fused_moe_
+    ancestor, or None if no such ancestor exists.
+    """
+
+    current = trace_tree.get_parent_event(evt)
+    while current is not None:
+        if current.get("name") == FUSED_MOE_PARENT:
+            return current
+        current = trace_tree.get_parent_event(current)
+    return None

--- a/TraceLens/Trace2Tree/extensions/pseudo_ops_utils.py
+++ b/TraceLens/Trace2Tree/extensions/pseudo_ops_utils.py
@@ -224,9 +224,7 @@ def inject_pseudo_op_above_event(
             "Input type": donor_args.get("Input type"),
             "Input Strides": donor_args.get("Input Strides"),
             "Concrete Inputs": donor_args.get("Concrete Inputs"),
-            "Sequence number": donor_args.get(
-                "Sequence number", parent_evt.get("UID")
-            ),
+            "Sequence number": donor_args.get("Sequence number", parent_evt.get("UID")),
             "Pseudo op": True,
         },
         "children": [target_evt["UID"]],
@@ -311,9 +309,7 @@ def apply_pseudo_op_extensions(tree, verbose: bool = False):
 
         extensions.append(("MoE_Flydsl", create_pseudo_ops_moe_flydsl))
         if verbose:
-            logger.info(
-                "Auto-detected flydsl MoE operations under aiter::fused_moe_"
-            )
+            logger.info("Auto-detected flydsl MoE operations under aiter::fused_moe_")
 
     # MLA Decode: AITER implementation
     if "aiter::mla_decode_stage1_asm_fwd" in tree.name2event_uids:

--- a/TraceLens/Trace2Tree/extensions/pseudo_ops_utils.py
+++ b/TraceLens/Trace2Tree/extensions/pseudo_ops_utils.py
@@ -174,6 +174,79 @@ def inject_pseudo_op_wrap_children(
     tree.cpu_root_nodes.append(pseudo_evt["UID"])
 
 
+def inject_pseudo_op_above_event(
+    tree,
+    target_evt,
+    name,
+    shape_donor_evt=None,
+    extra_args=None,
+):
+    """
+    Insert a new pseudo cpu_op between target_evt and its current parent.
+
+    Resulting layout: parent -> pseudo_evt -> target_evt (target's subtree unchanged).
+    Pseudo args (Input Dims / Input type / Input Strides / Concrete Inputs /
+    Sequence number) are inherited from shape_donor_evt; if None, falls back
+    to the target's current parent.
+
+    Args:
+        tree: TraceToTree instance
+        target_evt: Existing event the pseudo op should wrap (becomes its sole child)
+        name: Name of the pseudo-op
+        shape_donor_evt: Event to inherit shapes from (uses parent if None)
+        extra_args: Additional custom args to add to pseudo-op (dict)
+
+    Returns:
+        The pseudo event dict, or None if target_evt has no parent.
+    """
+
+    parent_evt = tree.get_parent_event(target_evt)
+    if parent_evt is None:
+        logger.warning(
+            f"inject_pseudo_op_above_event: target UID {target_evt.get('UID')} "
+            f"has no parent; skipping injection of {name}"
+        )
+        return None
+
+    donor = shape_donor_evt if shape_donor_evt is not None else parent_evt
+    donor_args = donor.get("args", {})
+
+    pseudo_evt = {
+        "ph": "X",
+        "name": name,
+        "cat": "cpu_op",
+        "pid": target_evt.get("pid", parent_evt.get("pid")),
+        "tid": target_evt.get("tid", parent_evt.get("tid")),
+        "ts": target_evt.get("ts"),
+        "dur": target_evt.get("dur"),
+        "args": {
+            "Input Dims": donor_args.get("Input Dims"),
+            "Input type": donor_args.get("Input type"),
+            "Input Strides": donor_args.get("Input Strides"),
+            "Concrete Inputs": donor_args.get("Concrete Inputs"),
+            "Sequence number": donor_args.get(
+                "Sequence number", parent_evt.get("UID")
+            ),
+            "Pseudo op": True,
+        },
+        "children": [target_evt["UID"]],
+        "gpu_events": list(target_evt.get("gpu_events", [])),
+    }
+
+    if extra_args:
+        pseudo_evt["args"].update(extra_args)
+
+    set_bookkeeping_attr(tree, pseudo_evt)
+
+    pseudo_evt["parent"] = parent_evt["UID"]
+    parent_children = parent_evt["children"]
+    idx = parent_children.index(target_evt["UID"])
+    parent_children[idx] = pseudo_evt["UID"]
+    target_evt["parent"] = pseudo_evt["UID"]
+
+    return pseudo_evt
+
+
 def apply_pseudo_op_extensions(tree, verbose: bool = False):
     """
     Apply all available pseudo-op extensions to trace tree.
@@ -231,6 +304,16 @@ def apply_pseudo_op_extensions(tree, verbose: bool = False):
                 logger.info(
                     "Auto-detected GPTQ/AWQ MoE operations (outplace_fused_experts)"
                 )
+
+    # MoE: flydsl 2-stage implementation (gated on aiter::fused_moe_ parent op)
+    if "aiter::fused_moe_" in tree.name2event_uids:
+        from .moe_flydsl_pseudo_ops import create_pseudo_ops_moe_flydsl
+
+        extensions.append(("MoE_Flydsl", create_pseudo_ops_moe_flydsl))
+        if verbose:
+            logger.info(
+                "Auto-detected flydsl MoE operations under aiter::fused_moe_"
+            )
 
     # MLA Decode: AITER implementation
     if "aiter::mla_decode_stage1_asm_fwd" in tree.name2event_uids:


### PR DESCRIPTION
This pull request adds support for flydsl two-stage Mixture-of-Experts (MoE) operations to the performance modeling and trace processing system. It introduces new pseudo-op injection utilities and performance models for the flydsl MoE stages, enabling the system to recognize, inject, and analyze these operations in traces. The main changes are grouped below.

**Support for flydsl MoE pseudo-ops and performance models:**

* Added new performance model classes `moe_flydsl_stage1` and `moe_flydsl_stage2` to `moe_perf_model_extensions.py`, including parameter extraction, FLOPs/bytes calculation, and compute precision logic for both stages. (_[TraceLens/PerfModel/extensions/moe_perf_model_extensions.pyR1227-R1401](diffhunk://#diff-bbd7dd8b7937bd2539fa07abdcc2d00cd9a4b5443bd5a29508536b2c7d3ffb3aR1227-R1401)_)
* Registered the new flydsl MoE performance models in the extension module’s `__init__.py` and the pseudo-op mapping in `pseudo_ops_perf_utils.py`. (_[[1]](diffhunk://#diff-e03d1c0a173269db65bf1bfc351afb58495b3f719c6eac8d35a0664ac43d7e9eR20-R21)_, _[[2]](diffhunk://#diff-e03d1c0a173269db65bf1bfc351afb58495b3f719c6eac8d35a0664ac43d7e9eR66-R67)_, _[[3]](diffhunk://#diff-9b10af80cc8b96cbbddd8ac221c1f69ee7c428aef4c3b9675d4be086fc6ee2cfR45-R47)_)

**Pseudo-op injection utilities and extensions:**

* Implemented `inject_pseudo_op_above_event` utility to insert a pseudo-op node as the parent of a target event, inheriting shape and type information from a donor event. (_[TraceLens/Trace2Tree/extensions/pseudo_ops_utils.pyR177-R247](diffhunk://#diff-f4c54d988b1e8030e18690a22f8586fd8c5a3d0bba789af91593f94a8b55f46cR177-R247)_)
* Added `create_pseudo_ops_moe_flydsl` in a new file `moe_flydsl_pseudo_ops.py`, which finds flydsl stage events in the trace, locates their `aiter::fused_moe_` ancestor, and injects the corresponding pseudo-op. (_[TraceLens/Trace2Tree/extensions/moe_flydsl_pseudo_ops.pyR1-R91](diffhunk://#diff-72c502ea467d7989a8512876ef2aad71785ee9ecb3245e0d8590bd379fdc6736R1-R91)_)
* Updated `apply_pseudo_op_extensions` to auto-detect and apply the flydsl MoE pseudo-op extension when relevant events are present in the trace. (_[TraceLens/Trace2Tree/extensions/pseudo_ops_utils.pyR306-R313](diffhunk://#diff-f4c54d988b1e8030e18690a22f8586fd8c5a3d0bba789af91593f94a8b55f46cR306-R313)_)

**Module and interface updates:**

* Updated `Trace2Tree/extensions/__init__.py` to expose the new pseudo-op injection functions and flydsl pseudo-op creation utility. (_[TraceLens/Trace2Tree/extensions/__init__.pyR10-R20](diffhunk://#diff-fca2492e940cb6e241c83a3bc0d478f7f175eea61c6c7fa48df6557daa450027R10-R20)_)

These changes collectively enable the system to correctly identify, inject, and model the performance of flydsl two-stage MoE operations in supported traces.
<!--
Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.

See LICENSE for license information.
-->

