### PR TITLE
Allow the agent's architecture utils to be used from the main reports

### DIFF
--- a/TraceLens/Reporting/generate_perf_report_jax.py
+++ b/TraceLens/Reporting/generate_perf_report_jax.py
@@ -5,7 +5,6 @@
 ###############################################################################
 
 import argparse, os, sys
-import json
 from typing import Optional, Dict
 import pandas as pd
 import logging
@@ -19,7 +18,11 @@ logging.basicConfig(
 
 from TraceLens.PerfModel import jax_op_mapping
 from TraceLens.TreePerf import TreePerfAnalyzer, JaxTreePerfAnalyzer
-from TraceLens.Reporting.reporting_utils import request_install
+from TraceLens.Reporting.reporting_utils import (
+    add_gpu_arch_cli_args,
+    request_install,
+    resolve_gpu_arch,
+)
 from TraceLens.util import TraceEventUtils
 
 
@@ -142,13 +145,15 @@ def generate_perf_report_jax(
     output_csvs_dir: Optional[str] = None,
     kernel_metadata_keyword_filters=None,
     gpu_arch_json_path: Optional[str] = None,
+    gpu_arch_platform: Optional[str] = None,
+    gpu_arch: Optional[dict] = None,
     enable_origami: bool = False,
 ) -> Dict[str, pd.DataFrame]:
-    if gpu_arch_json_path:
-        with open(gpu_arch_json_path, "r") as f:
-            gpu_arch_json = json.load(f)
-    else:
-        gpu_arch_json = None
+    gpu_arch_json = resolve_gpu_arch(
+        gpu_arch_json_path=gpu_arch_json_path,
+        gpu_arch_platform=gpu_arch_platform,
+        gpu_arch=gpu_arch,
+    )
     # Analyze trace profile
     dict_name2df = perf_analysis(
         profile_path,
@@ -221,12 +226,7 @@ def main():
         default=None,
         help="Kernel metadata keyword filters, performance analysis is computed only for the events containing the kerword in the metadata e.g. in framework name scope, e.g. --kernel_metadata_keyword_filters remat checkpoint",
     )
-    parser.add_argument(
-        "--gpu_arch_json_path",
-        type=str,
-        default=None,
-        help="Path to the GPU architecture JSON file",
-    )
+    add_gpu_arch_cli_args(parser)
     parser.add_argument(
         "--enable-origami",
         action="store_true",
@@ -242,6 +242,7 @@ def main():
         output_csvs_dir=args.output_csvs_dir,
         kernel_metadata_keyword_filters=args.kernel_metadata_keyword_filters,
         gpu_arch_json_path=args.gpu_arch_json_path,
+        gpu_arch_platform=args.gpu_arch_platform,
         enable_origami=args.enable_origami,
     )
 

--- a/TraceLens/Reporting/generate_perf_report_pytorch.py
+++ b/TraceLens/Reporting/generate_perf_report_pytorch.py
@@ -18,7 +18,11 @@ import pandas as pd
 
 from TraceLens import NcclAnalyser, TraceToTree, TraceDiff, TreePerfAnalyzer
 from TraceLens.PerfModel.torch_op_mapping import build_sheet_category_to_op_names
-from TraceLens.Reporting.reporting_utils import request_install
+from TraceLens.Reporting.reporting_utils import (
+    add_gpu_arch_cli_args,
+    request_install,
+    resolve_gpu_arch,
+)
 
 
 def get_dfs_short_kernels(
@@ -264,9 +268,11 @@ def generate_perf_report_pytorch(
     topk_roofline_ops: Optional[int] = None,
     comparison_json_path: Optional[str] = None,
     extension_file: Optional[str] = None,
-    # for gemm simulator / Origami (Origami requires --enable_origami when using gpu_arch_json_path)
+    # for gemm simulator / Origami (Origami requires --enable_origami when arch is set)
     python_path: Optional[str] = None,
     gpu_arch_json_path: Optional[str] = None,
+    gpu_arch_platform: Optional[str] = None,
+    gpu_arch: Optional[dict] = None,
     inductor_cache_dir: Optional[str] = None,
     group_by_num_kernels: bool = False,
     enable_origami: bool = False,
@@ -274,11 +280,11 @@ def generate_perf_report_pytorch(
     detect_recompute: bool = False,
     include_call_stack: bool = False,
 ) -> Dict[str, pd.DataFrame]:
-    if gpu_arch_json_path:
-        with open(gpu_arch_json_path, "r") as f:
-            gpu_arch_json = json.load(f)
-    else:
-        gpu_arch_json = None
+    gpu_arch_json = resolve_gpu_arch(
+        gpu_arch_json_path=gpu_arch_json_path,
+        gpu_arch_platform=gpu_arch_platform,
+        gpu_arch=gpu_arch,
+    )
     add_python_func = True if include_call_stack else False
     perf_analyzer = TreePerfAnalyzer.from_file(
         profile_filepath=profile_json_path,
@@ -985,12 +991,7 @@ def main():
         default=None,
         help="Path to the python executable for gemm simulator",
     )
-    parser.add_argument(
-        "--gpu_arch_json_path",
-        type=str,
-        default=None,
-        help="Path to the GPU architecture JSON file",
-    )
+    add_gpu_arch_cli_args(parser)
     parser.add_argument(
         "--group_by_num_kernels",
         action="store_true",
@@ -1062,6 +1063,7 @@ def main():
         extension_file=args.extension_file,
         python_path=args.python_path,
         gpu_arch_json_path=args.gpu_arch_json_path,
+        gpu_arch_platform=args.gpu_arch_platform,
         group_by_num_kernels=args.group_by_num_kernels,
         enable_origami=args.enable_origami,
         detect_recompute=args.detect_recompute,

--- a/TraceLens/Reporting/generate_perf_report_pytorch_inference.py
+++ b/TraceLens/Reporting/generate_perf_report_pytorch_inference.py
@@ -24,7 +24,11 @@ import zipfile
 
 from TraceLens import NcclAnalyser, TraceToTree, TraceDiff, TreePerfAnalyzer
 from TraceLens.PerfModel.torch_op_mapping import build_sheet_category_to_op_names
-from TraceLens.Reporting.reporting_utils import request_install
+from TraceLens.Reporting.reporting_utils import (
+    add_gpu_arch_cli_args,
+    request_install,
+    resolve_gpu_arch,
+)
 from TraceLens.util import TraceEventUtils
 from TraceLens.Trace2Tree.trace_capture_merge_experimental import (
     merge_capture_trace_into_graph,
@@ -544,19 +548,21 @@ def generate_perf_report_pytorch(
     topk_roofline_ops: Optional[int] = None,
     comparison_json_path: Optional[str] = None,
     extension_file: Optional[str] = None,
-    # for gemm simulator / Origami (Origami requires --enable_origami when using gpu_arch_json_path)
+    # for gemm simulator / Origami (Origami requires --enable_origami when arch is set)
     python_path: Optional[str] = None,
     gpu_arch_json_path: Optional[str] = None,
+    gpu_arch_platform: Optional[str] = None,
+    gpu_arch: Optional[dict] = None,
     enable_origami: bool = False,
     group_by_parent_module: bool = False,
     group_by_num_kernels: bool = False,
     include_call_stack: bool = False,
 ) -> Dict[str, pd.DataFrame]:
-    if gpu_arch_json_path:
-        with open(gpu_arch_json_path, "r") as f:
-            gpu_arch_json = json.load(f)
-    else:
-        gpu_arch_json = None
+    gpu_arch_json = resolve_gpu_arch(
+        gpu_arch_json_path=gpu_arch_json_path,
+        gpu_arch_platform=gpu_arch_platform,
+        gpu_arch=gpu_arch,
+    )
     add_python_func = (
         True if (group_by_parent_module or include_call_stack is True) else False
     )
@@ -1287,12 +1293,7 @@ def main():
         default=None,
         help="Path to the python executable for gemm simulator",
     )
-    parser.add_argument(
-        "--gpu_arch_json_path",
-        type=str,
-        default=None,
-        help="Path to the GPU architecture JSON file",
-    )
+    add_gpu_arch_cli_args(parser)
     parser.add_argument(
         "--enable-origami",
         action="store_true",
@@ -1362,6 +1363,7 @@ def main():
         extension_file=args.extension_file,
         python_path=args.python_path,
         gpu_arch_json_path=args.gpu_arch_json_path,
+        gpu_arch_platform=args.gpu_arch_platform,
         enable_origami=args.enable_origami,
         group_by_parent_module=args.group_by_parent_module,
         group_by_num_kernels=args.group_by_num_kernels,

--- a/TraceLens/Reporting/reporting_utils.py
+++ b/TraceLens/Reporting/reporting_utils.py
@@ -4,7 +4,9 @@
 # See LICENSE for license information.
 ###############################################################################
 
+import argparse
 import ast
+import json
 import logging
 import re
 from typing import Dict, List, Optional, Union
@@ -15,6 +17,64 @@ import sys
 import subprocess
 
 logger = logging.getLogger(__name__)
+
+
+def resolve_gpu_arch(
+    *,
+    gpu_arch_json_path: Optional[str] = None,
+    gpu_arch_platform: Optional[str] = None,
+    gpu_arch: Optional[dict] = None,
+) -> Optional[dict]:
+    """Resolve a GPU architecture dict for roofline / Origami.
+
+    Exactly one of ``gpu_arch_json_path``, ``gpu_arch_platform``, or ``gpu_arch``
+    may be set. ``gpu_arch_platform`` is loaded via
+    ``TraceLens.Agent.Analysis.utils.arch_utils.load_arch``.
+    """
+    sources = [
+        gpu_arch_json_path is not None,
+        gpu_arch_platform is not None,
+        gpu_arch is not None,
+    ]
+    if sum(sources) > 1:
+        raise ValueError(
+            "At most one of gpu_arch_json_path, gpu_arch_platform, and gpu_arch "
+            "may be set."
+        )
+    if gpu_arch is not None:
+        return gpu_arch
+    if gpu_arch_json_path is not None:
+        with open(gpu_arch_json_path, "r") as f:
+            return json.load(f)
+    if gpu_arch_platform is not None:
+        from TraceLens.Agent.Analysis.utils.arch_utils import load_arch
+
+        return load_arch(gpu_arch_platform)
+    return None
+
+
+def add_gpu_arch_cli_args(parser: argparse.ArgumentParser) -> None:
+    """Add mutually exclusive GPU arch CLI options to *parser*."""
+    from TraceLens.Agent.Analysis.utils.arch_utils import list_platforms
+
+    platforms = ", ".join(list_platforms())
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--gpu_arch_json_path",
+        type=str,
+        default=None,
+        help="Path to the GPU architecture JSON file",
+    )
+    group.add_argument(
+        "--gpu_arch_platform",
+        type=str,
+        default=None,
+        metavar="PLATFORM",
+        help=(
+            "Bundled or TL_EXTENSION platform name loaded via load_arch "
+            f"(available: {platforms})"
+        ),
+    )
 
 
 def export_data_df(

--- a/tests/test_reporting_gpu_arch.py
+++ b/tests/test_reporting_gpu_arch.py
@@ -1,0 +1,106 @@
+###############################################################################
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Tests for GPU arch resolution in Reporting scripts."""
+
+import json
+import os
+import tempfile
+
+import pytest
+
+from TraceLens.Agent.Analysis.utils.arch_utils import load_arch
+from TraceLens.Reporting.reporting_utils import resolve_gpu_arch
+from TraceLens.Reporting.generate_perf_report_pytorch import (
+    generate_perf_report_pytorch,
+)
+
+TRACE_PATH = os.path.join(
+    "tests",
+    "traces",
+    "mi300",
+    "Falconsai_nsfw_image_detection__1016002.json.gz",
+)
+
+VALID_BOUND_VALUES = {"COMPUTE_BOUND", "MEMORY_BOUND"}
+
+
+def test_resolve_gpu_arch_returns_none_by_default():
+    assert resolve_gpu_arch() is None
+
+
+def test_resolve_gpu_arch_from_json_path():
+    arch = {"name": "test-gpu", "mem_bw_gbps": 1}
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump(arch, f)
+        path = f.name
+    try:
+        assert resolve_gpu_arch(gpu_arch_json_path=path) == arch
+    finally:
+        os.unlink(path)
+
+
+def test_resolve_gpu_arch_from_platform():
+    loaded = resolve_gpu_arch(gpu_arch_platform="MI300X")
+    assert loaded["name"] == "MI300X"
+    assert "max_achievable_tflops" in loaded
+
+
+def test_resolve_gpu_arch_platform_matches_load_arch():
+    assert resolve_gpu_arch(gpu_arch_platform="MI300X") == load_arch("MI300X")
+
+
+def test_resolve_gpu_arch_direct_dict():
+    arch = {"name": "inline"}
+    assert resolve_gpu_arch(gpu_arch=arch) is arch
+
+
+def test_resolve_gpu_arch_rejects_multiple_sources():
+    with pytest.raises(ValueError, match="At most one"):
+        resolve_gpu_arch(
+            gpu_arch_json_path="/tmp/a.json",
+            gpu_arch_platform="MI300X",
+        )
+    with pytest.raises(ValueError, match="At most one"):
+        resolve_gpu_arch(gpu_arch={"name": "x"}, gpu_arch_platform="MI300X")
+
+
+def test_resolve_gpu_arch_unknown_platform():
+    with pytest.raises(KeyError):
+        resolve_gpu_arch(gpu_arch_platform="NotARealPlatformXYZ")
+
+
+def _find_col(df, prefix):
+    for col in df.columns:
+        if col.startswith(prefix):
+            return col
+    return None
+
+
+@pytest.fixture(scope="module")
+def perf_report_from_platform(tmp_path_factory):
+    output_dir = tmp_path_factory.mktemp("gpu_arch_platform")
+    csv_dir = str(output_dir / "perf_report_csvs")
+    generate_perf_report_pytorch(
+        profile_json_path=TRACE_PATH,
+        output_xlsx_path=None,
+        output_csvs_dir=csv_dir,
+        gpu_arch_platform="MI300X",
+        enable_origami=True,
+    )
+    return csv_dir
+
+
+def test_roofline_bound_with_gpu_arch_platform(perf_report_from_platform):
+    import pandas as pd
+
+    df = pd.read_csv(
+        os.path.join(perf_report_from_platform, "unified_perf_summary.csv")
+    )
+    bound_col = _find_col(df, "Roofline Bound")
+    assert bound_col is not None
+    bound_vals = set(df[bound_col].dropna().unique())
+    assert bound_vals <= VALID_BOUND_VALUES, f"Unexpected values: {bound_vals}"


### PR DESCRIPTION
When creating the Agent analysis for TraceLens, we created a set of utilities to pull GPU architecture files from known locations rather than explicitly providing them.

This PR wires these utilities up to the individual reports in TraceLens