### PR TITLE
Reasoning Marker Robustness

### DIFF
--- a/TraceLens/Agent/Analysis/.cursor/agents/kernel-fusion-analyzer.md
+++ b/TraceLens/Agent/Analysis/.cursor/agents/kernel-fusion-analyzer.md
@@ -200,7 +200,7 @@ Found N kernel fusion opportunities across M module types.
 
 ## Detailed Analysis
 
-<!-- reasoning-candidate tier=system rank=1 -->
+<!-- reasoning-candidate tier=fusion rank=1 -->
 #### <Pattern Name> (<time_ms> ms, <instance_count> instances)
 
 **Identification:** <1-2 sentences: how this fusion candidate was surfaced>
@@ -276,7 +276,7 @@ if not passed:
         print('  - ' + e)
     sys.exit(1)
 print('PASS: Findings file is valid')
-" '<output_dir>/system_findings/kernel_fusion_findings.md' 'system' '<comparison_scope>'
+" '<output_dir>/system_findings/kernel_fusion_findings.md' 'fusion' '<comparison_scope>'
 ```
 
 If validation fails, fix the findings file and re-run. Max 2 retries.

--- a/TraceLens/Agent/Analysis/utils/templates/analysis_template.md
+++ b/TraceLens/Agent/Analysis/utils/templates/analysis_template.md
@@ -340,6 +340,8 @@ communication/compute overlap). These affect the GPU pipeline as a whole.
 <!-- Paste reasoning blocks from sub-agent findings, augment headings with P-numbers, icons, and HTML anchors. Everything else should be copied verbatim-->
 <!-- Detailed Analysis labels per rule 9 — do not use these labels in optimization cards above -->
 <!-- Impact estimate bullets are rendered by each sub-agent from metadata/*.json → impact_estimates (same source as card Impact). -->
+<!-- MARKER CONTRACT: Every #### P<N>: heading in Detailed Analysis MUST be
+     preceded by  <!-- reasoning-candidate tier=<TIER> rank=<R> --> where TIER = compute | fusion | system (matching the ### subsection), R= 1, 2, 3, … incrementing per tier (rank=1 for first item, rank=2 for second, etc.). -->
 
 ### Compute Kernel Insights
 
@@ -350,6 +352,7 @@ communication/compute overlap). These affect the GPU pipeline as a whole.
 <!-- === STANDALONE Compute Kernel Data table === Use this schema for standalone mode ONLY. Use these 8 exact columns-->
 
 <a id="detailed-analysis-compute-p1"></a>
+<!-- reasoning-candidate tier=compute rank=1 -->
 #### 🔴 P1: <Brief Title> (<Library>)
 **Identification:**
 **Data:**
@@ -368,6 +371,7 @@ communication/compute overlap). These affect the GPU pipeline as a whole.
      Difference (ms) = operations[i].difference_ms (negative ⇒ Trace 1 slower), or —. -->
 
 <a id="detailed-analysis-compute-p1"></a>
+<!-- reasoning-candidate tier=compute rank=1 -->
 #### 🔴 P1: <Brief Title>
 **Identification:** [1-2 sentences - How this opportunity was surfaced relative to the target trace. Must end with (source: <artifact> → <keys>).]
 **Data:** [1 sentence summary of table]
@@ -391,6 +395,7 @@ communication/compute overlap). These affect the GPU pipeline as a whole.
 <!-- If kernel_fusion category is not in the manifest or findings are empty, show "No fusion impact estimates available." -->
 
 <a id="detailed-analysis-fusion-P1"></a>
+<!-- reasoning-candidate tier=fusion rank=1 -->
 #### 🔴/🟡/🟢 P1: <Candidate Name> (<time_ms> ms, <instance_count> instances)
 
 **Identification:**
@@ -404,6 +409,7 @@ communication/compute overlap). These affect the GPU pipeline as a whole.
 **Impact estimate:**
 
 <a id="detailed-analysis-fusion-P2"></a>
+<!-- reasoning-candidate tier=fusion rank=2 -->
 #### 🔴/🟡/🟢 P2: <Candidate Name> (<time_ms> ms, <instance_count> instances)
 
 *Repeat the same Identification + Data + Impact estimate format for each candidate, with anchors `detailed-analysis-fusion-PN`.*
@@ -416,6 +422,7 @@ communication/compute overlap). These affect the GPU pipeline as a whole.
      In comparative mode, system-level analysis covers Trace 1 () only. -->
 
 <a id="detailed-analysis-system-p1"></a>
+<!-- reasoning-candidate tier=system rank=1 -->
 #### 🔴 P1: <Brief Title>
 **Identification:**
 **Data:**

--- a/TraceLens/Agent/Analysis/utils/validation_utils.py
+++ b/TraceLens/Agent/Analysis/utils/validation_utils.py
@@ -36,7 +36,10 @@ _SYSTEM_P_ITEM_LABELS = ["**Insight**", "**Action**", "**Impact**"]
 _KERNEL_FUSION_FINDINGS = "kernel_fusion_findings.md"
 # Optional icon / prefix before P<N> (e.g. kernel fusion `### 🟢 P1:`).
 _P_ITEM_RE = re.compile(r"^### .*?P(\d+)\s*:", re.MULTILINE)
