### PR TITLE
Fix project root path and make commit SHA come from wheel version

### DIFF
--- a/tests/perf_tracker/tracelens_perf_harness.py
+++ b/tests/perf_tracker/tracelens_perf_harness.py
@@ -32,6 +32,8 @@ Usage:
 
 import argparse
 import cProfile
+import importlib
+import importlib.metadata
 import json
 import os
 import platform
@@ -128,20 +130,13 @@ def load_manifest(manifest_path):
 def get_tracelens_version():
     """Attempt to read TraceLens version from setup.py or package metadata."""
     try:
-        from importlib.metadata import version
-
-        return version("TraceLens")
+        return importlib.metadata.version("TraceLens")
     except Exception:
         return "unknown"
 
 
 def get_commit_sha():
-    """Extract the short commit SHA from the installed TraceLens wheel version.
-
-    Runs 'pip install -e .' first so setup.py re-stamps the version with the
-    current commit, then reads the local segment of the PEP 440 version string
-    (format: '0.1.0.dev<date>+g<shortsha>').
-    """
+    """Extract the short commit SHA from the installed TraceLens wheel version"""
     try:
         subprocess.run(
             [sys.executable, "-m", "pip", "install", "-e", "."],
@@ -154,12 +149,8 @@ def get_commit_sha():
         return "unknown"
 
     try:
-        # Reload metadata after reinstall
-        import importlib.metadata as _meta
-        import importlib
-
         importlib.invalidate_caches()
-        ver = _meta.version("TraceLens")
+        ver = importlib.metadata.version("TraceLens")
         # Version format: 0.1.0.dev20260612+gabcd123
         if "+" in ver:
             local = ver.split("+", 1)[1]  # e.g. "gabcd123"

--- a/tests/perf_tracker/tracelens_perf_harness.py
+++ b/tests/perf_tracker/tracelens_perf_harness.py
@@ -145,7 +145,9 @@ def get_commit_sha():
             capture_output=True,
         )
     except Exception as e:
-        print(f"Warning: 'pip install -e .' failed: {e}. commit SHA will be set to 'unknown'.")
+        print(
+            f"Warning: 'pip install -e .' failed: {e}. commit SHA will be set to 'unknown'."
+        )
         return "unknown"
 
     try:

--- a/tests/perf_tracker/tracelens_perf_harness.py
+++ b/tests/perf_tracker/tracelens_perf_harness.py
@@ -47,7 +47,7 @@ from pathlib import Path
 import yaml
 
 # Add project root to path so TraceLens can be imported
-PROJECT_ROOT = Path(__file__).resolve().parent.parent
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
 
 from TraceLens.TreePerf import TreePerfAnalyzer
@@ -136,21 +136,40 @@ def get_tracelens_version():
 
 
 def get_commit_sha():
-    """Get the current git commit SHA, warning if it cannot be determined."""
+    """Extract the short commit SHA from the installed TraceLens wheel version.
+
+    Runs 'pip install -e .' first so setup.py re-stamps the version with the
+    current commit, then reads the local segment of the PEP 440 version string
+    (format: '0.1.0.dev<date>+g<shortsha>').
+    """
     try:
-        result = subprocess.run(
-            ["git", "rev-parse", "HEAD"],
-            capture_output=True,
-            text=True,
+        subprocess.run(
+            [sys.executable, "-m", "pip", "install", "-e", "."],
             cwd=PROJECT_ROOT,
+            check=True,
+            capture_output=True,
         )
-        if result.returncode == 0 and result.stdout.strip():
-            return result.stdout.strip()
+    except Exception as e:
+        print(f"Warning: 'pip install -e .' failed: {e}. commit SHA will be set to 'unknown'.")
+        return "unknown"
+
+    try:
+        # Reload metadata after reinstall
+        import importlib.metadata as _meta
+        import importlib
+
+        importlib.invalidate_caches()
+        ver = _meta.version("TraceLens")
+        # Version format: 0.1.0.dev20260612+gabcd123
+        if "+" in ver:
+            local = ver.split("+", 1)[1]  # e.g. "gabcd123"
+            if local.startswith("g"):
+                return local[1:]  # strip the leading 'g'
     except Exception:
         pass
 
     print(
-        "Warning: could not determine commit SHA."
+        "Warning: could not determine commit SHA from installed TraceLens version. "
         "commit SHA will be set to 'unknown'."
     )
     return "unknown"


### PR DESCRIPTION
The project root path was not changed after moving tracelens_perf_harness.py from `tests/tracelens_perf_harness.py` to `tests/perf_tracker/tracelens_perf_harness.py`. It's fixed here.

The commit SHA now comes from the installed TraceLens wheel version. The harness runs `pip install -e .` every time it runs to update the wheel version to ensure the commit SHA is accurate.