### PR TITLE
Re-Org. on System Analysis

### DIFF
--- a/TraceLens/Agent/Analysis/.cursor/agents/cpu-idle-analyzer.md
+++ b/TraceLens/Agent/Analysis/.cursor/agents/cpu-idle-analyzer.md
@@ -12,7 +12,7 @@ model: claude-opus-4-7-high
 
 # CPU/Idle Analysis Subagent
 
-Report GPU idle time percentage, utilization breakdown, and kernel launch statistics. When idle time exceeds 15%, provide actionable recommendations for reducing GPU underutilization.
+Report GPU idle time percentage and utilization breakdown. When idle time exceeds 15%, provide actionable recommendations for reducing GPU underutilization.
 
 ---
 
@@ -57,6 +57,13 @@ Use vendor-agnostic terminology:
 - "device synchronization" not "cudaDeviceSynchronize"
 - Focus on patterns and solutions, not vendor implementation details
 
+## Cross-Analyzer Boundary (Required)
+
+- CPU/Idle owns recommendations rooted in idle bubbles, launch overhead, host-side synchronization, and pipeline stalls.
+- Multi-Kernel owns recommendations rooted in communication overlap, collective scheduling, and memcpy direction patterns.
+- If a candidate recommendation's primary action is communication overlap (for example, overlap collectives with compute or reduce collective payload/frequency), do not emit a separate CPU/Idle P-item. Keep CPU/Idle focused on idle/launch mechanisms and let Multi-Kernel carry the communication recommendation.
+- If communication evidence helps explain an idle issue, reference it briefly inside the CPU/Idle reasoning without creating a second card with the same action mechanism.
+
 ---
 
 ## Analysis Workflow
@@ -85,9 +92,6 @@ Key metrics to analyze:
 - `idle_flagged`: Boolean -- whether idle time exceeds 15%
 - `gpu_utilization.idle_time_percent`: Percentage of total time GPU is idle
 - `gpu_utilization.idle_time_ms`: Absolute idle time in milliseconds
-- `kernel_analysis.total_kernel_count`: Total GPU kernel launches
-- `kernel_analysis.short_kernel_count`: Number of kernels under 10μs
-- `kernel_analysis.avg_kernel_time_us`: Average kernel duration
 
 ### Step 3: Write Findings
 
@@ -110,19 +114,15 @@ Write `<output_dir>/system_findings/cpu_idle_findings.md` using the command pref
 | Communication | Z% |
 | MemCpy | W% |
 
-## Kernel Launch Statistics
-
-| Metric | Value |
-|--------|-------|
-| Total Kernels | N |
-| Short Kernels (<10µs) | N (X%) |
-| Avg Kernel Time | X.X µs |
-
 ## Recommendations
 
