### PR TITLE
Re-introduce Paths for Ops

### DIFF
--- a/TraceLens/Agent/Analysis/category_analyses/analysis_utils.py
+++ b/TraceLens/Agent/Analysis/category_analyses/analysis_utils.py
@@ -129,6 +129,11 @@ _KNOWN_PKG_ANCHORS = (
     "torchrec/",
     "components/",
     "megatron/",
+    "transformers/",
+    "model/",
+    "deepspeed/",
+    "flash_attn/",
+    "ops/",
 )
 
 
@@ -464,10 +469,8 @@ def _extract_launcher_path(call_stack_str: str, op_name: str) -> str:
     """Return the first non-infrastructure .py frame from a call stack, relativized.
 
     Absolute container prefixes are stripped using ``_KNOWN_PKG_ANCHORS``; unknown
-    roots fall back to the last 3 path segments.  ``aten::`` ops always return "".
+    roots fall back to the last 3 path segments.
     """
-    if op_name.startswith("aten::"):
-        return ""
     if not call_stack_str or call_stack_str == "nan":
         return ""
     frames = [f.strip() for f in call_stack_str.split(" => ")]
@@ -499,6 +502,17 @@ def _extract_module_chain(call_stack_str: str) -> List[str]:
         for f in call_stack_str.split(" => ")
         if f.strip().startswith("nn.Module: ")
     ]
+
+
+def _extract_backward_context(call_chain: List[str], library: str) -> str:
+    """Produce a descriptive label for autograd backward ops."""
+    for frame in call_chain:
+        if "autograd::engine::evaluate_function:" in frame:
+            fn = frame.split("autograd::engine::evaluate_function:")[-1].strip()
+            if library:
+                return f"{library} ({fn})"
+            return fn
+    return ""
 
 
 def _extract_call_chain(call_stack_str: str) -> List[str]:
