### PR TITLE
Heuristic Findings

### DIFF
--- a/TraceLens/Agent/Analysis/.cursor/agents/generic-op-analyzer.md
+++ b/TraceLens/Agent/Analysis/.cursor/agents/generic-op-analyzer.md
@@ -85,7 +85,7 @@ cat <output_dir>/category_data/<cat>_metrics.json
 
 Read `category_data/<cat>_metrics.json::category_findings`. Per [`utils/templates/sub_agent_spec.md`](../utils/templates/sub_agent_spec.md), emit one P-item per entry in ascending `rank` order. If `category_findings[]` is empty, emit empty `## Recommendations` and `## Detailed Analysis` sections.
 
-Entries whose `members[].type == "unmodeled_significant"` (op with no perf model) render as the lowest-priority non-quantifiable cards — follow [`sub_agent_spec.md`](../utils/templates/sub_agent_spec.md) § Non-quantifiable findings.
+Entries whose `estimate_method == "heuristic"` (op with no perf model) carry a numeric **estimated** impact derived from E2E share and rank by `impact_score` like any other compute finding — follow [`sub_agent_spec.md`](../utils/templates/sub_agent_spec.md) § Heuristic findings.
 
 **efficiency_percent semantics:**
 - **Standalone:** Treat `efficiency_percent` as **% of roofline**.

--- a/TraceLens/Agent/Analysis/.cursor/skills/analysis-orchestrator.md
+++ b/TraceLens/Agent/Analysis/.cursor/skills/analysis-orchestrator.md
@@ -534,7 +534,7 @@ If the plot fails (extension-absent branch), retry once. If still failing, proce
    b. **Compute Kernel Optimizations** — append `## Compute Kernel Optimizations` with `### Top Operations` table and P-item cards. Use `<prefix> tee -a <output_dir>/analysis.md << 'SECTION_EOF'`.
       - Data sources: `priority_data.json` — P1 = `findings[0]`, P2 = `findings[1]`, ... ; each card joins its sub-agent's Detailed Analysis block by `(findings[i].category, findings[i].category_rank)`. The Top Operations table materializes `priorities[]` verbatim (one row per entry, array order, no re-sorting).
       - `category_findings/*.md` — for each findings file, copy its `## Recommendations` P-items into the report card slots. **Copy table cells verbatim** from the source `category_findings/<cat>_findings.md`.
-      - Non-quantifiable findings (`findings[i].members[0].type == "unmodeled_significant"`) sort last in `findings[]` — render them as the lowest-priority cards (do NOT skip them) per `sub_agent_spec.md § Non-quantifiable findings`.
+      - Heuristic findings (`findings[i].estimate_method == "heuristic"`) carry a numeric estimated impact and sort by `impact_score` like any other compute finding — render them (do NOT skip them) per `sub_agent_spec.md § Heuristic findings`.
 
    c. **Kernel Fusion** — append `## Kernel Fusion Opportunities (Experimental)`. Use `<prefix> tee -a <output_dir>/analysis.md << 'SECTION_EOF'`.
       - Data source: `system_findings/kernel_fusion_findings.md`.

--- a/TraceLens/Agent/Analysis/category_analyses/analysis_utils.py
+++ b/TraceLens/Agent/Analysis/category_analyses/analysis_utils.py
@@ -36,7 +36,12 @@ TARGET_MID = 87.5
 MIN_PITEM_IMPACT_SCORE = (
     0.5  # Group-sum (% E2E) below which a finding is dropped from priority_data.json.
 )