-_CANDIDATE_RE = re.compile(r"<!-- reasoning-candidate\s+tier=\w+\s+rank=(\d+)\s*-->")
+_CANDIDATE_RE = re.compile(
+    r"<!-- reasoning-candidate\s+tier=(\w+)\s+rank=(\d+)\s*-->"
+)
+_DA_HEADING_RE = re.compile(r"^####\s+.*?P(\d+)\s*:", re.MULTILINE)
 _NOT_QUANTIFIABLE_SENTINEL = re.compile(
     r"not quantifiable from trace data", re.IGNORECASE
 )
@@ -141,7 +144,7 @@ def validate_findings_file(filepath, tier, comparison_scope=None):
 
     Args:
         filepath: Path to the *_findings.md file
-        tier: "compute" or "system"
+        tier: "compute", "system", or "fusion"
         comparison_scope: "standalone" or "comparative". When omitted, inferred
             from the category metrics JSON.
 
@@ -208,6 +211,17 @@ def validate_findings_file(filepath, tier, comparison_scope=None):
             f"P-item count ({len(p_items)}) does not match "
             f"reasoning-candidate count ({len(candidates)})"
         )
+
+    if candidates:
+        wrong_tier = [
+            (t, r) for t, r in candidates if t.lower() != tier
+        ]
+        if wrong_tier:
+            bad = ", ".join(f"tier={t} rank={r}" for t, r in wrong_tier)
+            errors.append(
+                f"reasoning-candidate tier mismatch: expected tier={tier}, "
+                f"found {bad}"
+            )
 
     # Compute tier only: shape + Args verbatim + Kernel Path verbatim, all
     # scoped to <!-- reasoning-candidate tier=compute --> blocks.
@@ -630,6 +644,8 @@ def validate_report(output_dir, comparison_scope=None):
 
     missing.extend(_validate_report_priority_consistency(content, output_dir))
 
+    missing.extend(_validate_report_reasoning_candidates(content))
+
     # Report-level marker structure
     missing.extend(MarkerValidator.check_report(report_path))
 
@@ -810,6 +826,59 @@ def _validate_report_priority_consistency(content, output_dir):
                 f"priority_data.json::priorities has {len(priorities)} entries"
             )
 
