### PR TITLE
Recognize sglang step[DECODE]/step[EXTEND] markers in trace splitter

### DIFF
--- a/TraceLens/TraceUtils/split_inference_trace_annotation.py
+++ b/TraceLens/TraceUtils/split_inference_trace_annotation.py
@@ -359,11 +359,82 @@ def parse_range(range_str: str, max_len: int) -> Tuple[int, int]:
     return start, min(end, max_len)
 
 
+# ---------------------------------------------------------------------------
+# SGLang step-annotation grammar.
+#
+# SGLang annotates each forward step (see
+# ``sglang/srt/model_executor/model_runner.py:_build_step_span_name``) as a
+# ``user_annotation`` event named:
+#     step[EXTEND bs=<bs> toks=<ext_toks>]     # prefill / extend step
+#     step[DECODE bs=<bs>]                      # decode-only step
+#     step[<MODE> bs=<bs>]                      # any other ForwardMode (IDLE,
+#                                                 MIXED, TARGET_VERIFY, ...)
+# These differ from the vLLM ``execute_..._context_..._generation_...`` grammar
+# parsed below, so they need their own matcher / parser. EXTEND/PREFILL maps to
+# the prefill phase (context requests), DECODE maps to steady-state decode
+# (generation requests), MIXED carries both.
+# ---------------------------------------------------------------------------
+SGLANG_STEP_PATTERN = [
+    re.compile(r"step\[\s*[A-Za-z_]+\s+bs=\d+"),
+]
+
+_SGLANG_STEP_RE = re.compile(
+    r"step\[\s*(?P<mode>[A-Za-z_]+)\s+bs=(?P<bs>\d+)(?:\s+toks=(?P<toks>\d+))?",
+    re.IGNORECASE,
+)
+
+
+def _parse_sglang_step_name(name: str) -> Optional[dict]:
+    """Parse an SGLang ``step[...]`` annotation into iter-detail fields.
+
+    Returns ``None`` when *name* is not an SGLang step annotation so callers
+    can fall back to the vLLM grammar.
+    """
+    m = _SGLANG_STEP_RE.search(name)
+    if m is None:
+        return None
+    mode = m.group("mode").upper()
+    bs = int(m.group("bs"))
+    toks = int(m.group("toks")) if m.group("toks") is not None else None
+
+    if mode == "DECODE":
+        # Decode-only step: each of the ``bs`` requests emits one query token.
+        ctx_req, ctx_sum, gen_req, gen_sum = 0, 0, bs, bs
+    elif mode in ("EXTEND", "PREFILL", "DRAFT_EXTEND", "SPLIT_PREFILL"):
+        # Prefill / extend step: ``bs`` context requests, ``toks`` query tokens.
+        ctx_req, ctx_sum, gen_req, gen_sum = bs, (toks if toks is not None else bs), 0, 0
+    elif mode == "MIXED":
+        # Mixed step carries both prefill and decode work in the same batch.
+        ctx_req, ctx_sum, gen_req, gen_sum = bs, (toks if toks is not None else bs), bs, bs
+    elif mode == "IDLE":
+        ctx_req, ctx_sum, gen_req, gen_sum = 0, 0, 0, 0
+    else:
+        # Unknown forward mode: token-bearing -> treat as prefill, else decode.
+        if toks is not None:
+            ctx_req, ctx_sum, gen_req, gen_sum = bs, toks, 0, 0
+        else:
+            ctx_req, ctx_sum, gen_req, gen_sum = 0, 0, bs, bs
+
+    return {
+        "batch_size": ctx_sum + gen_sum,
+        "num_requests": ctx_req + gen_req,
+        "context_requests": ctx_req,
+        "context_sum": ctx_sum,
+        "generation_requests": gen_req,
+        "generation_sum": gen_sum,
+    }
+
+
 def get_iter_details_from_name(name: str, prefix: str = "annotation_iteration") -> dict:
 
-    name = name.replace("(", "_").replace(")", "_")
     if not "annotation_iteration" in prefix:
         return {"batch_size": 0}
