### PR TITLE
docs: add CI status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ See LICENSE for license information.
 
 # TraceLens
 
+[![Lint](https://github.com/AMD-AGI/TraceLens/actions/workflows/lint.yml/badge.svg)](https://github.com/AMD-AGI/TraceLens/actions/workflows/lint.yml)
+[![Regression Tests](https://github.com/AMD-AGI/TraceLens/actions/workflows/regression-tests.yml/badge.svg)](https://github.com/AMD-AGI/TraceLens/actions/workflows/regression-tests.yml)
+
 TraceLens is a Python library focused on **automating analysis from trace files** and enabling rich performance insights. Designed with **simplicity and extensibility** in mind, this library provides tools to simplify the process of profiling and debugging complex distributed training and inference systems.
 
 ## Key Features


### PR DESCRIPTION
## Summary
- Adds status badges for the main CI workflows at the top of the `README.md`:
  - **Lint** (`lint.yml`)
  - **Regression Tests** (`regression-tests.yml`)
- Each badge links to its workflow's Actions page so CI status is visible at a glance.

## Notes
- These two workflows actively run and pass on `main`. The **Format (auto-fix)** workflow (`format.yml`) was intentionally omitted because it only runs on feature branches (committing formatting fixes) and has no `main`-branch runs, so its badge would show "no status." Happy to add it if preferred.

## Test plan
- [ ] Confirm badges render and resolve to the correct workflow runs once merged to `main`.
