### PR TITLE
Other Kernel + Custom Collective Handling

### DIFF
--- a/TraceLens/Agent/Analysis/.cursor/agents/generic-op-analyzer.md
+++ b/TraceLens/Agent/Analysis/.cursor/agents/generic-op-analyzer.md
@@ -14,7 +14,7 @@ model: claude-opus-4-7-high
 
 Analyze GPU operations that do not fit standard categories (GEMM, SDPA, Elementwise, Reduce, Norm, Convolution, MoE, Triton). Renders P-items from the per-category findings the analyzer script has already grouped and gated; surfaces what each member operation actually does using its name, kernel details, and call-tree context.
 
-**Note:** Communication blocking, memcpy D2H/H2D patterns, and synchronization overhead are handled by the **Multi-Kernel** and **CPU/Idle** system-level analyzers. This analyzer must NOT duplicate those findings.
+**Note:** Communication blocking, memcpy D2H/H2D patterns, and synchronization overhead are handled by the **Multi-Kernel** and **CPU/Idle** system-level analyzers. This analyzer must NOT duplicate those findings. **Exception:** `customcollective` categories are in scope.
 
 ---
 
@@ -77,13 +77,15 @@ Use vendor-agnostic terminology:
 cat <output_dir>/category_data/<cat>_metrics.json
 ```
 
-`metrics['category_specific']` carries sub-category counts (`communication_count`, `graph_count`, `miscellaneous_count`). **Communication kernels are skipped by the analysis script**: if `category_specific.communication_ops_skipped.count > 0`, include a "Communication Kernels (Skipped)" section in the findings directing users to TraceLens's NCCL Analyzer and do NOT analyze those operations here.
+`metrics['category_specific']` carries sub-category counts (`communication_count`, `graph_count`, `miscellaneous_count`). If `category == "other"` and `category_specific.communication_ops_skipped.count > 0`, include a "Communication Kernels (Skipped)" section directing users to TraceLens's NCCL Analyzer.
 
 `operations[i].module_chain` (list of nn.Module names, leaf-to-root) identifies which model layer / module the op belongs to. Use it in the **Identification** prose to name what the operation actually does and where it sits. When `operations[i].call_chain` is present, use it for deeper context.
 
 ### Step 3: Render P-items from `category_findings`
 
 Read `category_data/<cat>_metrics.json::category_findings`. Per [`utils/templates/sub_agent_spec.md`](../utils/templates/sub_agent_spec.md), emit one P-item per entry in ascending `rank` order. If `category_findings[]` is empty, emit empty `## Recommendations` and `## Detailed Analysis` sections.
+
+Entries whose `members[].type == "unmodeled_significant"` (op with no perf model) render as the lowest-priority non-quantifiable cards — follow [`sub_agent_spec.md`](../utils/templates/sub_agent_spec.md) § Non-quantifiable findings.
 
 **efficiency_percent semantics:**
 - **Standalone:** Treat `efficiency_percent` as **% of roofline**.

--- a/TraceLens/Agent/Analysis/.cursor/skills/analysis-orchestrator.md
+++ b/TraceLens/Agent/Analysis/.cursor/skills/analysis-orchestrator.md
@@ -534,6 +534,7 @@ If the plot fails (extension-absent branch), retry once. If still failing, proce
    b. **Compute Kernel Optimizations** — append `## Compute Kernel Optimizations` with `### Top Operations` table and P-item cards. Use `<prefix> tee -a <output_dir>/analysis.md << 'SECTION_EOF'`.
       - Data sources: `priority_data.json` — P1 = `findings[0]`, P2 = `findings[1]`, ... ; each card joins its sub-agent's Detailed Analysis block by `(findings[i].category, findings[i].category_rank)`. The Top Operations table materializes `priorities[]` verbatim (one row per entry, array order, no re-sorting).
       - `category_findings/*.md` — for each findings file, copy its `## Recommendations` P-items into the report card slots. **Copy table cells verbatim** from the source `category_findings/<cat>_findings.md`.
+      - Non-quantifiable findings (`findings[i].members[0].type == "unmodeled_significant"`) sort last in `findings[]` — render them as the lowest-priority cards (do NOT skip them) per `sub_agent_spec.md § Non-quantifiable findings`.
 
    c. **Kernel Fusion** — append `## Kernel Fusion Opportunities (Experimental)`. Use `<prefix> tee -a <output_dir>/analysis.md << 'SECTION_EOF'`.
       - Data source: `system_findings/kernel_fusion_findings.md`.

