### PR TITLE
Propagate trace metadata through TraceLens analyzers

### DIFF
--- a/TraceLens/Trace2Tree/trace_to_tree.py
+++ b/TraceLens/Trace2Tree/trace_to_tree.py
@@ -5,7 +5,7 @@
 ###############################################################################
 
 from collections import defaultdict
-from typing import Dict, Any, Callable
+from typing import Dict, Any, Callable, Optional
 import TraceLens.util
 
 from ..util import TraceEventUtils, JaxProfileProcessor
@@ -25,12 +25,14 @@ class BaseTraceToTree(ABC):
         compute_end_times=True,
         linking_key: str = None,
         event_to_category: Callable[[dict], str] = None,
+        trace_metadata: Optional[Dict[str, Any]] = None,
     ):
 
         self.events = [
             {**data, TraceLens.util.TraceEventUtils.TraceKeys.UID: i}
             for i, data in enumerate(events_data)
         ]
+        self.trace_metadata = dict(trace_metadata or {})
         self.events_by_uid = {
             event[TraceLens.util.TraceEventUtils.TraceKeys.UID]: event
             for event in self.events
@@ -300,6 +302,7 @@ class JaxTraceToTree(BaseTraceToTree):
         event_to_category: Callable[
             [dict], str
         ] = TraceEventUtils.prepare_event_categorizer,
+        trace_metadata: Optional[Dict[str, Any]] = None,
     ):
 
         super().__init__(
@@ -308,6 +311,7 @@ class JaxTraceToTree(BaseTraceToTree):
             compute_end_times=compute_end_times,
             linking_key=linking_key,
             event_to_category=event_to_category,
+            trace_metadata=trace_metadata,
         )
         self._preprocess_and_index_events()
         self._annotate_gpu_events_with_stream_index()
@@ -592,6 +596,7 @@ class TraceToTree(BaseTraceToTree):
         event_to_category: Callable[
             [dict], str
         ] = TraceLens.util.TraceEventUtils.default_categorizer,
+        trace_metadata: Optional[Dict[str, Any]] = None,
     ):
         super().__init__(
             events_data,
@@ -599,6 +604,7 @@ class TraceToTree(BaseTraceToTree):
             compute_end_times=compute_end_times,
             linking_key=linking_key,
             event_to_category=event_to_category,
+            trace_metadata=trace_metadata,
         )
         self.metadata = TraceEventUtils.get_metadata(self.events)
         self._preprocess_and_index_events()

--- a/TraceLens/TreePerf/tree_perf.py
+++ b/TraceLens/TreePerf/tree_perf.py
@@ -168,6 +168,48 @@ class TreePerfAnalyzer:
         # Creates a TreePerfAnalyzer from the trace in the provided filepath.
         # *args, **kwargs are passed to the TreePerfAnalyzer constructor.
         data = DataLoader.load_data(profile_filepath)
+        # PyTorch Chrome traces carry run metadata as top-level JSON fields.
+        # Field presence varies by profiler version, profiler options, and backend, e.g.
+        # {
+        #   "schemaVersion": 1,          # usually present
+        #   "deviceProperties": [{       # usually present for GPU traces
+        #     "id": 0,
+        #     "name": "AMD Instinct MI210",
+        #     "totalGlobalMem": 68702699520,
+        #     "computeMajor": 9,
+        #     "computeMinor": 0,
+        #     "maxThreadsPerBlock": 1024,
+        #     "maxThreadsPerMultiprocessor": 2048,
+        #     "regsPerBlock": 131072,
+        #     "warpSize": 64,
+        #     "sharedMemPerBlock": 65536,
+        #     "maxSharedMemoryPerMultiProcessor": 65536,
+        #     "numSms": 104
+        #   }],
+        #   "distributedInfo": {         # optional; distributed profiler traces
+        #     "backend": "nccl",
+        #     "rank": 0,
+        #     "world_size": 1,
+        #     "pg_count": 7,
+        #     "pg_config": [{
+        #       "pg_name": "0",
+        #       "pg_desc": "default_pg",
+        #       "backend_config": "cuda:nccl",
+        #       "pg_size": 1,
+        #       "ranks": [0]
+        #     }]
+        #   },
+        #   "record_shapes": 1,              # optional; profiler option/version dependent
+        #   "with_stack": 1,                 # optional; profiler option/version dependent
+        #   "roctracer_version": 4.1,        # optional; ROCm traces only
+        #   "hip_runtime_version": 70253211, # optional; ROCm traces only
+        #   "hip_driver_version": 70253211,  # optional; ROCm traces only
+        #   "traceEvents": [...]             # required event payload
+        # }
+        # Keep these trace-level fields separate from Chrome "M" metadata events.
+        trace_metadata = {
+            key: value for key, value in data.items() if key != "traceEvents"
+        }
         data = data["traceEvents"]
 
         categorizer = (
@@ -176,7 +218,11 @@ class TreePerfAnalyzer:
             else TraceEventUtils.prepare_event_categorizer(data)
         )
         data = data if not jax else TraceEventUtils.non_metadata_events(data)
