### PR TITLE
fix capture traces directory inside the torch profiler dir

### DIFF
--- a/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.14.0.patch
+++ b/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.14.0.patch
@@ -65,7 +65,7 @@ index 525ad5db4..bb182e02e 100644
 +        enable_profiler = (local_rank == 0) and self.vllm_config.profiler_config.capture_torch_profiler_dir
 +
 +        if enable_profiler:
-+            trace_dir = self.vllm_config.profiler_config.capture_torch_profiler_dir
++            trace_dir = self.vllm_config.profiler_config.torch_profiler_dir + "/capture_traces"
 +            profiler = torch.profiler.profile(
 +                activities=[
 +                    torch.profiler.ProfilerActivity.CPU,

--- a/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.15.0.patch
+++ b/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.15.0.patch
@@ -59,7 +59,7 @@ index 64f6263cc..9eb356b5f 100644
 +        enable_profiler = (local_rank == 0) and self.vllm_config.profiler_config.capture_torch_profiler_dir
 +        
 +        if enable_profiler:
-+            trace_dir = self.vllm_config.profiler_config.capture_torch_profiler_dir
++            trace_dir = self.vllm_config.profiler_config.torch_profiler_dir + "/capture_traces"
 +            profiler = torch.profiler.profile(
 +                activities=[
 +                    torch.profiler.ProfilerActivity.CPU,

--- a/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.16.0.patch
+++ b/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.16.0.patch
@@ -59,7 +59,7 @@ index a7c2a8800..4b2e16fbc 100644
 +        enable_profiler = (local_rank == 0) and self.vllm_config.profiler_config.capture_torch_profiler_dir
 +        
 +        if enable_profiler:
-+            trace_dir = self.vllm_config.profiler_config.capture_torch_profiler_dir
++            trace_dir = self.vllm_config.profiler_config.torch_profiler_dir + "/capture_traces"
 +            profiler = torch.profiler.profile(
 +                activities=[
 +                    torch.profiler.ProfilerActivity.CPU,

--- a/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.17.0.patch
+++ b/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.17.0.patch
@@ -59,7 +59,7 @@ index e4ddefc81..3942904f9 100644
 +        enable_profiler = (local_rank == 0) and self.vllm_config.profiler_config.capture_torch_profiler_dir
 +        
 +        if enable_profiler:
-+            trace_dir = self.vllm_config.profiler_config.capture_torch_profiler_dir
++            trace_dir = self.vllm_config.profiler_config.torch_profiler_dir + "/capture_traces"
 +            profiler = torch.profiler.profile(
 +                activities=[
 +                    torch.profiler.ProfilerActivity.CPU,

--- a/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.18.0.patch
+++ b/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.18.0.patch
@@ -59,7 +59,7 @@ index 98e1dab36..a22fcc79d 100644
 +        local_rank = get_world_group().local_rank
 +        enable_profiler = (local_rank == 0) and self.vllm_config.profiler_config.capture_torch_profiler_dir
 +        if enable_profiler:
-+            trace_dir = self.vllm_config.profiler_config.capture_torch_profiler_dir
++            trace_dir = self.vllm_config.profiler_config.torch_profiler_dir + "/capture_traces"
 +            profiler = torch.profiler.profile(
 +                activities=[
 +                    torch.profiler.ProfilerActivity.CPU,

--- a/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.19.0.patch
+++ b/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.19.0.patch
@@ -59,7 +59,7 @@ index 2e62206da..3194ea16f 100644
 +        local_rank = get_world_group().local_rank
 +        enable_profiler = (local_rank == 0) and self.vllm_config.profiler_config.capture_torch_profiler_dir
 +        if enable_profiler:
-+            trace_dir = self.vllm_config.profiler_config.capture_torch_profiler_dir
++            trace_dir = self.vllm_config.profiler_config.torch_profiler_dir + "/capture_traces"
 +            profiler = torch.profiler.profile(
 +                activities=[
 +                    torch.profiler.ProfilerActivity.CPU,

--- a/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.20.0.patch
+++ b/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.20.0.patch
@@ -58,7 +58,7 @@ index a0ba47f..e8150c6 100644
 +        local_rank = get_world_group().local_rank
 +        enable_profiler = (local_rank == 0) and self.vllm_config.profiler_config.capture_torch_profiler_dir
 +        if enable_profiler:
-+            trace_dir = self.vllm_config.profiler_config.capture_torch_profiler_dir
++            trace_dir = self.vllm_config.profiler_config.torch_profiler_dir + "/capture_traces"
 +            profiler = torch.profiler.profile(
 +                activities=[
 +                    torch.profiler.ProfilerActivity.CPU,

--- a/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.21.0.patch
+++ b/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.21.0.patch
@@ -58,7 +58,7 @@ index 98b2fbf12..d7f1f5179 100644
 +        local_rank = get_world_group().local_rank
 +        enable_profiler = (local_rank == 0) and self.vllm_config.profiler_config.capture_torch_profiler_dir
 +        if enable_profiler:
-+            trace_dir = self.vllm_config.profiler_config.capture_torch_profiler_dir
++            trace_dir = self.vllm_config.profiler_config.torch_profiler_dir + "/capture_traces"
 +            profiler = torch.profiler.profile(
 +                activities=[
 +                    torch.profiler.ProfilerActivity.CPU,


### PR DESCRIPTION
This pull request updates the way profiler trace directories are set up in several patch files for different `vllm` versions. Instead of using the `capture_torch_profiler_dir` directly, the code now constructs the trace directory by appending `/capture_traces` to the `torch_profiler_dir` path. This ensures consistency in where profiler traces are stored across all supported versions.

**Profiler trace directory update:**

* Changed the assignment of `trace_dir` in all `config_vllm_v0.14.0.patch`, `config_vllm_v0.15.0.patch`, `config_vllm_v0.16.0.patch`, `config_vllm_v0.17.0.patch`, `config_vllm_v0.18.0.patch`, `config_vllm_v0.19.0.patch`, `config_vllm_v0.20.0.patch`, and `config_vllm_v0.21.0.patch` to use `self.vllm_config.profiler_config.torch_profiler_dir + "/capture_traces"` instead of `capture_torch_profiler_dir`. [[1]](diffhunk://#diff-e52de35a2f127f650a0c366525b4b165b1536da40a0fa588affe361a325bdb25L68-R68) [[2]](diffhunk://#diff-9e247fc5fd178a9e0c2cdc8069a08d05bdf8d6fa3221b0586a744469d5ad7f3dL62-R62) [[3]](diffhunk://#diff-1aff913653e81e2925c0141dd2b8b287184d4cd0bef7e8d78e06eaa77e13d028L62-R62) [[4]](diffhunk://#diff-573509070a76968c5ec8c695a9ce568ec994032c2ef8979d8fd7441fcdae7df1L62-R62) [[5]](diffhunk://#diff-96c8bc8d1ef177a538f5707e2fa92da3ec16f330c6fb3c73000977a8cd07eac3L62-R62) [[6]](diffhunk://#diff-d0a52249b1cb29a6c189770e443f0998d087a9b9ada0a1c5fc8b6340b84e885fL62-R62) [[7]](diffhunk://#diff-bbb65cd1e9dc0fa6e7e351de23da5e4c7365fa4aadd36bcfec64acdbbf4f01fbL61-R61) [[8]](diffhunk://#diff-8a129650614cc4d2ab18e798ab98dcb1763f00c24240f3b238fcec5923637dfeL61-R61)
<!--
Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.

See LICENSE for license information.
-->