--- a/TraceLens/Agent/Analysis/category_analyses/analysis_utils.py
+++ b/TraceLens/Agent/Analysis/category_analyses/analysis_utils.py
@@ -36,6 +36,9 @@ TARGET_MID = 87.5
 MIN_PITEM_IMPACT_SCORE = (
     0.5  # Group-sum (% E2E) below which a finding is dropped from priority_data.json.
 )
+UNMODELED_E2E_THRESHOLD = (
+    4.0  # Summed %E2E (per op-name, across shapes) above which an unmodeled op becomes a non-quantifiable low-priority finding.
+)
 _EFF_BUCKET_BOUNDARIES = (30, 60)
 
 _OP_NAME_LIBRARY_RULES = [
@@ -831,6 +834,80 @@ def build_category_findings(
     findings.sort(key=lambda f: f["impact_score"], reverse=True)
     for rank, f in enumerate(findings, start=1):
         f["rank"] = rank
+    return findings
+
+
+def build_unmodeled_significant_findings(
+    operations: List[dict],
+    category: str,
+    start_rank: int = 1,
+) -> List[dict]:
+    """Emit non-quantifiable findings for significant ops that have no perf model.
+
+    Contributions are summed by op-name across shapes before thresholding (so a
+    collective fragmented across token shapes is judged on its combined %E2E).
+    Findings carry ``impact_score = None`` and rank from ``start_rank`` after the
+    category's quantified findings.
+    """
+    aggregated = {}
+    for op in operations:
+        eff = op.get("efficiency") or {}
+        if eff.get("efficiency_percent") is not None:
+            continue
+        pct = op.get("percent_of_total")
+        if pct is None:
+            continue
+        if (op.get("time_ms") or 0) <= 0:
+            continue
+        if op.get("fusion_flagged"):
+            continue
+        name = op.get("name", "Unknown")
+        agg = aggregated.setdefault(
+            name,
+            {"percent_of_total": 0.0, "time_ms": 0.0, "n_shapes": 0, "library": None},
+        )
+        agg["percent_of_total"] += pct
+        agg["time_ms"] += op.get("time_ms", 0) or 0
+        agg["n_shapes"] += 1
+        if agg["library"] is None:
+            agg["library"] = op.get("library")
+
+    qualifying = [
+        (name, agg)
+        for name, agg in aggregated.items()
+        if agg["percent_of_total"] > UNMODELED_E2E_THRESHOLD
+    ]
+    qualifying.sort(key=lambda item: item[1]["percent_of_total"], reverse=True)
+
+    findings = []
+    for offset, (name, agg) in enumerate(qualifying):
+        member = {
+            "operation": name,
+            "category": category,
+            "type": "unmodeled_significant",
+            "impact_score": None,
+            "impact_score_low": None,
+            "impact_score_high": None,
+            "efficiency_pct": None,
+            "bound_type": None,
+            "library": agg["library"],
+            "time_ms": round(agg["time_ms"], 3),
+            "percent_of_total": round(agg["percent_of_total"], 2),
+            "n_shapes": agg["n_shapes"],
+        }
+        findings.append(
+            {
+                "bound_type": "unmodeled",
+                "library": agg["library"] or "Unknown",
+                "eff_bucket": "unknown",
+                "impact_score": None,
+                "impact_score_low": None,
+                "impact_score_high": None,
+                "member_count": 1,
+                "members": [member],
+                "rank": start_rank + offset,
+            }
+        )
     return findings
 
 

--- a/TraceLens/Agent/Analysis/category_analyses/other_analysis.py
+++ b/TraceLens/Agent/Analysis/category_analyses/other_analysis.py
@@ -25,6 +25,7 @@ from analysis_utils import (
     calculate_time_metrics,
     build_operation_metrics,
     build_category_findings,
+    build_unmodeled_significant_findings,
     compute_impact_estimates,
     write_metrics_json,
 )
@@ -158,6 +159,17 @@ def main():
     category_findings = build_category_findings(
         impact_estimates, comparison_scope=args.comparison_scope
     )
+
+    # Surface no-perf-model significant ops as non-quantifiable findings.
+    # Standalone only: comparative efficiency is a ratio, not a roofline gap.
+    if args.comparison_scope == "standalone":
+        category_findings.extend(
+            build_unmodeled_significant_findings(
+                operations,
+                category,
+                start_rank=len(category_findings) + 1,
+            )
+        )
 
     metrics = {
         "category": category,

--- a/TraceLens/Agent/Analysis/utils/report_utils.py
+++ b/TraceLens/Agent/Analysis/utils/report_utils.py
@@ -248,6 +248,9 @@ def generate_priority_data(output_dir: str, max_recommendations: int = 6) -> str
             }
         )
         for f in findings:
+            # impact_score=None (no perf model): excluded from rollup/plot, ranked last.
+            if f.get("impact_score") is None:
+                continue
             cat = f["category"]
             quantified[cat]["impact_score"] += f.get("impact_score", 0)
             quantified[cat]["impact_score_low"] += f.get("impact_score_low", 0)
@@ -323,7 +326,15 @@ def generate_priority_data(output_dir: str, max_recommendations: int = 6) -> str
             )
             next_rank += 1
 