@@ -639,8 +653,23 @@ def build_operation_metrics(
         cs_raw = row.get("call_stack")
         cs_str = "" if cs_raw is None or pd.isna(cs_raw) else str(cs_raw)
         launcher = _extract_launcher_path(cs_str, op_name)
-        op_metric["launcher_path"] = launcher if launcher else "—"
-        op_metric["module_chain"] = _extract_module_chain(cs_str)
+
+        if not launcher:
+            launcher = _extract_backward_context(
+                _extract_call_chain(cs_str) if cs_str else [],
+                op_metric.get("library", ""),
+            )
+
+        module_chain = _extract_module_chain(cs_str)
+
+        if not launcher and module_chain:
+            launcher = " > ".join(module_chain[:3])
+
+        if not launcher and op_metric.get("library"):
+            launcher = f"{op_metric['library']} (vendor)"
+
+        op_metric["launcher_path"] = launcher if launcher else "\u2014"
+        op_metric["module_chain"] = module_chain
         op_metric["_raw_call_stack"] = cs_str
 
         operations.append(op_metric)


### PR DESCRIPTION
## Summary

Fills the Kernel Path column for `aten::` operations that previously showed "---" despite having call stacks. Removes the blanket `aten::` early-return in `_extract_launcher_path()`, extends `_KNOWN_PKG_ANCHORS` with 5 package roots, and adds a tiered fallback chain (autograd backward label, module chain, library tag) for ops without user `.py` frames.

1 file changed, +34 insertions, -5 deletions.

## Why

| Pain point | Old | New |
|---|---|---|
| All `aten::` ops return empty launcher_path | `_extract_launcher_path` early-returns `""` for any op starting with `aten::`, discarding rich call stacks | Guard removed; the existing frame-walking logic now extracts user `.py` frames for `aten::` ops |
| Backward-pass ops have no path even with autograd provenance | Ops like `aten::mm` through `autograd::engine::evaluate_function: AddmmBackward0` get "---" | New `_extract_backward_context()` produces `Tensile (AddmmBackward0)` combining library + backward function |
| Forward ops with only nn.Module lineage get "---" | Ops with `module_chain` like `['Conv2d', 'Conv2dNormActivation', 'ResBottleneckBlock']` but no user `.py` frame are blank | Module chain fallback renders `Conv2d > Conv2dNormActivation > ResBottleneckBlock` |
| HuggingFace, custom model, and DeepSpeed paths not recognized | `transformers/`, `model/`, `deepspeed/`, `flash_attn/`, `ops/` not in `_KNOWN_PKG_ANCHORS` | Added |

## Before / After Examples

**Vision-language inference trace (all `aten::` ops, 96 total):**

Before (0% coverage):
```
| aten::bmm | (1,16,5185,5185)... | —       | 36.13 | 3.98 | ...
| aten::mm  | (5185,768)...       | —       | 16.41 | 1.81 | ...
| aten::copy_| (1,16,5185,64)...  | —       | 6.23  | 0.69 | ...
```

After (100% coverage):
```
| aten::bmm | (1,16,5185,5185)... | transformers/models/owlv2/modeling_owlv2.py(410): forward | 36.13 | 3.98 | ...
| aten::mm  | (5185,768)...       | transformers/models/owlv2/modeling_owlv2.py(655): forward | 16.41 | 1.81 | ...
| aten::copy_| (1,16,5185,64)...  | transformers/models/owlv2/modeling_owlv2.py(407): _shape  | 6.23  | 0.69 | ...
```

**Training trace backward ops (autograd fallback):**

Before:
```
| aten::mm | (512,2048)... | —  | 1.82 | 0.17 | ...
```

After:
```
| aten::mm | (512,2048)... | Tensile (AddmmBackward0)  | 1.82 | 0.17 | ...
```

**Training trace forward ops (module chain fallback):**

Before:
```
| aten::batch_norm | (128,64,56,56)... | —  | 0.45 | 0.04 | ...
```

After:
```
| aten::batch_norm | (128,64,56,56)... | BatchNorm2d > Conv2dNormActivation > ResBottleneckBlock  | 0.45 | 0.04 | ...
```

## Architecture

```
unified_perf_callstacks.csv
        │
        ▼
┌───────────────────────────────────────────────────────┐
│  analysis_utils.py                                    │
│                                                       │
│  _KNOWN_PKG_ANCHORS ── +5 new package roots           │
│  _SKIP_PY_PATTERNS ── (unchanged)                     │
│                                                       │
│  _extract_launcher_path(call_stack, op_name)           │
│    ├─ [REMOVED] aten:: → ""                           │
│    ├─ skip torch/, _dynamo/, vllm/compilation/        │
│    └─ first qualifying .py frame → relativize         │
│                                                       │
│  _extract_backward_context(call_chain, library) [NEW]  │
│    └─ autograd::evaluate_function → "lib (BwdFn)"     │
│                                                       │
│  build_operation_metrics()                             │
│    ├─ Tier 1: _extract_launcher_path (user .py frame) │
│    ├─ Tier 2: _extract_backward_context               │
│    ├─ Tier 3: module_chain[:3] joined                 │
│    ├─ Tier 4: library + " (vendor)"                   │
│    └─ op_metric["launcher_path"] = result | "—"       │
└───────────────────────────────────────────────────────┘
        │
        ▼
  *_metrics.json → sub_agent_spec.md → analysis.md
```

## What changed

### Python (1 file)

| File | Change |
|---|---|
| `TraceLens/Agent/Analysis/category_analyses/analysis_utils.py` | Remove `aten::` early-return guard in `_extract_launcher_path()`. Add `transformers/`, `model/`, `deepspeed/`, `flash_attn/`, `ops/` to `_KNOWN_PKG_ANCHORS`. Add `_extract_backward_context()` helper. Replace single-line launcher assignment in `build_operation_metrics()` with 4-tier fallback chain. |

## Net diff

```
1 file changed, 34 insertions(+), 5 deletions(-)
```