+    # SGLang ``step[...]`` annotations use a different grammar than the vLLM
+    # ``execute_...`` names; try them first and fall back to the vLLM parser.
+    sglang_details = _parse_sglang_step_name(name)
+    if sglang_details is not None:
+        return sglang_details
+    name = name.replace("(", "_").replace(")", "_")
     iter_details = re.sub(r"[sqk]+", "_", name).split("_")
     if len(iter_details) < 10:
         ctx_req, ctx_sum, gen_req, gen_sum = (
@@ -1201,10 +1272,26 @@ def main():
     gpu_corr_map, flow_corr_map, meta_events = preprocess_trace(events)
     print(f"Loaded {len(events)} events")
 
-    # Find iterations and dummy runs
+    # Find iterations and dummy runs.
+    #
+    # Prefer the vLLM / roofline ``execute_..._context_..._generation_...``
+    # annotations (richer: they carry per-phase token sums). When the trace
+    # has none (e.g. an SGLang run where the roofline annotation patch is not
+    # active, or a stock SGLang build), fall back to SGLang's native
+    # ``step[DECODE bs=..]`` / ``step[EXTEND bs=.. toks=..]`` step markers so
+    # the steady-state split still works (issue #723). Preferring execute_*
+    # first also avoids double-counting when both are present (the execute_*
+    # annotation is nested inside the step[...] span).
     iteration_roots = find_events_by_pattern(
         events, ANNOTATION_PATTERN, "execution steps (iteration)", cat="user_annotation"
     )
+    if not iteration_roots:
+        iteration_roots = find_events_by_pattern(
+            events,
+            SGLANG_STEP_PATTERN,
+            "SGLang step annotations (iteration)",
+            cat="user_annotation",
+        )
     dummy_roots = find_events_by_pattern(events, RUNTIME_EVENT_PATTERN, "_dummy_run")
 
     # Create output directory

--- a/tests/test_split_inference_sglang_markers.py
+++ b/tests/test_split_inference_sglang_markers.py
@@ -1,0 +1,163 @@
+###############################################################################
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Tests for sglang ``step[...]`` annotation parsing in the inference trace splitter.
+
+Regression coverage for issue #723: the splitter previously only recognized
+vLLM-style ``execute_..._context_..._generation_...`` iteration markers and
+crashed on sglang traces whose per-step ``user_annotation`` markers are named
+``step[DECODE bs=N]`` / ``step[EXTEND bs=N toks=M]``.
+"""
+
+import pytest
+
+from TraceLens.TraceUtils.split_inference_trace_annotation import (
+    SGLANG_STEP_PATTERN,
+    _parse_sglang_step_name,
+    find_phase_from_window,
+    get_iter_details_from_name,
+)
+
+
+# ---------------------------------------------------------------------------
+# Marker matching (find_events_by_pattern uses pattern.match, anchored at start)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "step[DECODE bs=64]",
+        "step[EXTEND bs=4 toks=512]",
+        "step[ EXTEND bs=4 toks=512 ]",
+        "step[MIXED bs=8 toks=100]",
+        "step[IDLE bs=0]",
+    ],
+)
+def test_sglang_step_pattern_matches_step_markers(name):
+    assert any(p.match(name) for p in SGLANG_STEP_PATTERN), name
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "execute_context_5(10)_generation_3(8)",
+        "ProfilerStep#3",
+        "vllm/v1/worker/gpu_model_runner.py(123): _dummy_run",
+        "nn.Module: FusedMoE",
+    ],
+)
+def test_sglang_step_pattern_ignores_non_sglang_names(name):
+    assert not any(p.match(name) for p in SGLANG_STEP_PATTERN), name
+
+
+# ---------------------------------------------------------------------------
+# _parse_sglang_step_name grammar
+# ---------------------------------------------------------------------------
+
+
+def test_parse_decode_step():
+    details = _parse_sglang_step_name("step[DECODE bs=64]")
+    assert details == {
+        "batch_size": 64,
+        "num_requests": 64,
+        "context_requests": 0,
+        "context_sum": 0,
+        "generation_requests": 64,
+        "generation_sum": 64,
+    }
+
+
+def test_parse_extend_step_with_tokens():
+    details = _parse_sglang_step_name("step[EXTEND bs=4 toks=512]")
+    assert details == {
+        "batch_size": 512,
+        "num_requests": 4,
+        "context_requests": 4,
+        "context_sum": 512,
+        "generation_requests": 0,
+        "generation_sum": 0,
+    }
+
+
+def test_parse_extend_step_without_tokens_falls_back_to_bs():
+    details = _parse_sglang_step_name("step[EXTEND bs=4]")
+    assert details["context_requests"] == 4
+    assert details["context_sum"] == 4
+    assert details["generation_requests"] == 0
+
+
+def test_parse_mixed_step_carries_both_phases():
+    details = _parse_sglang_step_name("step[MIXED bs=8 toks=100]")
+    assert details["context_requests"] == 8
+    assert details["context_sum"] == 100
+    assert details["generation_requests"] == 8
+    assert details["generation_sum"] == 8
+
+
+def test_parse_idle_step_is_empty():
+    details = _parse_sglang_step_name("step[IDLE bs=0]")
+    assert details["num_requests"] == 0
+    assert details["batch_size"] == 0
+
+
+def test_parse_is_case_insensitive_for_mode():
+    assert _parse_sglang_step_name("step[decode bs=2]")["generation_requests"] == 2
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "execute_context_5(10)_generation_3(8)",
+        "ProfilerStep#3",
+        "completely unrelated name",
+    ],
+)
+def test_parse_returns_none_for_non_sglang(name):
+    assert _parse_sglang_step_name(name) is None
+
+
+# ---------------------------------------------------------------------------
+# get_iter_details_from_name dispatches sglang first, vLLM fallback unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_get_iter_details_uses_sglang_branch():
+    assert get_iter_details_from_name("step[DECODE bs=64]") == _parse_sglang_step_name(
+        "step[DECODE bs=64]"
+    )
+
+
+def test_get_iter_details_vllm_grammar_still_parses():
+    """vLLM names must still flow through the legacy parser (no regression)."""
+    details = get_iter_details_from_name("execute_context_5(10)_generation_3(8)")
+    assert details == {
+        "batch_size": 18,
+        "num_requests": 8,
+        "context_requests": 5,
+        "context_sum": 10,
+        "generation_requests": 3,
+        "generation_sum": 8,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Phase classification over a window of sglang steps
+# ---------------------------------------------------------------------------
+
+
+def test_find_phase_from_window_classifies_sglang_steps():
+    names = (
+        ["step[DECODE bs=64]"] * 3
+        + ["step[EXTEND bs=4 toks=512]"] * 2
+        + ["step[MIXED bs=8 toks=100]"]
+    )
+    iter_details = [get_iter_details_from_name(n) for n in names]
+    phase = find_phase_from_window(iter_details)
+    assert phase["num_decode"] == 3
+    assert phase["num_prefill"] == 2
+    assert phase["num_prefilldecode"] == 1


### PR DESCRIPTION
## Summary

Fixes the inference trace splitter (`TraceLens/TraceUtils/split_inference_trace_annotation.py`) crashing on **sglang** torch traces. The splitter only matched vLLM-style `execute_..._context_..._generation_...` iteration markers, so on sglang traces — whose per-step `user_annotation` markers are named `step[DECODE bs=N]` / `step[EXTEND bs=N toks=M]` — it found **0** iteration roots, extracted **0** chunks, produced no steady-state split, and triggered downstream `trace_split_no_steady_state` failures (observed on Qwen3-30B-A3B, sglang, MI300X).

## Changes

- **`SGLANG_STEP_PATTERN`** + an `iteration_roots` fallback in `main()`: the sglang grammar is tried **only when no vLLM `execute_*` annotations are present**, so traces that carry both nested markers are not double-counted (the `execute_*` annotation is nested inside the `step[...]` span).
- **`_parse_sglang_step_name()`** maps each step mode to iter-detail fields:
  - `DECODE` → decode requests (`generation_requests = bs`)
  - `EXTEND` / `PREFILL` → context requests (`context_requests = bs`, `context_sum = toks`)
  - `MIXED` → both phases
  - `IDLE` → empty
  - unknown mode → token-bearing treated as prefill, else decode
- **`get_iter_details_from_name()`** consults the sglang parser first and falls back to the existing vLLM grammar (unchanged for vLLM names).

The change is additive: vLLM trace handling is untouched (sglang parser returns `None` for non-sglang names).

## Files changed

- `TraceLens/TraceUtils/split_inference_trace_annotation.py` — sglang step grammar + fallback wiring
- `tests/test_split_inference_sglang_markers.py` — new unit tests

## Test plan

- [x] `pytest tests/test_split_inference_sglang_markers.py` (21 passed): marker matching, step grammar (DECODE/EXTEND/MIXED/IDLE, with/without `toks`, case-insensitive), sglang/vLLM dispatch in `get_iter_details_from_name` (incl. vLLM regression), and phase classification over a mixed window.
- [x] `pytest tests/test_copyright_headers.py` (new file carries the standard header).

Closes #723

Made with [Cursor](https://cursor.com)