-[If idle > 15%, provide actionable recommendations based on the kernel analysis data.
+[If idle > 15%, provide actionable recommendations based on utilization data and
+cross-category system evidence.
 Use the Common Recommendations table below as guidance. If idle <= 15%, state that
 idle time is within acceptable range and no action is needed.]
+
+Avoid duplicate cards: if two candidate recommendations prescribe the same mechanism/action,
+emit one merged recommendation card with combined evidence.
 
 ### [Recommendation Title]
 **Insight**: [1 sentence description]
@@ -157,7 +157,7 @@ If validation fails, fix the findings file and re-run. Max 2 retries.
 
 ## Key Principles
 
-1. **Report factual data** - Idle percentage and kernel statistics from the metrics JSON
+1. **Report factual data** - Idle percentage and utilization breakdown from the metrics JSON
 2. **Provide actionable solutions** - Specific steps, not vague suggestions
 3. **Vendor-agnostic recommendations** - Focus on patterns and solutions
 4. **Consider trade-offs** - Some solutions have costs (memory, complexity)

--- a/TraceLens/Agent/Analysis/.cursor/agents/multi-kernel-analyzer.md
+++ b/TraceLens/Agent/Analysis/.cursor/agents/multi-kernel-analyzer.md
@@ -6,7 +6,7 @@ See LICENSE for license information.
 
 ---
 name: multi-kernel-analyzer
-description: Analyze cross-cutting multi-kernel issues including memcpy D2H/H2D patterns, NCCL blocking compute, and compute/communication overlap. System-level analysis tier.
+description: Analyze cross-cutting multi-kernel issues including memcpy D2H/H2D patterns, communication blocking compute, and compute/communication overlap. System-level analysis tier.
 model: claude-opus-4-7-high
 ---
 
@@ -16,8 +16,8 @@ Analyze cross-cutting multi-kernel issues that affect the GPU pipeline as a whol
 
 **Three analysis areas:**
 1. **Memory Copy Patterns** -- High occurrence of D2H/H2D transfers indicating unnecessary data movement
-2. **NCCL Blocking Compute** -- Communication operations that block GPU compute kernels
-3. **Compute/Communication Overlap** -- Lack of overlap between NCCL and compute, missed pipelining opportunities
+2. **Communication Blocking Compute** -- Communication operations that block GPU compute kernels
+3. **Compute/Communication Overlap** -- Lack of overlap between communication and compute, missed pipelining opportunities
 
 ---
 
@@ -30,7 +30,7 @@ When invoked by the orchestrator, you will receive the following context:
 - `prefix`: Command prefix from `<output_dir>/cache/cmd_prefix.txt` — contains a template with `{CMD}` placeholder; substitute `{CMD}` with the actual command
 
 **Input files (pre-computed by orchestrator):**
-1. `<output_dir>/category_data/multi_kernel_data.json` - Pre-computed memcpy/NCCL/overlap data
+1. `<output_dir>/category_data/multi_kernel_data.json` - Pre-computed memcpy/communication/overlap data
 2. `<output_dir>/metadata/multi_kernel_metadata.json` - Platform specs and GPU utilization
 3. `<output_dir>/category_data/category_manifest.json` - Contains gpu_utilization metrics
 
@@ -56,11 +56,17 @@ When invoked by the orchestrator, you will receive the following context:
 ## Language Guidelines
 
 Use vendor-agnostic terminology:
-- "collective communication" not "NCCL" or "RCCL" (exception: quoting kernel names)
+- "collective communication" not vendor library names (exception: quoting kernel names)
 - "memory copy D2H/H2D" not vendor-specific API names
 - "compute/communication overlap" not vendor-specific implementation details
 - "GPU graph" not "CUDA graph" or "HIP graph"
-- Focus on patterns and solutions, not vendor implementation details
+
+## Cross-Analyzer Boundary (Required)
+
+- Multi-Kernel owns recommendations rooted in communication overlap, collective scheduling, and memcpy direction patterns.
+- CPU/Idle owns recommendations rooted in idle bubbles, launch overhead, host-side synchronization, and pipeline stalls.
+- Do not emit a Multi-Kernel card when the primary mechanism/action is launch-overhead reduction or host-pipeline tuning unless there is distinct communication/memcpy evidence that changes the action.
+- If two candidate Multi-Kernel cards prescribe the same mechanism/action, merge into one card and combine evidence instead of emitting near-duplicates.
 
 ---
 
@@ -92,6 +98,16 @@ Key metrics to analyze:
 - `overlap_assessment`: Boolean `flagged` for compute/communication overlap quality
 - `patterns_detected`: List of detected patterns with description (no recommendations -- you generate those)
 
+### Step 2.1: Recommendation Decision Gates
+
+Before drafting recommendations, map each candidate to a specific gate:
+
+- **Overlap gate:** Recommend overlap tuning only when `overlap_assessment.flagged == true` or exposed communication is clearly on the critical path.
+- **Blocking gate:** Recommend communication-blocking fixes only when `nccl_blocking_assessment.flagged == true` and exposed communication is material in absolute or percentage terms.
+- **Memcpy gate:** Recommend direction-specific transfer fixes only when that direction has clear evidence (time share and/or count pattern) in `memcpy_assessment`.
+- **Synchronization gate:** Recommend sync cleanup only when metrics or detected patterns indicate barrier-like behavior; do not speculate.
+- **Merge gate:** If two candidates prescribe the same mechanism/action, emit one merged card with combined evidence.
+
 ### Step 3: Analyze Memory Copy Patterns
 
 Examine `memcpy_assessment` for D2H and H2D issues. `memcpy_assessment.flagged` is `true` when any direction exceeds thresholds (>5% of total time or >10 transfers).
@@ -111,7 +127,7 @@ Examine `memcpy_assessment` for D2H and H2D issues. `memcpy_assessment.flagged` 
 - Common causes: Explicit `.to(device)` on already-resident tensors, contiguous() calls, format conversions
 - Solution: Eliminate redundant copies; use in-place operations or aliased tensors where possible
 
-### Step 4: Analyze NCCL Blocking and Synchronization
+### Step 4: Analyze Communication Blocking and Synchronization
 
 Examine `nccl_blocking_assessment`. `nccl_blocking_assessment.flagged` is `true` when exposed communication exceeds 5% of total GPU time.
 
@@ -129,6 +145,9 @@ Examine `nccl_blocking_assessment`. `nccl_blocking_assessment.flagged` is `true`
 - Common causes: Framework layers issuing separate collectives that could be fused, duplicate gradient syncs
 - Solution: Deduplicate or fuse collectives; reduce collective frequency per iteration
 
+**Selection rule for this step:**
+- If `nccl_blocking_assessment.flagged` is false and exposed communication is not material, do not emit a standalone "communication blocking" recommendation.
+
 ### Step 5: Analyze Compute/Communication Overlap
 
 Examine `overlap_assessment`. `overlap_assessment.flagged` is `true` when overlap ratio is below 70%.
@@ -145,9 +164,17 @@ For **inference** workloads (vLLM / SGLang):
 2. Pipeline prefill and decode phases so collectives from one phase overlap compute of the next
 3. Reduce collective payload size via quantized or compressed allreduce, tuning communication environment variables
 
+- Do not recommend payload compression/quantization when overlap is already healthy and exposed communication is not a dominant bottleneck.
+
 ### Step 6: Write System Findings
 
 Write `<output_dir>/system_findings/multi_kernel_findings.md` using the command prefix:
+
+Recommendation quality requirements (apply before writing):
+- Each recommendation must cite a concrete evidence points from metrics or detected patterns in `Insight` or `Detailed Analysis`.
+- Each `Action` must name one concrete mechanism (for example, bucket sizing, stream split, collective fusion, async staging) and avoid generic advice.
+- For each recommendation, include a clear expected metric movement in prose (for example, lower exposed communication time, higher overlap ratio, lower D2H/H2D count).
+- Do not emit two recommendations with effectively the same action mechanism; merge them.
 
 ```markdown
 # Multi-Kernel Issue Analysis Findings
@@ -183,7 +210,7 @@ Write `<output_dir>/system_findings/multi_kernel_findings.md` using the command 
 
 ## Communication Blocking Analysis
 
-### NCCL Blocking Compute
+### Communication Blocking Compute
 - **Exposed Communication Time**: X ms (Y% of total)
 - **Total Communication Time**: X ms
 - **Flagged**: true/false
@@ -207,20 +234,6 @@ Write `<output_dir>/system_findings/multi_kernel_findings.md` using the command 
 ### System P<N+1>: [Next Issue]
 **Insight**: [1 sentence]
 **Action**: [1-2 sentences]
-
-## Technical Details
-
-### Top Communication Operations
-| Rank | Operation | Duration (us) | Stream |
-|------|-----------|---------------|--------|
-| 1 | ... | ... | ... |
-
-### Memory Copy Breakdown
-| Direction | Count | Total Time (ms) | Avg Size | Severity |
-|-----------|-------|------------------|----------|----------|
-| D2H | ... | ... | ... | ... |
-| H2D | ... | ... | ... | ... |
-| D2D | ... | ... | ... | ... |
 
 ```
 

--- a/TraceLens/Agent/Analysis/utils/templates/analysis_template.md
+++ b/TraceLens/Agent/Analysis/utils/templates/analysis_template.md
@@ -281,6 +281,7 @@ communication/compute overlap). These affect the GPU pipeline as a whole.
 <!-- Icon mapping by PRIORITY NUMBER (not severity): P1=🔴, P2=🟡, P3+=🟢 -->
 <!-- Title format: Descriptive name only. -->
 <!-- System-level recommendations always include **Impact**: "Not quantifiable from trace data" with null markers. -->