-        findings.sort(key=lambda f: f["impact_score"], reverse=True)
+        # Quantified findings sort by impact_score descending; non-quantifiable
+        # (impact_score=None) findings always rank last.
+        findings.sort(
+            key=lambda f: (
+                f.get("impact_score") is not None,
+                f.get("impact_score") or 0,
+            ),
+            reverse=True,
+        )
         for global_rank, f in enumerate(findings, start=1):
             f["global_rank"] = global_rank
 

--- a/TraceLens/Agent/Analysis/utils/templates/analysis_template.md
+++ b/TraceLens/Agent/Analysis/utils/templates/analysis_template.md
@@ -158,6 +158,7 @@ One row per entry in `priority_data.json::priorities[]`, in array order (no mani
 <!-- Icon mapping by PRIORITY NUMBER (not severity): P1=🔴, P2=🟡, P3+=🟢 -->
 <!-- One card per entry in priority_data.findings[] in array order. Title uses the entry's category and library; Action text is category-appropriate. Do NOT recommend "fuse the SDPA kernel" (already fused — defer upstream/downstream fusion to Kernel Fusion section). -->
 <!-- Skip categories that have empty category_findings[] in category_data/<cat>_metrics.json (no P-items for that category). -->
+<!-- Non-quantifiable findings (priority_data.findings[i].members[0].type == "unmodeled_significant") sort last; render per sub_agent_spec.md § Non-quantifiable findings. -->
 
 ### 🔴 P1: <Brief Title> (<Library>)
 

--- a/TraceLens/Agent/Analysis/utils/templates/sub_agent_spec.md
+++ b/TraceLens/Agent/Analysis/utils/templates/sub_agent_spec.md
@@ -238,14 +238,24 @@ The set of P-items is decided by `category_findings[]` alone — `MIN_PITEM_IMPA
 | `bound_type` | `compute` \| `memory`. Selects the matching Action Prose Guidance row. |
 | `library` | One per finding. Drives the `(<Library>)` title suffix. |
 | `eff_bucket` | Roofline-efficiency band: `"0-30"`, `"30-60"`, `"60-100"`, or `"unknown"` (standalone); `"all"` (comparative). Members within a finding share the same band. |
-| `impact_score` / `_low` / `_high` | Group-summed % of E2E. Render verbatim into `kind=p_item` and `kind=detail_estimate` markers. |
-| `member_count`, `members[]` | Underlying per-op estimate rows (operation, time_ms, efficiency_pct, …) — rows of the `**Data:**` table. |
+| `impact_score` / `_low` / `_high` | Group-summed % of E2E, or `null` for non-quantifiable findings (see below). Render verbatim into `kind=p_item` and `kind=detail_estimate` markers. |
+| `member_count`, `members[]` | Underlying per-op estimate rows (operation, time_ms, efficiency_pct, `type`, …) — rows of the `**Data:**` table. `members[].type == "unmodeled_significant"` marks a non-quantifiable finding (op with no perf model, see below); `"kernel_tuning"` is a normal quantified finding. |
 
 ### Empty category_findings
 
 If `category_findings[]` is empty, emit `## Recommendations` with no P-items
 and `## Detailed Analysis` with no candidates. Do not manufacture sub-threshold
 cards to fill the section — that is the honest "no actionable issues" answer.
+
+### Non-quantifiable findings (`members[].type == "unmodeled_significant"`)
+
+These describe an op with no perf model whose combined (summed across shapes)
+E2E GPU-time share crosses the unmodeled threshold. `impact_score` / `_low` /
+`_high` are `null` (no roofline to estimate headroom), and the analyzer ranks
+them after all quantified findings. Render like a normal P-item card except:
+- `**Impact**`: `Not quantifiable from trace data`, with `low=null mid=null high=null` on the `kind=p_item` marker.
+- Add one note line giving the op's E2E share (`members[0].percent_of_total`%).
+- In `## Detailed Analysis`: use the sentinel `Impact estimate is not quantifiable from trace data.` (no `kind=detail_estimate` marker); the `**Data:**` row renders `—` for `Efficiency` and `Bound`.
 
 ### Rendering in `## Detailed Analysis` (compute tier)
 

--- a/TraceLens/Agent/Analysis/utils/validation_utils.py
+++ b/TraceLens/Agent/Analysis/utils/validation_utils.py
@@ -547,7 +547,9 @@ def _check_priority_consistency(output_dir, manifest):
             continue
         cat = p.get("category")
         expected = sum(
-            f.get("impact_score", 0) for f in findings if f.get("category") == cat
+            f.get("impact_score", 0)
+            for f in findings
+            if f.get("category") == cat and f.get("impact_score") is not None
         )
         actual = p.get("impact_score", 0) or 0
         if abs(actual - expected) > _ROLLUP_IMPACT_TOL:
@@ -726,14 +728,16 @@ def _validate_report_args_column(content, output_dir):
 def _validate_report_priority_consistency(content, output_dir):
     """Cross-check analysis.md against priority_data.json.
 
-    R1: Compute Kernel Optimizations P-item heading count == len(quantified findings).
+    R1: Compute Kernel Optimizations P-item heading count == len(findings).
     R2: Each kind=p_item marker's category attr (in doc order) == findings[N-1].category.
     R3: Each marker's low/mid/high attrs match findings[N-1] impact_score_low / impact_score / impact_score_high.
     R4: Top Operations marker rows == len(priorities).
 
     Silently skips when priority_data.json is absent (Step 8 already warns).
     Numeric attrs are compared as 2-decimal strings to match the writer's
-    rounding in generate_priority_data.
+    rounding in generate_priority_data. Non-quantifiable findings
+    (impact_score=None, e.g. unmodeled significant ops) are included: they
+    render as bottom P-items with low=null mid=null high=null markers.
     """
     pd_path = os.path.join(output_dir, "priority_data.json")
     if not os.path.exists(pd_path):
@@ -743,9 +747,7 @@ def _validate_report_priority_consistency(content, output_dir):
             pd = json.load(f)
     except (OSError, json.JSONDecodeError):
         return []
-    findings = [
-        f for f in (pd.get("findings", []) or []) if f.get("impact_score") is not None
-    ]
+    findings = pd.get("findings", []) or []
     priorities = pd.get("priorities", []) or []
     errors = []
 
@@ -759,7 +761,7 @@ def _validate_report_priority_consistency(content, output_dir):
     if n_p != len(findings):
         errors.append(
             f"R1: Compute Kernel Optimizations has {n_p} P-item headings but "
-            f"priority_data.json has {len(findings)} quantified findings"
+            f"priority_data.json has {len(findings)} findings"
         )
 
     p_markers = []
@@ -774,7 +776,7 @@ def _validate_report_priority_consistency(content, output_dir):
         if idx >= len(findings):
             errors.append(
                 f"R2: extra kind=p_item marker #{idx + 1} in Compute Kernel "
-                f"Optimizations beyond {len(findings)} quantified findings"
+                f"Optimizations beyond {len(findings)} findings"
             )
             break
         f = findings[idx]


### PR DESCRIPTION
# Surface unmodeled significant ops as non-quantifiable findings

## Summary

Operations that consume a meaningful share of GPU time but carry no roofline performance model (custom collectives such as QuickReduce, paged-attention decode kernels, activation-quant kernels) were previously dropped from the report: the impact estimator skips anything with `efficiency_percent is None`, and the compute-tier analyzer deflected collective categories to the NCCL Analyzer. This PR surfaces those ops as low-priority, non-quantifiable P-items (null impact, kept off the savings plot), aggregating each op's contribution by name across shape signatures so a kernel fragmented across many token shapes is judged on its combined E2E share. Net: 8 files changed, +129/−13, plus a standalone audit script.

## Why

| Pain point | Old | New |
|---|---|---|
| Custom collectives (QuickReduce / custom all-reduce) | Deflected to NCCL Analyzer; never appeared as a compute card | `customcollective` is in analyzer scope; surfaced as a non-quantifiable P-item when significant |
| Unmodeled high-runtime ops (no roofline) | Silently dropped because `efficiency_percent is None` | Surfaced as null-impact bottom P-items with an E2E-share note |
| Per-shape fragmentation | A kernel split across N shapes never cleared a per-shape threshold | Contributions summed by op-name before thresholding (>4% combined) |

## Architecture

```mermaid
flowchart TD
    A["build_operation_metrics()<br/>efficiency_percent may be None"]
    B["other_analysis.py<br/>category = other &#124; customcollective"]
    B1["build_category_findings()<br/>quantified findings"]
    B2["build_unmodeled_significant_findings() — NEW<br/>group by op-name, sum percent_of_total / time_ms,<br/>keep combined share &gt; 4%, null impact"]
    C["category_data/&lt;cat&gt;_metrics.json<br/>category_findings[]"]
    D["report_utils.generate_priority_data()<br/>null impact: excluded from rollup + plot,<br/>sorted last, contiguous global_rank"]
    E["priority_data.json :: findings[]"]
    F["generic-op-analyzer.md<br/>members[].type == unmodeled_significant<br/>renders p_item (low=mid=high=null) +<br/>paired reasoning-candidate Data block"]
    G["analysis.md"]
    H["validation_utils.validate_report()<br/>null markers + INV7' / R2 / R3 pass"]

    A --> B
    B --> B1
    B --> B2
    B1 --> C
    B2 --> C
    C --> D --> E --> F --> G --> H
```

## What changed

### Python (4 files)

| File | Change |
|---|---|
| `TraceLens/Agent/Analysis/category_analyses/analysis_utils.py` | Add `UNMODELED_E2E_THRESHOLD` (4.0) and `build_unmodeled_significant_findings()`: aggregate unmodeled ops by op-name, sum `percent_of_total`/`time_ms`, emit one null-impact finding per name above threshold |
| `TraceLens/Agent/Analysis/category_analyses/other_analysis.py` | Append `build_unmodeled_significant_findings()` after quantified findings (standalone scope); scope the communication-kernel strip to the `other` bucket so `customcollective` keeps its ops |
| `TraceLens/Agent/Analysis/utils/report_utils.py` | In `generate_priority_data`: skip null-impact findings from the quantified rollup/plot, sort null impact last, keep `global_rank` contiguous |
| `TraceLens/Agent/Analysis/utils/validation_utils.py` | Guard the null impact_score sum in the priority-consistency check; stop filtering null findings so null `p_item` markers map 1:1 |
| `TraceLens/Agent/Analysis/utils/audit_unmodeled_significant.py` | New standalone scanner: aggregate-by-name, default 4.0, scans `other_metrics.json` and `customcollective_metrics.json` |

### Templates (2 files)

| File | Change |
|---|---|
| `TraceLens/Agent/Analysis/utils/templates/sub_agent_spec.md` | Document the non-quantifiable finding shape (`members[].type == "unmodeled_significant"`), null `p_item` marker, and paired reasoning-candidate Data block |
| `TraceLens/Agent/Analysis/utils/templates/analysis_template.md` | Note that non-quantifiable findings sort last and render as lowest-priority cards |

### Sub-agent .md files (1)

| File | Change |
|---|---|
| `TraceLens/Agent/Analysis/.cursor/agents/generic-op-analyzer.md` | Put `customcollective` in scope (no longer deflected); document rendering of `unmodeled_significant` findings |

### Orchestrator skill (1 file)

| File | Change |
|---|---|
| `TraceLens/Agent/Analysis/.cursor/skills/analysis-orchestrator.md` | Note that non-quantifiable findings sort last and must be rendered, not skipped |

## Net diff

```
8 files changed, 129 insertions(+), 13 deletions(-)
```