### PR TITLE
Diagnostics Tags

### DIFF
--- a/TraceLens/Agent/Analysis/.cursor/skills/analysis-orchestrator.md
+++ b/TraceLens/Agent/Analysis/.cursor/skills/analysis-orchestrator.md
@@ -148,7 +148,7 @@ Write the resolved template to `<output_dir>/cache/cmd_prefix.txt`. Then validat
 <prefix> python3 -c "import TraceLens; print('PREFIX_OK')"
 ```
 
-If this fails, check that `<tracelens_dir>` is the **parent** of TraceLens (not the repo root itself), verify the container/venv is accessible, rebuild, and retry. Do NOT proceed to Step 1 until validation passes.
+If this fails, inform the user with `[DIAG:pipeline:PREFIX_FAIL]` and check that `<tracelens_dir>` is the **parent** of TraceLens (not the repo root itself), verify the container/venv is accessible, rebuild, and retry. Do NOT proceed to Step 1 until validation passes.
 
 ### Command Execution Pattern
 
@@ -614,11 +614,9 @@ embed_plot_in_report(sys.argv[1])
 If the plot is skipped, the `{{PERF_PLOT}}` placeholder is removed so the report remains clean.
 ---
 
-## Unsupported Trace Features
+## Trace Feature Detection
 
-If Steps 1 or many of Steps 2-5 fail or produce unexpected results, check whether the trace uses unsupported features before retrying:
-
-- **Torch Compile**: `ops_summary.csv` contains op names matching `triton_poi_fused_*`, `triton_red_fused_*`, `triton_per_fused_*`, or `CompiledFunction`. If found, inform the user.
+If Steps 1 or many of Steps 2-5 fail or produce unexpected results, check whether the trace uses the following features before retrying:
 - **GPU Graph Replay**: raw trace JSON contains `hipGraphLaunch` or `cudaGraphLaunch`.
-  - **Default mode** (analysis_mode = `default`): Inform the user that GPU graph replay was detected and that the default analysis mode supports typical PyTorch traces. **Abort** -- do not retry or continue.
+  - **Default mode** (analysis_mode = `default`): Inform the user with `[DIAG:trace_quality:GPU_GRAPH_REPLAY]` that GPU graph replay was detected and that the default analysis mode supports typical PyTorch traces. **Abort** -- do not retry or continue.
   - **Inference mode** (analysis_mode = `inference`): Graph launches are expected and supported if graph capture folder is provided, do not abort. If inference_exec_mode is `eager` (no capture folder was provided), continue.

--- a/TraceLens/Agent/Analysis/utils/orchestrator_prepare.py
+++ b/TraceLens/Agent/Analysis/utils/orchestrator_prepare.py
@@ -824,6 +824,14 @@ def main():
         trace1_csv_dir = os.path.join(output_dir, "perf_report_csvs")
         trace2_csv_dir = None
 
+    try:
+        for csv_dir in filter(None, [trace1_csv_dir, trace2_csv_dir]):
+            if not os.path.isdir(csv_dir) or not os.listdir(csv_dir):
+                raise FileNotFoundError(csv_dir)
+    except FileNotFoundError as e:
+        print(f"[DIAG:pipeline:STEP1_FAIL] Perf report CSVs missing at {e}")
+        sys.exit(1)
+
     print("=" * 80)
     print("TRACELENS AGENT - ORCHESTRATOR PREPARATION")
     print("=" * 80)
@@ -879,10 +887,13 @@ def main():
         f"  Communication: {gpu_utilization_metrics['exposed_comm_time_percent']:.4f}%"
     )
     print(f"  MemCpy: {gpu_utilization_metrics['exposed_memcpy_time_percent']:.2f}%")
-    print(f"  Idle: {gpu_utilization_metrics['idle_time_percent']:.2f}%")
+    idle_pct = gpu_utilization_metrics['idle_time_percent']
+    print(f"  Idle: {idle_pct:.2f}%")
 
-    if gpu_utilization_metrics["computation_time_percent"] < 95:
-        print(f"  ⚠️  WARNING: Compute utilization < 95%")
+    if idle_pct > 15:
+        print(f"  [DIAG:trace_quality:HIGH_IDLE] GPU idle time {idle_pct:.1f}% exceeds 15% threshold")
+    if gpu_utilization_metrics["computation_time_percent"] < 85:
+        print(f"  [DIAG:trace_quality:HIGH_IDLE] Compute utilization < 85%")
 
     # ============================================================================
     # STEP 3: Identify Top Operations
@@ -1209,7 +1220,7 @@ def main():
                 json.dump([], f)
 
     except Exception as e:
-        print(f"  ⚠️  Error during tree data pre-computation: {e}")
+        print(f"  [DIAG:pipeline:STEP2_5_FAIL] Error during tree data pre-computation: {e}")
         traceback.print_exc()
 
     # ============================================================================


### PR DESCRIPTION
Add [DIAG:category:id] tags to orchestrator diagnostic messages so the triage skill can grep for them in stream JSONB and disk artifacts. Tags are added inline to orchestrator_prepare.py (STEP1_FAIL, HIGH_IDLE, STEP2_5_FAIL) and to the orchestrator skill prose (PREFIX_FAIL, GPU_GRAPH_REPLAY). Also fixes the "Unsupported Trace Features" section: renames it to "Trace Feature Detection" and updates the Torch Compile bullet to reflect that Triton is now a supported category routed to triton-analyzer.