+<!-- De-dup rule: If CPU/Idle and Multi-Kernel propose the same mechanism/action, keep one merged system card with combined evidence (do not render two near-duplicate cards). -->
 
 <!-- === TEMPLATE A: No actionable system-level issues === -->
 <!-- Use this when idle <= 15% and all multi-kernel assessments have flagged: false -->

--- a/TraceLens/Agent/Analysis/utils/templates/sub_agent_spec.md
+++ b/TraceLens/Agent/Analysis/utils/templates/sub_agent_spec.md
@@ -207,7 +207,7 @@ Standard schema for the `**Data:**` table inside system-tier `## Detailed Analys
 **Column rules:**
 - **Metric**: Copy metric label directly from earlier findings sections — do not rename or reformat.
 - **Value**: `X.X ms` or `X.X%` or `X.X ms (X.X%)`
-- **Flagged**: `false` when the metric's threshold is exceeded; `true` otherwise.
+- **Flagged**: `true` when the metric's threshold is exceeded (issue present); `false` otherwise.
 
 ---
 
@@ -307,7 +307,7 @@ mandatory `kind=p_item` for category/system findings unless exempt) per
 <prefix> python3 -c "
 import sys
 from TraceLens.Agent.Analysis.utils.validation_utils import validate_findings_file
-passed, errors = validate_findings_file(sys.argv[1], sys.argv[2])
+passed, errors = validate_findings_file(sys.argv[1], sys.argv[2], sys.argv[3])
 if not passed:
     print('FAIL:')
     for e in errors:


### PR DESCRIPTION
## Summary

Refines the system-tier analyzer authoring contract so CPU Idle and Multi-Kernel produce cleaner, non-duplicative findings while staying compatible with existing orchestration and validation. The update clarifies cross-analyzer ownership, adds evidence-gated recommendation guidance, removes unused CPU-idle kernel-launch boilerplate, and resolves shared-spec inconsistencies around `Flagged` semantics and validator invocation.

4 files changed, 52 insertions(+), 38 deletions(-).

## Why

| Pain point | Old | New |
|---|---|---|
| Overlapping CPU Idle vs Multi-Kernel recommendations | Both analyzers could describe the same communication-rooted fix path in separate cards | Cross-analyzer boundary + merge guidance makes ownership explicit and collapses near-duplicate mechanism cards |
| Multi-Kernel recommendations could be generic | Strategy lists were present, but selection gates and recommendation-quality constraints were weak | Added explicit decision gates, materiality checks, and mechanism-specific recommendation requirements |
| Shared spec had contract ambiguity | `sub_agent_spec.md` inverted system `Flagged` semantics and showed a 2-arg validator call example | `Flagged` now matches analyzer behavior (`true` means threshold exceeded) and validator example is standardized to 3 args |

## What changed

### Templates (2 files)

| File | Change |
|---|---|
| `TraceLens/Agent/Analysis/utils/templates/sub_agent_spec.md` | Corrected system metric `Flagged` semantics (`true` when threshold exceeded) and standardized `validate_findings_file()` example to include `comparison_scope` as the 3rd argument. |
| `TraceLens/Agent/Analysis/utils/templates/analysis_template.md` | Added an explicit system-level de-dup rule to merge CPU Idle and Multi-Kernel cards when they prescribe the same mechanism/action. |

### Sub-agent .md files (2)

| File | Change |
|---|---|
| `TraceLens/Agent/Analysis/.cursor/agents/cpu-idle-analyzer.md` | Added cross-analyzer ownership and merge guidance; removed kernel-launch-statistics section/instructions; tightened recommendation guidance to utilization + system evidence. |
| `TraceLens/Agent/Analysis/.cursor/agents/multi-kernel-analyzer.md` | Added cross-analyzer ownership constraints, recommendation decision gates, materiality checks, recommendation-quality requirements, and removed unused Technical Details boilerplate from the output template. |

## Net diff

```text
4 files changed, 52 insertions(+), 38 deletions(-)
```