+    return errors
+
+
+def _extract_detailed_analysis_subsection(content, subsection_header):
+    """Extract a ### subsection from ## Detailed Analysis.
+
+    Returns the text from the subsection header to the next ### or ## header,
+    or None if not found.
+    """
+    da_start = content.find("## Detailed Analysis")
+    if da_start < 0:
+        return None
+    da_text = content[da_start:]
+    sub_start = da_text.find(subsection_header)
+    if sub_start < 0:
+        return None
+    sub_text = da_text[sub_start + len(subsection_header):]
+    next_h3 = re.search(r"^### ", sub_text, re.MULTILINE)
+    next_h2 = re.search(r"^## ", sub_text, re.MULTILINE)
+    ends = [pos.start() for pos in [next_h3, next_h2] if pos is not None]
+    end = min(ends) if ends else len(sub_text)
+    return sub_text[:end]
+
+
+def _validate_report_reasoning_candidates(content):
+    """Check reasoning-candidate markers in Detailed Analysis match P-item headings.
+
+    For each tier (compute / system), the number of
+    ``<!-- reasoning-candidate tier=<tier> -->`` markers must equal the number
+    of ``#### P<N>:`` headings in the corresponding subsection. Missing markers
+    break Hyperloom's ``parse_analysis_md()`` which uses them as block delimiters.
+    """
+    errors = []
+    checks = [
+        ("compute", "### Compute Kernel Insights"),
+        ("fusion", "### Kernel Fusion Insights"),
+        ("system", "### System-Level Insights"),
+    ]
+    for tier, header in checks:
+        subsection = _extract_detailed_analysis_subsection(content, header)
+        if subsection is None:
+            continue
+        n_headings = len(_DA_HEADING_RE.findall(subsection))
+        n_markers = sum(
+            1 for m in _CANDIDATE_RE.finditer(subsection)
+            if m.group(1).lower() == tier
+        )
+        if n_headings > 0 and n_markers != n_headings:
+            label = header.lstrip("# ")
+            errors.append(
+                f"R5: {label} has {n_headings} #### P<N>: headings but "
+                f"{n_markers} reasoning-candidate tier={tier} markers"
+            )
     return errors
 
 

--- a/agent_evals/Analysis/eval_utils/workflow_scripted_evals.py
+++ b/agent_evals/Analysis/eval_utils/workflow_scripted_evals.py
@@ -44,6 +44,9 @@ _MV_ATTR_RE = re.compile(r"\b(\w+)=([^\s]+)")
 _TOP_OPS_ROW_RE = re.compile(r"<!--\s*top-ops-row\s+([^>]*?)-->")
 _DETAIL_P_HEADER_RE = re.compile(r"^####\s+.+P(\d+):", re.MULTILINE)
 _DETAIL_P_HEADER_FALLBACK_RE = re.compile(r"^(?:####|###)\s+.+P(\d+):", re.MULTILINE)
+_REASONING_CANDIDATE_RE = re.compile(
+    r"<!--\s*reasoning-candidate\s+tier=(\w+)\s+rank=(\d+)\s*-->"
+)
 _NOT_QUANTIFIABLE_RE = re.compile(
     r"not\s+quantifiable\s+from\s+trace\s+data", re.IGNORECASE
 )
@@ -1155,6 +1158,98 @@ def _check_marker_detail_estimates(output_dir, comparison_scope=None):
     return rows
 
 