-UNMODELED_E2E_THRESHOLD = 4.0  # Summed %E2E (per op-name, across shapes) above which an unmodeled op becomes a non-quantifiable low-priority finding.
+# Recoverable fraction of an unmodeled op's %E2E used as its heuristic impact.
+HEURISTIC_FRACTION_LOW = 0.15
+HEURISTIC_FRACTION_MID = 0.30
+HEURISTIC_FRACTION_HIGH = 0.45
+
+# Efficiency Boundary for grouping
 _EFF_BUCKET_BOUNDARIES = (30, 60)
 
 _OP_NAME_LIBRARY_RULES = [
@@ -662,85 +667,112 @@ def compute_impact_estimates(
     category: str,
     min_impact_score: float = 0.01,
     baseline_ms: float = 0,
+    comparison_scope: str = "standalone",
 ) -> List[dict]:
     """
-    Deterministically compute kernel_tuning impact estimates from operation metrics.
+    Compute per-op impact estimates via an estimator ladder.
 
-    Two-step computation:
+    Each op gets a numeric ``impact_score`` from the first method that applies:
 
-      1. Per-op roofline headroom ``gap``.
+      - ``quantified`` (``estimate_method="quantified"``): when ``efficiency_percent``
+        is present and not anomalous. Impact comes from an efficiency model
+        (standalone: roofline headroom; comparative: the t2/t1 ratio), as a per-op
+        ``gap`` weighted by the op's share of E2E:
             gap_high = max(0, 1 - efficiency_pct / TARGET_HIGH)
             gap_low  = (TARGET_LOW / TARGET_HIGH) * gap_high
             gap_mid  = (TARGET_MID / TARGET_HIGH) * gap_high
-
-      2. ``impact_score`` = The impact estimate on E2E GPU time obtained by weighting the gap by the op's share
-         of E2E:
             impact_score_high = gap_high * time_ms / baseline_ms * 100
             impact_score_low  = gap_low  * time_ms / baseline_ms * 100
             impact_score      = gap_mid  * time_ms / baseline_ms * 100
-
-    The midpoint (87.5% of the way from 75%->100% target closure) is the
-    primary estimate used for plots and aggregation. Anomalous efficiencies
-    (>100%) are excluded.
-
-    If ``baseline_ms`` is missing or non-positive, ``impact_score`` is undefined
-    (would divide by zero or produce a negative percentage). In that case this
-    function emits a stderr warning and returns an empty list.
+        The midpoint (87.5% of the way from the 75%->100% target closure) is the
+        primary estimate used for plots and aggregation. Anomalous efficiencies
+        (>100%) route to the heuristic instead.
+      - ``heuristic`` (``estimate_method="heuristic"``): the fallback
+        for ops with missing or anomalous efficiency (no perf model). Impact is
+        the op's E2E share scaled by HEURISTIC_FRACTION_*; standalone only
+        (comparative efficiency is a t2/t1 ratio, not a roofline gap).
 
     Args:
         operations: List of operation metric dicts (from build_operation_metrics)
         category: Category name for labelling
-        min_impact_score: Per-op noise floor on ``impact_score_high`` (% E2E).
-        baseline_ms: Total end-to-end GPU time for impact_score calculation.
-            Must be > 0; otherwise an empty list is returned.
+        min_impact_score: Per-op noise floor on quantified ``impact_score_high`` (% E2E).
+        baseline_ms: Total end-to-end GPU time for the quantified calculation. When
+            non-positive, only the heuristic branch runs (it needs no baseline).
+        comparison_scope: ``standalone`` enables the heuristic fallback.
 
     Returns:
         List of impact estimate dicts sorted by ``impact_score`` descending.
     """
-    if baseline_ms is None or baseline_ms <= 0:
+    baseline_ok = baseline_ms is not None and baseline_ms > 0
+    if not baseline_ok:
         print(
             f"[analysis_utils.compute_impact_estimates] baseline_ms="
-            f"{baseline_ms!r} is invalid; skipping impact_score computation "
+            f"{baseline_ms!r} is invalid; skipping impact_score computation"
             f"for category={category!r}",
             file=sys.stderr,
         )
-        return []
 
     estimates = []
     for op in operations:
         if op.get("fusion_flagged"):
             continue
-        eff = op.get("efficiency", {})
-        eff_pct = eff.get("efficiency_percent")
-        if eff_pct is None or eff.get("is_anomaly"):
-            continue
         time_ms = op.get("time_ms", 0)
         if time_ms <= 0:
             continue
+        eff = op.get("efficiency", {})
+        eff_pct = eff.get("efficiency_percent")
 
-        gap_high = max(0, 1 - eff_pct / TARGET_HIGH)
-        gap_low = (TARGET_LOW / TARGET_HIGH) * gap_high
-        gap_mid = (TARGET_MID / TARGET_HIGH) * gap_high
+        if eff_pct is not None and not eff.get("is_anomaly") and baseline_ok:
+            gap_high = max(0, 1 - eff_pct / TARGET_HIGH)
+            gap_low = (TARGET_LOW / TARGET_HIGH) * gap_high
+            gap_mid = (TARGET_MID / TARGET_HIGH) * gap_high
 
-        impact_score_high = gap_high * time_ms / baseline_ms * 100
-        impact_score_low = gap_low * time_ms / baseline_ms * 100
-        impact_score_mid = gap_mid * time_ms / baseline_ms * 100
+            impact_score_high = gap_high * time_ms / baseline_ms * 100
+            impact_score_low = gap_low * time_ms / baseline_ms * 100
+            impact_score_mid = gap_mid * time_ms / baseline_ms * 100
 
-        if impact_score_high < min_impact_score:
-            continue
-        estimate = {
-            "operation": op.get("name", "Unknown"),
-            "category": category,
-            "type": "kernel_tuning",
-            "impact_score": round(impact_score_mid, 2),
-            "impact_score_low": round(impact_score_low, 2),
-            "impact_score_high": round(impact_score_high, 2),
-            "efficiency_pct": round(eff_pct, 2),
-            "bound_type": eff.get("bound_type"),
-            "library": op.get("library"),
-            "time_ms": round(time_ms, 3),
-        }
-        estimates.append(estimate)
+            if impact_score_high < min_impact_score:
+                continue
+            estimates.append(
+                {
+                    "operation": op.get("name", "Unknown"),
+                    "category": category,
+                    "type": "kernel_tuning",
+                    "estimate_method": "quantified",
+                    "impact_score": round(impact_score_mid, 2),
+                    "impact_score_low": round(impact_score_low, 2),
+                    "impact_score_high": round(impact_score_high, 2),
+                    "efficiency_pct": round(eff_pct, 2),
+                    "bound_type": eff.get("bound_type"),
+                    "library": op.get("library"),
+                    "time_ms": round(time_ms, 3),
+                }
+            )
+        # Heuristic fallback, NOT the default path: reached only when the
+        # quantified branch above did not apply -- i.e. the op has no perf model
+        # (efficiency_percent is None), its efficiency is anomalous, or baseline_ms
+        # was non-positive. Standalone only; comparative efficiency is a t2/t1
+        # ratio, not a roofline gap.
+        elif comparison_scope == "standalone":
+            pct = op.get("percent_of_total")
+            if pct is None or pct <= 0:
+                continue
+            estimates.append(
+                {
+                    "operation": op.get("name", "Unknown"),
+                    "category": category,
+                    "type": "unmodeled_significant",
+                    "estimate_method": "heuristic",
+                    "impact_score": round(pct * HEURISTIC_FRACTION_MID, 2),
+                    "impact_score_low": round(pct * HEURISTIC_FRACTION_LOW, 2),
+                    "impact_score_high": round(pct * HEURISTIC_FRACTION_HIGH, 2),
+                    "efficiency_pct": None,
+                    "bound_type": None,
+                    "library": op.get("library"),
+                    "time_ms": round(time_ms, 3),
+                    "percent_of_total": pct,
+                }
+            )
     return sorted(estimates, key=lambda x: x["impact_score"], reverse=True)
 
 
@@ -749,17 +781,20 @@ def build_category_findings(
 ) -> List[dict]:
     """Group one category's per-op impact estimates into P-item findings.
 
-    Standalone mode groups by ``(bound_type, library, eff_bucket)`` so
-    kernels at different roofline-efficiency levels get separate P-items.
-    Comparative mode groups by ``(bound_type, library)`` only because
-    ``efficiency_pct`` represents a trace-time ratio, not roofline utilization.
+    Quantified estimates (``estimate_method != "heuristic"``) group by
+    ``(bound_type, library, eff_bucket)`` in standalone, or ``(bound_type,
+    library)`` in comparative (``efficiency_pct`` is a trace-time ratio there).
+    Heuristic estimates group by op-name (so a kernel fragmented across
+    shapes is judged on its combined %E2E).
 
     Sums impact across members, drops groups below ``MIN_PITEM_IMPACT_SCORE``,
-    sorts by ``impact_score`` desc, attaches intra-category ``rank``. Each
-    surviving group becomes one P-item the sub-agent renders. The orchestrator
-    later concatenates these arrays across categories to derive the global
+    sorts by ``impact_score`` desc, attaches intra-category ``rank``. The
+    orchestrator concatenates these across categories to derive the global
     ``priority_data.json::findings[]`` ranking.
     """
+    quantified = [e for e in estimates if e.get("estimate_method") != "heuristic"]
+    heuristic = [e for e in estimates if e.get("estimate_method") == "heuristic"]
+
     use_eff_bucket = comparison_scope == "standalone"
     groups: dict = defaultdict(
         lambda: {
@@ -769,12 +804,11 @@ def build_category_findings(
             "impact_score_high": 0.0,
         }
     )
-    for e in estimates:
+    for e in quantified:
         bound = e.get("bound_type") or "unknown"
         lib = e.get("library") or "Unknown"
         bucket = _eff_bucket(e.get("efficiency_pct")) if use_eff_bucket else "all"
-        key = (bound, lib, bucket)
-        g = groups[key]
+        g = groups[(bound, lib, bucket)]
         g["members"].append(e)
         g["impact_score"] += e.get("impact_score", 0)
         g["impact_score_low"] += e.get("impact_score_low", 0)
@@ -789,6 +823,7 @@ def build_category_findings(
                 "bound_type": bound,
                 "library": lib,
                 "eff_bucket": bucket,
+                "estimate_method": "quantified",
                 "impact_score": round(g["impact_score"], 2),
                 "impact_score_low": round(g["impact_score_low"], 2),
                 "impact_score_high": round(g["impact_score_high"], 2),
@@ -801,83 +836,51 @@ def build_category_findings(
             }
         )
 
-    findings.sort(key=lambda f: f["impact_score"], reverse=True)
-    for rank, f in enumerate(findings, start=1):
-        f["rank"] = rank
-    return findings
-
-
-def build_unmodeled_significant_findings(
-    operations: List[dict],
-    category: str,
-    start_rank: int = 1,
-) -> List[dict]:
-    """Emit non-quantifiable findings for significant ops that have no perf model.
-
-    Contributions are summed by op-name across shapes before thresholding (so a
-    collective fragmented across token shapes is judged on its combined %E2E).
-    Findings carry ``impact_score = None`` and rank from ``start_rank`` after the
-    category's quantified findings.
-    """
-    aggregated = {}
-    for op in operations:
-        eff = op.get("efficiency") or {}
-        if eff.get("efficiency_percent") is not None:
-            continue
-        pct = op.get("percent_of_total")
-        if pct is None:
-            continue
-        if (op.get("time_ms") or 0) <= 0:
-            continue
-        if op.get("fusion_flagged"):
-            continue
-        name = op.get("name", "Unknown")
-        agg = aggregated.setdefault(
-            name,
-            {"percent_of_total": 0.0, "time_ms": 0.0, "n_shapes": 0, "library": None},
-        )
-        agg["percent_of_total"] += pct
-        agg["time_ms"] += op.get("time_ms", 0) or 0
-        agg["n_shapes"] += 1
-        if agg["library"] is None:
-            agg["library"] = op.get("library")
-
-    qualifying = [
-        (name, agg)
-        for name, agg in aggregated.items()
-        if agg["percent_of_total"] > UNMODELED_E2E_THRESHOLD
-    ]
-    qualifying.sort(key=lambda item: item[1]["percent_of_total"], reverse=True)
-
-    findings = []
-    for offset, (name, agg) in enumerate(qualifying):
-        member = {
-            "operation": name,
-            "category": category,
-            "type": "unmodeled_significant",
-            "impact_score": None,
-            "impact_score_low": None,
-            "impact_score_high": None,
-            "efficiency_pct": None,
-            "bound_type": None,
-            "library": agg["library"],
-            "time_ms": round(agg["time_ms"], 3),
-            "percent_of_total": round(agg["percent_of_total"], 2),
-            "n_shapes": agg["n_shapes"],
+    hgroups: dict = defaultdict(
+        lambda: {
+            "members": [],
+            "impact_score": 0.0,
+            "impact_score_low": 0.0,
+            "impact_score_high": 0.0,
+            "percent_of_total": 0.0,
+            "library": None,
         }
+    )
+    for e in heuristic:
+        g = hgroups[e.get("operation", "Unknown")]
+        g["members"].append(e)
+        g["impact_score"] += e.get("impact_score", 0)
+        g["impact_score_low"] += e.get("impact_score_low", 0)
+        g["impact_score_high"] += e.get("impact_score_high", 0)
+        g["percent_of_total"] += e.get("percent_of_total", 0) or 0
+        if g["library"] is None:
+            g["library"] = e.get("library")
+
+    for g in hgroups.values():
+        if g["impact_score"] < MIN_PITEM_IMPACT_SCORE:
+            continue
         findings.append(
             {
                 "bound_type": "unmodeled",
-                "library": agg["library"] or "Unknown",
+                "library": g["library"] or "Unknown",
                 "eff_bucket": "unknown",
-                "impact_score": None,
-                "impact_score_low": None,
-                "impact_score_high": None,
-                "member_count": 1,
-                "members": [member],
-                "rank": start_rank + offset,
+                "estimate_method": "heuristic",
+                "impact_score": round(g["impact_score"], 2),
+                "impact_score_low": round(g["impact_score_low"], 2),
+                "impact_score_high": round(g["impact_score_high"], 2),
+                "percent_of_total": round(g["percent_of_total"], 2),
+                "member_count": len(g["members"]),
+                "members": sorted(
+                    g["members"],
+                    key=lambda m: m.get("impact_score", 0),
+                    reverse=True,
+                ),
             }
         )
+
+    findings.sort(key=lambda f: f["impact_score"], reverse=True)
+    for rank, f in enumerate(findings, start=1):
+        f["rank"] = rank
     return findings
 
 
@@ -1046,6 +1049,7 @@ def run_category_analysis(
             operations,
             category,
             baseline_ms=baseline_ms,
+            comparison_scope=comparison_scope,
         )
     else:
         impact_estimates = []

--- a/TraceLens/Agent/Analysis/category_analyses/other_analysis.py
+++ b/TraceLens/Agent/Analysis/category_analyses/other_analysis.py
@@ -25,7 +25,6 @@ from analysis_utils import (
     calculate_time_metrics,
     build_operation_metrics,
     build_category_findings,
-    build_unmodeled_significant_findings,
     compute_impact_estimates,
     write_metrics_json,
 )
@@ -155,21 +154,11 @@ def main():
         operations,
         category,
         baseline_ms=baseline_ms,
+        comparison_scope=args.comparison_scope,
     )
     category_findings = build_category_findings(
         impact_estimates, comparison_scope=args.comparison_scope
     )
-
-    # Surface no-perf-model significant ops as non-quantifiable findings.
-    # Standalone only: comparative efficiency is a ratio, not a roofline gap.
-    if args.comparison_scope == "standalone":
-        category_findings.extend(
-            build_unmodeled_significant_findings(
-                operations,
-                category,
-                start_rank=len(category_findings) + 1,
-            )
-        )
 
     metrics = {
         "category": category,

--- a/TraceLens/Agent/Analysis/utils/report_utils.py
+++ b/TraceLens/Agent/Analysis/utils/report_utils.py
@@ -248,8 +248,9 @@ def generate_priority_data(output_dir: str, max_recommendations: int = 6) -> str
             }
         )
         for f in findings:
-            # impact_score=None (no perf model): excluded from rollup/plot, ranked last.
-            if f.get("impact_score") is None:
+            # Heuristic findings rank in findings[] but are kept out of the
+            # quantified savings rollup/plot (a guess must not inflate projected savings).
+            if f.get("estimate_method") == "heuristic":
                 continue
             cat = f["category"]
             quantified[cat]["impact_score"] += f.get("impact_score", 0)
@@ -294,12 +295,17 @@ def generate_priority_data(output_dir: str, max_recommendations: int = 6) -> str
             )
 
         quantified_cats = set(quantified.keys())