-        tree = TraceToTree(data, event_to_category=categorizer)
+        tree = TraceToTree(
+            data,
+            event_to_category=categorizer,
+            trace_metadata=trace_metadata,
+        )
 
         # Optionally merge capture trace into graph tree
         if capture_trace_filepath is not None:
@@ -213,6 +259,7 @@ class TreePerfAnalyzer:
         self.jax = jax
         self.GPUEventAnalyser = GPUEventAnalyser if not jax else JaxGPUEventAnalyser
         self.tree = tree
+        self.trace_metadata = self.tree.trace_metadata
         self.detect_recompute = detect_recompute
         if detect_recompute:
             add_python_func = True

--- a/tests/test_trace_metadata.py
+++ b/tests/test_trace_metadata.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 #
 # See LICENSE for license information.
 ###############################################################################

--- a/tests/test_trace_metadata.py
+++ b/tests/test_trace_metadata.py
@@ -1,0 +1,71 @@
+###############################################################################
+# Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+import json
+
+from TraceLens.Trace2Tree.trace_to_tree import TraceToTree
+from TraceLens.TreePerf.tree_perf import TreePerfAnalyzer
+
+
+def _minimal_events():
+    return [
+        {
+            "ph": "X",
+            "cat": "cpu_op",
+            "name": "aten::empty",
+            "pid": 1,
+            "tid": 1,
+            "ts": 10,
+            "dur": 5,
+            "args": {},
+        }
+    ]
+
+
+def test_trace_to_tree_defaults_to_empty_trace_metadata():
+    tree = TraceToTree(_minimal_events())
+
+    assert tree.trace_metadata == {}
+    assert "trace_metadata" not in tree.events[0]
+
+
+def test_trace_to_tree_preserves_trace_metadata():
+    metadata = {
+        "traceName": "example_trace.json",
+        "record_shapes": 1,
+        "deviceProperties": [{"name": "gfx942", "totalGlobalMem": 1}],
+    }
+
+    tree = TraceToTree(_minimal_events(), trace_metadata=metadata)
+
+    assert tree.trace_metadata == metadata
+    assert tree.trace_metadata is not metadata
+    assert "traceEvents" not in tree.trace_metadata
+    assert "trace_metadata" not in tree.events[0]
+
+
+def test_tree_perf_analyzer_from_file_exposes_trace_metadata(tmp_path):
+    trace = {
+        "schemaVersion": 1,
+        "traceName": "from_file_trace.json",
+        "record_shapes": 1,
+        "deviceProperties": [{"name": "gfx942"}],
+        "traceEvents": _minimal_events(),
+    }
+    trace_path = tmp_path / "trace.json"
+    trace_path.write_text(json.dumps(trace), encoding="utf-8")
+
+    analyzer = TreePerfAnalyzer.from_file(trace_path.as_posix(), rebuild_tree=False)
+
+    expected_metadata = {
+        "schemaVersion": 1,
+        "traceName": "from_file_trace.json",
+        "record_shapes": 1,
+        "deviceProperties": [{"name": "gfx942"}],
+    }
+    assert analyzer.trace_metadata == expected_metadata
+    assert analyzer.tree.trace_metadata == expected_metadata
+    assert "traceEvents" not in analyzer.trace_metadata


### PR DESCRIPTION
## Summary
- Preserve top-level trace JSON fields as trace-level metadata while keeping `traceEvents` as the event payload.
- Expose metadata through `TraceToTree` and `TreePerfAnalyzer` for report consumers.
- Keep metadata optional so direct synthetic-event construction remains backward compatible.

## Example usage
```python
from TraceLens.TreePerf.tree_perf import TreePerfAnalyzer

analyzer = TreePerfAnalyzer.from_file("profile.trace.json", rebuild_tree=False)
metadata = analyzer.trace_metadata

gpu_names = [
    gpu.get("name", "unknown GPU")
    for gpu in metadata.get("deviceProperties", [])
]
print(f"GPUs: {', '.join(gpu_names) if gpu_names else 'unknown'}")
print(f"GPU count: {len(gpu_names)}")

rank_info = metadata.get("distributedInfo") or {}
if rank_info:
    print(f"Rank: {rank_info.get('rank')} / {rank_info.get('world_size')}")
```

Verified on a small real PyTorch Chrome trace. The exact GPU model is trace-dependent:
```text
GPUs: AMD Instinct MI300X
GPU count: 1
Distributed info: not present
```

## Test plan
- `python -m pytest tests/test_trace_metadata.py`
- `python -m pytest tests/test_trace_metadata.py tests/test_kernel_launchers.py -q`

Replaces #643 after cleaning up the branch name and commit history.