+def _extract_detailed_analysis_subsection(content, subsection_header):
+    """Extract a ### subsection from ## Detailed Analysis."""
+    da_match = re.search(
+        r"^## Detailed Analysis[^\n]*\n(.*?)(?=^## |\Z)",
+        content,
+        re.MULTILINE | re.DOTALL,
+    )
+    if not da_match:
+        return None
+    da_text = da_match.group(0)
+    sub_start = da_text.find(subsection_header)
+    if sub_start < 0:
+        return None
+    sub_text = da_text[sub_start + len(subsection_header) :]
+    next_h3 = re.search(r"^### ", sub_text, re.MULTILINE)
+    next_h2 = re.search(r"^## ", sub_text, re.MULTILINE)
+    ends = [pos.start() for pos in [next_h3, next_h2] if pos is not None]
+    end = min(ends) if ends else len(sub_text)
+    return sub_text[:end]
+
+
+def _check_marker_reasoning_candidates(output_dir, comparison_scope=None):
+    """Marker eval 4: reasoning-candidate markers match P-item headings per tier."""
+    content = _read_report(output_dir)
+    if content is None:
+        return [
+            _make_marker_row(
+                "marker_eval_4",
+                "Reasoning-candidate markers",
+                "FAIL",
+                "analysis.md not found",
+                "pipeline",
+                "Re-run report generation",
+            )
+        ]
+
+    rows = []
+    checks = [
+        ("compute", "### Compute Kernel Insights"),
+        ("fusion", "### Kernel Fusion Insights"),
+        ("system", "### System-Level Insights"),
+    ]
+    for tier, header in checks:
+        subsection = _extract_detailed_analysis_subsection(content, header)
+        if subsection is None:
+            continue
+        n_headings = len(_DETAIL_P_HEADER_RE.findall(subsection))
+        n_markers = sum(
+            1 for m in _REASONING_CANDIDATE_RE.finditer(subsection)
+            if m.group(1).lower() == tier
+        )
+        if n_headings == 0:
+            continue
+        result = "PASS" if n_markers == n_headings else "FAIL"
+        detail = (
+            ""
+            if result == "PASS"
+            else (
+                f"{n_headings} #### P<N>: headings but "
+                f"{n_markers} reasoning-candidate tier={tier} markers"
+            )
+        )
+        rows.append(
+            _make_marker_row(
+                f"marker_eval_4_{tier}",
+                f"reasoning-candidate markers ({tier})",
+                result,
+                detail,
+                "template" if result == "FAIL" else "",
+                (
+                    f"Add <!-- reasoning-candidate tier={tier} rank=N --> before each "
+                    f"#### P<N>: heading in {header}"
+                    if result == "FAIL"
+                    else ""
+                ),
+            )
+        )
+
+    if not rows:
+        rows.append(
+            _make_marker_row(
+                "marker_eval_4",
+                "Reasoning-candidate markers",
+                "PASS",
+                "No Detailed Analysis subsections with P-items found",
+                "",
+                "",
+            )
+        )
+    return rows
+
+
 _MULTI_EVAL_CHECKS = [
     _check_report_template,
     _check_exec_summary,
@@ -1163,6 +1258,7 @@ _MULTI_EVAL_CHECKS = [
     _check_marker_top_ops,
     _check_marker_p_items,
     _check_marker_detail_estimates,
+    _check_marker_reasoning_candidates,
 ]
 
 _GATE_FAIL_NEW_EVALS = [
@@ -1173,6 +1269,7 @@ _GATE_FAIL_NEW_EVALS = [
     ("marker_eval_1", "Top Operations markers (kind=top_ops)"),
     ("marker_eval_2", "P-item markers (kind=p_item)"),
     ("marker_eval_3", "Detail estimate markers (kind=detail_estimate)"),
+    ("marker_eval_4", "Reasoning-candidate markers"),
 ]
 
 


### PR DESCRIPTION
## Summary

Adds `<!-- reasoning-candidate tier=<TIER> rank=<R> -->` markers to the report template and fusion analyzer, introduces validation that marker counts match P-item heading counts per tier (compute/fusion/system), and extends the eval suite with a new `marker_eval_4` check. Downstream consumers use these markers as block delimiters; rare misses causes them to silently return zero candidates.

5 files changed, +207 insertions, −18 deletions.

## Why

| Pain point | Old | New |
|---|---|---|
| Final reports dropped all `reasoning-candidate` markers because the report template showed P-item blocks without them — the LLM had no example to follow | Template had bare `#### P<N>:` headings with no marker comments | Template includes `<!-- reasoning-candidate tier=compute rank=1 -->`, `tier=fusion`, and `tier=system` markers before every example P-item heading |
| Fusion findings were labeled `tier=system` at source, inflating system marker counts and leaving fusion items invisible to tier-scoped consumers | `kernel-fusion-analyzer.md` hardcoded `tier=system` in its template and passed `'system'` to `validate_findings_file` | Changed to `tier=fusion` in both the marker and the validation call |
| Neither `validate_report()` nor `validate_findings_file()` caught missing or wrong-tier markers | No marker-count or tier-value checks existed | `validate_report()` now runs `_validate_report_reasoning_candidates()` (R5 errors); `validate_findings_file()` rejects markers whose tier does not match the expected tier argument |
| The eval suite had no check for reasoning-candidate markers, so regressions went undetected | `workflow_scripted_evals.py` covered `top_ops`, `p_item`, and `detail_estimate` markers only | New `marker_eval_4` check with per-tier rows (`marker_eval_4_compute`, `marker_eval_4_fusion`, `marker_eval_4_system`) |

## Architecture

```
kernel-fusion-analyzer.md          sub_agent_spec.md (compute/system analyzers)
  tier=fusion rank=N                 tier=compute rank=N / tier=system rank=N
        │                                    │
        ▼                                    ▼
  *_findings.md  ──(verbatim copy)──►  analysis.md  (## Detailed Analysis)
                                             │
                    ┌────────────────────────┤
                    ▼                        ▼
        validate_findings_file()     validate_report()
          (Level 1: per-file)        (Level 3: assembled report)
          checks: tier value           checks: marker count == heading count
                    │                        │
                    ▼                        ▼
              retry/repair loop      retry/repair loop (Step 11.1)
                                             │
                                             ▼
                                  workflow_scripted_evals.py
                                    marker_eval_4 (per-tier)
```

## What changed

### Python (2 files)

| File | Change |
|---|---|
| `TraceLens/Agent/Analysis/utils/validation_utils.py` | Consolidated `_CANDIDATE_RE` to capture both tier and rank. Added `_DA_HEADING_RE`. Added `_extract_detailed_analysis_subsection()` and `_validate_report_reasoning_candidates()` (R5 check: marker count vs heading count per tier). Wired into `validate_report()`. Added tier-value check in `validate_findings_file()` — rejects markers whose tier does not match the expected argument. Updated docstring to accept `"fusion"` tier. |
| `agent_evals/Analysis/eval_utils/workflow_scripted_evals.py` | Added `_REASONING_CANDIDATE_RE` regex, `_extract_detailed_analysis_subsection()`, and `_check_marker_reasoning_candidates()` (marker_eval_4). Registered in `_MULTI_EVAL_CHECKS` and `_GATE_FAIL_NEW_EVALS`. |

### Templates (1 file)

| File | Change |
|---|---|
| `TraceLens/Agent/Analysis/utils/templates/analysis_template.md` | Added `<!-- reasoning-candidate tier=compute rank=1 -->` before standalone and comparative compute P-item examples, `tier=fusion rank=1/2` before fusion P-item examples, `tier=system rank=1` before the system P-item example. Added marker contract comment block above `## Detailed Analysis`. |

### Sub-agent .md files (1 file)

| File | Change |
|---|---|
| `TraceLens/Agent/Analysis/.cursor/agents/kernel-fusion-analyzer.md` | Changed marker from `tier=system` to `tier=fusion` in the Detailed Analysis template. Changed `validate_findings_file` call from `'system'` to `'fusion'`. |

### Orchestrator skill (1 file)

| File | Change |
|---|---|
| `TraceLens/Agent/Analysis/.cursor/skills/analysis-orchestrator.md` | Step 11 rewrite (incremental `tee -a` write order, `validate_report` now receives `comparison_scope`). Pre-existing change from a prior PR included in this branch. |

## Net diff

```
5 files changed, 207 insertions(+), 18 deletions(-)
```