+        heuristic_cats = {
+            f["category"]
+            for f in findings
+            if f.get("estimate_method") == "heuristic"
+        }
         unmodeled = []
         for cat_entry in manifest.get("categories", []):
             cat_name = cat_entry.get("name")
             if cat_entry.get("tier") != "compute_kernel":
                 continue
-            if cat_name in quantified_cats:
+            if cat_name in quantified_cats or cat_name in heuristic_cats:
                 continue
             gpu_time = cat_entry.get("gpu_kernel_time_ms", 0)
             if gpu_time >= threshold_ms:
@@ -326,15 +332,9 @@ def generate_priority_data(output_dir: str, max_recommendations: int = 6) -> str
             )
             next_rank += 1
 
-        # Quantified findings sort by impact_score descending; non-quantifiable
-        # (impact_score=None) findings always rank last.
-        findings.sort(
-            key=lambda f: (
-                f.get("impact_score") is not None,
-                f.get("impact_score") or 0,
-            ),
-            reverse=True,
-        )
+        # Every finding now carries a numeric impact_score (quantified or
+        # heuristic); sort descending for the global P-item ranking.
+        findings.sort(key=lambda f: f.get("impact_score", 0), reverse=True)
         for global_rank, f in enumerate(findings, start=1):
             f["global_rank"] = global_rank
 

