### PR TITLE
Remove confidence scores from compute agents

### DIFF
--- a/TraceLens/Agent/Analysis/category_analyses/analysis_utils.py
+++ b/TraceLens/Agent/Analysis/category_analyses/analysis_utils.py
@@ -693,7 +693,6 @@ def compute_impact_estimates(
 
         if impact_score_high < min_impact_score:
             continue
-        confidence = "high" if time_ms > 5 and eff_pct < 70 else "medium"
         estimate = {
             "operation": op.get("name", "Unknown"),
             "category": category,
@@ -701,7 +700,6 @@ def compute_impact_estimates(
             "impact_score": round(impact_score_mid, 2),
             "impact_score_low": round(impact_score_low, 2),
             "impact_score_high": round(impact_score_high, 2),
-            "confidence": confidence,
             "efficiency_pct": round(eff_pct, 2),
             "bound_type": eff.get("bound_type"),
             "library": op.get("library"),

--- a/tests/test_analysis_agent.py
+++ b/tests/test_analysis_agent.py
@@ -114,7 +114,6 @@ def output_dir_with_manifest_and_metrics(tmp_path):
                 "impact_score": 100.0,
                 "impact_score_low": 85.0,
                 "impact_score_high": 115.0,
-                "confidence": "high",
             },
             {
                 "operation": "aten::mm",
@@ -123,7 +122,6 @@ def output_dir_with_manifest_and_metrics(tmp_path):
                 "impact_score": 50.0,
                 "impact_score_low": 42.0,
                 "impact_score_high": 58.0,
-                "confidence": "medium",
             },
         ],
         "category_findings": [
@@ -153,7 +151,6 @@ def output_dir_with_manifest_and_metrics(tmp_path):
                 "impact_score": 80.0,
                 "impact_score_low": 68.0,
                 "impact_score_high": 92.0,
-                "confidence": "medium",
             },
         ],
         "category_findings": [


### PR DESCRIPTION
## Summary

Removes the unused kernel-tuning `confidence` field from `compute_impact_estimates()`. This field assigned `"high"` or `"medium"` to every per-op impact estimate but was never consumed: no sub-agent markdown, template, validator, or ranking logic reads it. The kernel-fusion confidence system (`_classify_confidence()` in `kernel_fusion_analysis.py`) is a separate pipeline and is untouched.

2 files changed, 5 deletions(−).

## What changed

### Python (1 file)

| File | Change |
|---|---|
| `TraceLens/Agent/Analysis/category_analyses/analysis_utils.py` | Removed the `confidence` variable assignment (`"high" if time_ms > 5 and eff_pct < 70 else "medium"`) and its inclusion in the estimate dict from `compute_impact_estimates()`. |

### Tests (1 file)

| File | Change |
|---|---|
| `tests/test_analysis_agent.py` | Removed `"confidence"` entries from 3 `impact_estimates` fixture dicts (gemm high, gemm medium, sdpa_fwd medium). No assertions referenced this field. |