--- a/TraceLens/Agent/Analysis/utils/templates/analysis_template.md
+++ b/TraceLens/Agent/Analysis/utils/templates/analysis_template.md
@@ -158,7 +158,7 @@ One row per entry in `priority_data.json::priorities[]`, in array order (no mani
 <!-- Icon mapping by PRIORITY NUMBER (not severity): P1=🔴, P2=🟡, P3+=🟢 -->
 <!-- One card per entry in priority_data.findings[] in array order. Title uses the entry's category and library; Action text is category-appropriate. Do NOT recommend "fuse the SDPA kernel" (already fused — defer upstream/downstream fusion to Kernel Fusion section). -->
 <!-- Skip categories that have empty category_findings[] in category_data/<cat>_metrics.json (no P-items for that category). -->
-<!-- Non-quantifiable findings (priority_data.findings[i].members[0].type == "unmodeled_significant") sort last; render per sub_agent_spec.md § Non-quantifiable findings. -->
+<!-- Heuristic findings (priority_data.findings[i].estimate_method == "heuristic") carry a numeric estimated impact and sort by impact_score like any other compute finding; render per sub_agent_spec.md § Heuristic findings. -->
 
 ### 🔴 P1: <Brief Title> (<Library>)
 

--- a/TraceLens/Agent/Analysis/utils/templates/sub_agent_spec.md
+++ b/TraceLens/Agent/Analysis/utils/templates/sub_agent_spec.md
@@ -238,8 +238,10 @@ The set of P-items is decided by `category_findings[]` alone — `MIN_PITEM_IMPA
 | `bound_type` | `compute` \| `memory`. Selects the matching Action Prose Guidance row. |
 | `library` | One per finding. Drives the `(<Library>)` title suffix. |
 | `eff_bucket` | Roofline-efficiency band: `"0-30"`, `"30-60"`, `"60-100"`, or `"unknown"` (standalone); `"all"` (comparative). Members within a finding share the same band. |
-| `impact_score` / `_low` / `_high` | Group-summed % of E2E, or `null` for non-quantifiable findings (see below). Render verbatim into `kind=p_item` and `kind=detail_estimate` markers. |
-| `member_count`, `members[]` | Underlying per-op estimate rows (operation, time_ms, efficiency_pct, `type`, …) — rows of the `**Data:**` table. `members[].type == "unmodeled_significant"` marks a non-quantifiable finding (op with no perf model, see below); `"kernel_tuning"` is a normal quantified finding. |
+| `impact_score` / `_low` / `_high` | Group-summed % of E2E. Render verbatim into `kind=p_item` and `kind=detail_estimate` markers. |
+| `estimate_method` | `"quantified"` (impact from a perf model — standalone roofline gap or comparative t2/t1 ratio) or `"heuristic"` (op has no perf model; impact estimated from E2E share — see below). |
+| `percent_of_total` | Heuristic findings only: the op's combined E2E GPU-time share (summed across shapes). Drives the warning line in § Heuristic findings. Absent on quantified findings. |
+| `member_count`, `members[]` | Underlying per-op estimate rows (operation, time_ms, efficiency_pct, `type`, …) — rows of the `**Data:**` table. `members[].type == "unmodeled_significant"` marks a heuristic finding; `"kernel_tuning"` is a quantified (perf-modeled) finding. |
 
 ### Empty category_findings
 
@@ -247,15 +249,20 @@ If `category_findings[]` is empty, emit `## Recommendations` with no P-items
 and `## Detailed Analysis` with no candidates. Do not manufacture sub-threshold
 cards to fill the section — that is the honest "no actionable issues" answer.
 
-### Non-quantifiable findings (`members[].type == "unmodeled_significant"`)
+### Heuristic findings (`estimate_method == "heuristic"`)
 
-These describe an op with no perf model whose combined (summed across shapes)
-E2E GPU-time share crosses the unmodeled threshold. `impact_score` / `_low` /
-`_high` are `null` (no roofline to estimate headroom), and the analyzer ranks
-them after all quantified findings. Render like a normal P-item card except:
-- `**Impact**`: `Not quantifiable from trace data`, with `low=null mid=null high=null` on the `kind=p_item` marker.
-- Add one note line giving the op's E2E share (`members[0].percent_of_total`%).
-- In `## Detailed Analysis`: use the sentinel `Impact estimate is not quantifiable from trace data.` (no `kind=detail_estimate` marker); the `**Data:**` row renders `—` for `Efficiency` and `Bound`.
+An op with no perf model: `impact_score` / `_low` / `_high` are estimated from a
+recoverable fraction of its E2E share (`percent_of_total`, summed across shapes)
+and ranked alongside quantified findings.
+
+Render like a normal P-item card (numeric `low`/`mid`/`high` on `kind=p_item`,
+normal `kind=detail_estimate` bullets) with two additions:
+- Immediately **after** the `kind=p_item` impact marker block (i.e. *outside* the `impact-begin`/`impact-end` markers), add a warning line, substituting the finding's `percent_of_total`:
+
+```markdown
+> **Warning — estimated:** No performance model for this op; impact is derived from its E2E GPU-time share (<percent_of_total>%), not a gap projection.
+```
+- In the `## Detailed Analysis` `**Data:**` row, render `—` for `Efficiency` and `Bound`.
 
 ### Rendering in `## Detailed Analysis` (compute tier)
 
@@ -268,8 +275,6 @@ Two bullets — low and high. Wrap in `kind=detail_estimate` markers (see
 - High end impact_score: <impact_score_high>
 <!-- impact-end -->
 ```
-
-**Non-quantifiable:** `Impact estimate is not quantifiable from trace data.`
 
 ## Impact markers (REQUIRED)
 
@@ -292,8 +297,8 @@ The block between them is exactly the `impact_score`-based markdown you would ot
 
 | `kind` | Where | Required attributes | Optional attributes |
 |--------|-------|--------------------|---------------------|
-| `p_item` | Around every P-item `**Impact**` line in `## Recommendations`. | `low`, `mid`, `high` (all three; use `null` for non-quantifiable). | `category` is reserved for the orchestrator template; sub-agents do **not** emit it. |
-| `detail_estimate` | Around the two-bullet `Low end ... / High end ...` block under `**Impact estimate:**` in each `## Detailed Analysis` candidate. Skip for non-quantifiable estimates. | `low`, `high` (impact_score values, % of E2E). | none |
+| `p_item` | Around every P-item `**Impact**` line in `## Recommendations`. | `low`, `mid`, `high` (all three; use `null` only for system-tier non-quantifiable). | `category` is reserved for the orchestrator template; sub-agents do **not** emit it. |
+| `detail_estimate` | Around the two-bullet `Low end ... / High end ...` block under `**Impact estimate:**` in each `## Detailed Analysis` candidate. Skip only for system-tier non-quantifiable estimates. | `low`, `high` (impact_score values, % of E2E). | none |
 
 ### Value-source rule
 

--- a/TraceLens/Agent/Analysis/utils/validation_utils.py
+++ b/TraceLens/Agent/Analysis/utils/validation_utils.py
@@ -542,10 +542,14 @@ def _check_priority_consistency(output_dir, manifest):
         if p.get("source") != "findings_rollup":
             continue
         cat = p.get("category")
+        # Mirror generate_priority_data: the findings_rollup excludes
+        # heuristic findings, so the consistency sum must too.
         expected = sum(
             f.get("impact_score", 0)
             for f in findings
-            if f.get("category") == cat and f.get("impact_score") is not None
+            if f.get("category") == cat
+            and f.get("impact_score") is not None
+            and f.get("estimate_method") != "heuristic"
         )
         actual = p.get("impact_score", 0) or 0
         if abs(actual - expected) > _ROLLUP_IMPACT_TOL:
@@ -731,9 +735,9 @@ def _validate_report_priority_consistency(content, output_dir):
 
     Silently skips when priority_data.json is absent (Step 8 already warns).
     Numeric attrs are compared as 2-decimal strings to match the writer's
-    rounding in generate_priority_data. Non-quantifiable findings
-    (impact_score=None, e.g. unmodeled significant ops) are included: they
-    render as bottom P-items with low=null mid=null high=null markers.
+    rounding in generate_priority_data. Every compute-tier finding now carries
+    a numeric impact_score (quantified or heuristic estimate), so p_item
+    markers in this section must use numeric low/mid/high (never null).
     """
     pd_path = os.path.join(output_dir, "priority_data.json")
     if not os.path.exists(pd_path):


### PR DESCRIPTION
## Summary

Give GPU kernels that have **no roofline performance model** a numeric, rankable impact score instead of `impact_score=None`. Previously these "unmodeled significant" ops were pinned to the bottom of the priority list (or invisible),
even when a single such op consumed a large share of end-to-end GPU time. They now receive a **share-based heuristic** estimate (`impact_score = %E2E ×recoverable_fraction`) and are ranked inline alongside roofline-modelled findings, while being kept out of the quantified savings rollup so a guess can never inflate projected savings. Net: 8 files changed, +173 / −171.

## Why

| Pain point | Old | New |
|---|---|---|
| Kernel with no perf model but large E2E share | `impact_score=None` → forced to the bottom / effectively invisible | numeric heuristic `impact_score` = `%E2E × {0.15 / 0.30 / 0.50}`, ranked by global impact like any other finding |
| `estimate_method` label | `"roofline"` — ambiguous (also covered the comparative t2/t1 ratio path) | `"quantified"` (perf-model: standalone roofline gap *or* comparative ratio) vs `"heuristic"` (E2E-share estimate) |
| Savings projections | n/a (unmodeled ops weren't scored) | heuristic findings excluded from the savings rollup **and** the impact plot — estimates don't pollute quantified projections |
| Reader trust | a guessed impact rendered identically to a modelled one | each heuristic P-item carries a `> **Warning — estimated:**` blockquote placed **outside** the impact markers, so it survives marker rehydration |

## Architecture

```
per-category analyzer (e.g. other_analysis.py)
        │
        ▼
compute_impact_estimates(...)            [analysis_utils.py]
   ├─ quantified branch  → roofline gap (standalone) | t2/t1 ratio (comparative)
   └─ heuristic branch   → %E2E × recoverable_fraction   (no perf model;
                                                          fusion-flagged ops skipped)
        │
        ▼
build_category_findings(...)             [analysis_utils.py]
   ├─ quantified: group by (bound_type, library, eff_bucket)
   └─ heuristic:  group by op name (aggregate across shapes), carry percent_of_total
        │
        ▼
category_data/<cat>_metrics.json   (estimate_method ∈ {quantified, heuristic})
        │
        ▼
generate_priority_data(...)              [report_utils.py]
   ├─ global sort by numeric impact_score (heuristics interleaved)
   ├─ heuristic findings EXCLUDED from savings rollup + perf_improvement.png
   └─ suppress manifest fallback row for a category that already has heuristics
        │
        ▼
priority_data.json  →  orchestrator Step 11 composes analysis.md
   (kind=p_item markers low/mid/high + "Warning — estimated" blockquote)
        │
        ▼
validate_report(...)                     [validation_utils.py]
   (rollup-consistency sum mirrors the heuristic exclusion)
```

## What changed

### Python (4 files)

| File | Change |
|---|---|
| `TraceLens/Agent/Analysis/category_analyses/analysis_utils.py` | Two-path estimator ladder in `compute_impact_estimates` (quantified + heuristic); heuristic grouping by op name in `build_category_findings`; `percent_of_total` on heuristic findings; baseline-ms guard lets the heuristic branch run even when no roofline gap exists; anomalous (>100%) efficiency routes to heuristic; fusion-flagged ops skipped; `roofline`→`quantified` rename; removed `build_unmodeled_significant_findings`. |
| `TraceLens/Agent/Analysis/category_analyses/other_analysis.py` | Drop the bespoke `build_unmodeled_significant_findings` call; pass `comparison_scope` into `compute_impact_estimates` so heuristics flow through the unified path. |
| `TraceLens/Agent/Analysis/utils/report_utils.py` | Rank every finding by numeric `impact_score`; exclude `estimate_method == "heuristic"` from the savings rollup and plot; suppress the manifest fallback row when a category already has heuristic findings. |
| `TraceLens/Agent/Analysis/utils/validation_utils.py` | Rollup-consistency sum excludes heuristic findings (mirrors `generate_priority_data`); docstring updated — every compute finding now has a numeric `impact_score`, so p_item markers use numeric low/mid/high (never null). |

### Templates (2 files)

| File | Change |
|---|---|
| `TraceLens/Agent/Analysis/utils/templates/sub_agent_spec.md` | New `§ Heuristic findings` (rendering rules + the `Warning — estimated` blockquote, placed outside impact markers); `percent_of_total` added to the `category_findings[]` schema; `roofline`→`quantified` / drop `share_heuristic`→`heuristic`. |
| `TraceLens/Agent/Analysis/utils/templates/analysis_template.md` | P-item rendering comment switched from "non-quantifiable / sort last" to "heuristic findings carry a numeric estimated impact and sort by `impact_score`". |

### Sub-agent .md files (1)

| File | Change |
|---|---|
| `TraceLens/Agent/Analysis/.cursor/agents/generic-op-analyzer.md` | Unmodeled ops now render as heuristic compute cards ranked by `impact_score`, not lowest-priority non-quantifiable cards. |

### Orchestrator skill (1 file)

| File | Change |
|---|---|
| `TraceLens/Agent/Analysis/.cursor/skills/analysis-orchestrator.md` | Step 11 guidance: heuristic findings (`estimate_method == "heuristic"`) carry numeric impact and sort inline; render (do not skip) per `sub_agent_spec.md § Heuristic findings`. |

### New utility (untracked — stage before pushing)

| File | Change |
|---|---|
| `TraceLens/Agent/Analysis/utils/audit_unmodeled_significant.py` | Standalone audit script (122 lines) for the unmodeled-significance threshold; uses the new heuristic fraction constants and unified floor. |

## Net diff

```
8 files changed, 173 insertions(+), 171 deletions(-)
(+ audit_unmodeled_significant.py — 122 lines, untracked)
```

### Rollback

Revert the single commit; `priority_data.json` reverts to `impact_score=None` for unmodeled ops (ranked last) and reports drop the `Warning — estimated` lines. No schema field is removed that downstream `parse_analysis_md` depends on (it reads only `category/low/mid/high` marker attrs), so a rollback is safe for Hyperloom.

CC: @kyle-hoffmeyer, @devalshah-amd 