### PR TITLE
Integrate new call stack info into agent

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 # Syntax:     https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 # Last matching rule wins. Prefer GitHub Teams over individuals.
 # Default — every file requires project-team approval
-*                            @AMD-AGI/tracelens-code-owners
+*                            @AMD-AGI/perf-opt
 # Stricter paths — leads must approve
 
 # TraceLens package changes require Adeem or Gabe review

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 # Syntax:     https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 # Last matching rule wins. Prefer GitHub Teams over individuals.
 # Default — every file requires project-team approval
-*                            @AMD-AGI/perf-opt
+*                            @AMD-AGI/tracelens-code-owners
 # Stricter paths — leads must approve
 
 # TraceLens package changes require Adeem or Gabe review

--- a/TraceLens/Agent/Analysis/category_analyses/analysis_utils.py
+++ b/TraceLens/Agent/Analysis/category_analyses/analysis_utils.py
@@ -600,8 +600,19 @@ def build_operation_metrics(
         cs_raw = row.get("call_stack_full")
         cs_str = "" if cs_raw is None or pd.isna(cs_raw) else str(cs_raw)
 
-        op_metric["launcher_path"] = row.get("entry_point", "Not found")
-        op_metric["module_chain"] = _extract_module_chain(cs_str)
+        launcher = row.get("entry_point", "")
+        module_chain = _extract_module_chain(cs_str)
+
+        if not launcher or launcher == "Not found":
+            if module_chain:
+                launcher = " > ".join(module_chain[:3])
+            elif op_metric.get("library"):
+                launcher = f"{op_metric['library']} (vendor)"
+            else:
+                launcher = "Not found"
+
+        op_metric["launcher_path"] = launcher
+        op_metric["module_chain"] = module_chain
         op_metric["_raw_call_stack"] = cs_str
 
         operations.append(op_metric)

--- a/TraceLens/Agent/Analysis/category_analyses/analysis_utils.py
+++ b/TraceLens/Agent/Analysis/category_analyses/analysis_utils.py
@@ -443,32 +443,24 @@ def _match_fusion_op(kd_str: str, fusion_map: Dict[str, str]) -> Optional[str]:
     return None
 
 
-def _flatten_call_stack(call_stack_full: str) -> List[str]:
-    """Parse call_stack_full (Python list repr) into a flat list of frames."""
+def _parse_call_stack(call_stack_full: str) -> List[str]:
+    """Parse call_stack_full"""
     if not call_stack_full or call_stack_full == "nan":
         return []
     try:
         stack = ast.literal_eval(str(call_stack_full))
-    except Exception:
+    except Exception:   
         return []
-
-    def _flatten(frames):
-        flat = []
-        for f in frames:
-            if isinstance(f, list):
-                flat.extend(_flatten(f))
-            else:
-                flat.append(f)
-        return flat
-
-    return _flatten(stack) if isinstance(stack, list) else []
+    if not isinstance(stack, list):
+        return []
+    return [f for f in stack if isinstance(f, str)]
 
 
 def _extract_module_chain(call_stack_full: str) -> List[str]:
     """Extract nn.Module names from call_stack_full."""
     return [
         f.removeprefix("nn.Module: ")
-        for f in _flatten_call_stack(call_stack_full)
+        for f in _parse_call_stack(call_stack_full)
         if f.startswith("nn.Module: ")
     ]
 
@@ -477,7 +469,7 @@ def _extract_call_chain(call_stack_full: str) -> List[str]:
     """Return meaningful frames from call_stack_full, filtering torch dispatch internals."""
     return [
         f
-        for f in _flatten_call_stack(call_stack_full)
+        for f in _parse_call_stack(call_stack_full)
         if not any(s in f for s in _CALL_CHAIN_SKIP)
         and (f.startswith("nn.Module:") or ".py" in f or "::" in f)
     ]

--- a/TraceLens/Agent/Analysis/category_analyses/analysis_utils.py
+++ b/TraceLens/Agent/Analysis/category_analyses/analysis_utils.py
@@ -115,18 +115,6 @@ def perf_report_csv_dir(output_dir: str) -> str:
     return os.path.join(output_dir, "perf_report_csvs")
 
 
-_SKIP_PY_PATTERNS = (
-    "torch/",
-    "_functorch/",
-    "_dynamo/",
-    "torch/cuda/",
-    "torch/utils/",
-    "vllm/compilation/",
-    "/tmp/torchinductor",
-    "kernel_shape_profiler",
-)
-
-
 def load_category_data(output_dir: str, category: str) -> Tuple[pd.DataFrame, dict]:
     """
     Load CSV operations data and metadata JSON for a category.
@@ -455,52 +443,41 @@ def _match_fusion_op(kd_str: str, fusion_map: Dict[str, str]) -> Optional[str]:
     return None
 
 
-def _extract_launcher_path(call_stack_str: str, op_name: str) -> str:
-    """Return the first non-infrastructure .py frame from a call stack."""
-    if not call_stack_str or call_stack_str == "nan":
-        return ""
-    frames = [f.strip() for f in call_stack_str.split(" => ")]
-    for i, frame in enumerate(frames):
-        if i == 0:
-            continue
-        if ".py" not in frame:
-            continue
-        if any(p in frame for p in _SKIP_PY_PATTERNS):
-            continue
-        return frame
-    return ""
-
-
-def _extract_module_chain(call_stack_str: str) -> List[str]:
-    """Extract nn.Module names from a call stack string (leaf-to-root order)."""
-    if not call_stack_str or call_stack_str == "nan":
+def _flatten_call_stack(call_stack_full: str) -> List[str]:
+    """Parse call_stack_full (Python list repr) into a flat list of frames."""
+    if not call_stack_full or call_stack_full == "nan":
         return []
+    try:
+        stack = ast.literal_eval(str(call_stack_full))
+    except Exception:
+        return []
+
+    def _flatten(frames):
+        flat = []
+        for f in frames:
+            if isinstance(f, list):
+                flat.extend(_flatten(f))
+            else:
+                flat.append(f)
+        return flat
+
+    return _flatten(stack) if isinstance(stack, list) else []
+
+
+def _extract_module_chain(call_stack_full: str) -> List[str]:
+    """Extract nn.Module names from call_stack_full."""
     return [
-        f.strip().removeprefix("nn.Module: ")
-        for f in call_stack_str.split(" => ")
-        if f.strip().startswith("nn.Module: ")
+        f.removeprefix("nn.Module: ")
+        for f in _flatten_call_stack(call_stack_full)
+        if f.startswith("nn.Module: ")
     ]
 
 
-def _extract_backward_context(call_chain: List[str], library: str) -> str:
-    """Produce a descriptive label for autograd backward ops."""
-    for frame in call_chain:
-        if "autograd::engine::evaluate_function:" in frame:
-            fn = frame.split("autograd::engine::evaluate_function:")[-1].strip()
-            if library:
-                return f"{library} ({fn})"
-            return fn
-    return ""
-
-
-def _extract_call_chain(call_stack_str: str) -> List[str]:
-    """Return meaningful frames from a call stack, filtering torch dispatch internals."""
-    if not call_stack_str or call_stack_str == "nan":
-        return []
-    frames = [f.strip() for f in call_stack_str.split(" => ")]
+def _extract_call_chain(call_stack_full: str) -> List[str]:
+    """Return meaningful frames from call_stack_full, filtering torch dispatch internals."""
     return [
         f
-        for f in frames
+        for f in _flatten_call_stack(call_stack_full)
         if not any(s in f for s in _CALL_CHAIN_SKIP)
         and (f.startswith("nn.Module:") or ".py" in f or "::" in f)
     ]
@@ -628,26 +605,11 @@ def build_operation_metrics(
                 op_metric["fusion_flagged"] = True
                 op_metric["fusion_candidate_name"] = matched
 
-        cs_raw = row.get("call_stack")
+        cs_raw = row.get("call_stack_full")
         cs_str = "" if cs_raw is None or pd.isna(cs_raw) else str(cs_raw)
-        launcher = _extract_launcher_path(cs_str, op_name)
 
-        if not launcher:
-            launcher = _extract_backward_context(
-                _extract_call_chain(cs_str) if cs_str else [],
-                op_metric.get("library", ""),
-            )
-
-        module_chain = _extract_module_chain(cs_str)
-
-        if not launcher and module_chain:
-            launcher = " > ".join(module_chain[:3])
-
-        if not launcher and op_metric.get("library"):
-            launcher = f"{op_metric['library']} (vendor)"
-
-        op_metric["launcher_path"] = launcher if launcher else "\u2014"
-        op_metric["module_chain"] = module_chain
+        op_metric["launcher_path"] = row.get("entry_point", "Not found")
+        op_metric["module_chain"] = _extract_module_chain(cs_str)
         op_metric["_raw_call_stack"] = cs_str
 
         operations.append(op_metric)

--- a/TraceLens/Agent/Analysis/utils/orchestrator_prepare.py
+++ b/TraceLens/Agent/Analysis/utils/orchestrator_prepare.py
@@ -1234,29 +1234,6 @@ def main():
 
     unified_df = pd.read_csv(os.path.join(trace1_csv_dir, "unified_perf_summary.csv"))
 
-    # Join full call_stack from perf callstacks CSV (if available) so each
-    # per-category ops CSV carries the complete call stack per row.
-    cs_path = os.path.join(trace1_csv_dir, "unified_perf_callstacks.csv")
-    if os.path.exists(cs_path):
-        cs_df = pd.read_csv(cs_path)
-        cs_df["_trunc_cs"] = cs_df["call_stack"].apply(
-            lambda s: " => ".join(str(s).split(" => ")[:4])
-        )
-        cs_df = cs_df.drop_duplicates(
-            subset=["name", "op category", "_trunc_cs"], keep="first"
-        )
-        pre_merge_len = len(unified_df)
-        unified_df = unified_df.merge(
-            cs_df[["name", "op category", "_trunc_cs", "call_stack"]],
-            left_on=["name", "op category", "trunc_call_stack"],
-            right_on=["name", "op category", "_trunc_cs"],
-            how="left",
-        )
-        unified_df.drop(columns=["_trunc_cs"], inplace=True)
-        assert (
-            len(unified_df) == pre_merge_len
-        ), f"call_stack join changed row count: {pre_merge_len} -> {len(unified_df)}"
-
     # Apply enhanced categorization
     unified_df["enhanced_category"], unified_df["display_name"] = zip(
         *unified_df.apply(_normalize_category, axis=1)

--- a/TraceLens/Reporting/generate_perf_report_pytorch.py
+++ b/TraceLens/Reporting/generate_perf_report_pytorch.py
@@ -80,6 +80,12 @@ def _is_wrapper_frame(frame):
 def _find_entry_point(call_stack_value, op_name):
     """Find the dispatch entry point for a CPU op from its call stack.
 
+    Returns a dict with keys:
+    - ``entry_point``: the matched frame string, or ``""``
+    - ``num_wrappers``: number of frames between entry point and the CPU op
+    - ``traversal``: ``"inward"`` or ``"outward"`` (which strategy matched)
+    - ``wrappers``: list of frames between the CPU op and the entry point
+
     Strategy:
     1. **Inward matching** – search the call stack for a .py frame whose
        function name contains the op name (part after '::').
@@ -87,34 +93,14 @@ def _find_entry_point(call_stack_value, op_name):
        call stack from innermost frame outward, skip wrapper/dispatch
        functions, and return the first non-wrapper .py frame.
     """
+    empty = {"entry_point": "", "num_wrappers": -1, "traversal": "", "wrappers": ""}
     try:
         stack = ast.literal_eval(str(call_stack_value))
         if not isinstance(stack, list):
-            return ""
+            return empty
     except Exception:
-        return ""
-    # Use the local name part after '::' if present
-    local_name = op_name.split("::")[-1].lower() if "::" in op_name else op_name.lower()
+        return empty
 
-    # --- Inward matching: find a .py frame whose function name contains the op name ---
-    def search_inward(frames):
-        for frame in frames:
-            if isinstance(frame, list):
-                result = search_inward(frame)
-                if result:
-                    return result
-            elif ".py" in frame:
-                func_name = frame.split("): ")[-1].lower() if "): " in frame else frame.lower()
-                if local_name in func_name:
-                    return frame
-        return ""
-
-    result = search_inward(stack)
-    if result:
-        return result
-
-    # --- Outward matching (fallback): flatten the stack, walk from innermost
-    #     frame outward, skip wrappers, return first non-wrapper .py frame ---
     def flatten(frames):
         flat = []
         for frame in frames:
@@ -125,15 +111,53 @@ def _find_entry_point(call_stack_value, op_name):
         return flat
 
     flat_stack = flatten(stack)
-    # Walk from innermost (end) toward root (start)
-    for frame in reversed(flat_stack):
+
+    # Use the local name part after '::' if present
+    local_name = op_name.split("::")[-1].lower() if "::" in op_name else op_name.lower()
+
+    # Find the CPU op position in the flat stack (search from end for the exact op_name)
+    op_idx = -1
+    for i in range(len(flat_stack) - 1, -1, -1):
+        if flat_stack[i] == op_name:
+            op_idx = i
+            break
+    if op_idx == -1:
+        return empty
+
+    # --- Inward matching: from CPU op toward leaf (children), find a .py frame
+    #     whose function name contains the op name ---
+    for i in range(op_idx + 1, len(flat_stack)):
+        frame = flat_stack[i]
+        if ".py" in frame:
+            func_name = frame.split("): ")[-1].lower() if "): " in frame else frame.lower()
+            if local_name in func_name:
+                between = flat_stack[op_idx + 1 : i]
+                wrappers_list = [op_name] + between + [frame]
+                return {
+                    "entry_point": frame,
+                    "num_wrappers": len(between),
+                    "traversal": "inward",
+                    "wrappers": str(wrappers_list),
+                }
+
+    # --- Outward matching (fallback): from CPU op toward root (parents),
+    #     skip wrappers, return first non-wrapper .py frame ---
+    for i in range(op_idx - 1, -1, -1):
+        frame = flat_stack[i]
         if ".py" not in frame:
             continue
         if _is_wrapper_frame(frame):
             continue
-        return frame
+        between = flat_stack[i + 1 : op_idx]
+        wrappers_list = [frame] + between + [op_name]
+        return {
+            "entry_point": frame,
+            "num_wrappers": len(between),
+            "traversal": "outward",
+            "wrappers": str(wrappers_list),
+        }
 
-    return ""
+    return empty
 
 
 
@@ -775,14 +799,31 @@ def generate_perf_report_pytorch(
                 )
                 if "call_stack_full" in df_unified_perf_summary.columns:
                     cs_col = df_unified_perf_summary.columns.get_loc("call_stack_full")
+                    ep_results = df_unified_perf_summary.apply(
+                        lambda row: _find_entry_point(row["call_stack_full"], row["name"]),
+                        axis=1,
+                    )
                     df_unified_perf_summary.insert(
                         cs_col,
                         "entry_point",
-                        df_unified_perf_summary.apply(
-                            lambda row: _find_entry_point(row["call_stack_full"], row["name"]),
-                            axis=1,
-                        ),
+                        ep_results.apply(lambda x: x["entry_point"]),
                     )
+                    if os.environ.get("TRACELENS_DEBUG"):
+                        df_unified_perf_summary.insert(
+                            cs_col + 1,
+                            "num_wrappers",
+                            ep_results.apply(lambda x: x["num_wrappers"]),
+                        )
+                        df_unified_perf_summary.insert(
+                            cs_col + 2,
+                            "traversal",
+                            ep_results.apply(lambda x: x["traversal"]),
+                        )
+                        df_unified_perf_summary.insert(
+                            cs_col + 3,
+                            "wrappers",
+                            ep_results.apply(lambda x: x["wrappers"]),
+                        )
                 dict_name2df["unified_perf_summary"] = df_unified_perf_summary
 
             if _tracediff_diff_stats is not None and not _tracediff_diff_stats.empty:

--- a/TraceLens/Reporting/generate_perf_report_pytorch.py
+++ b/TraceLens/Reporting/generate_perf_report_pytorch.py
@@ -27,9 +27,66 @@ from TraceLens.Reporting.reporting_utils import (
 )
 
 
+_WRAPPER_FILE_PATTERNS = (
+    "torch/_ops.py",
+    "torch/nn/modules/",
+    "torch/utils/_contextlib.py",
+    "torch/utils/_device.py",
+    "torch/_tensor.py",
+    "torch/nn/functional.py",
+    "torch/functional.py",
+    "torch/overrides.py",
+    "torch/_inductor/",
+    "torch/_functorch/",
+    "torch/distributed/c10d_logger.py",
+)
+
+_WRAPPER_NAME_PREFIXES = (
+    "<built-in",
+    "pybind11_builtins",
+    "nn.Module:",
+)
+
+_WRAPPER_FUNC_NAMES = frozenset({
+    "__torch_function__",
+    "_call_impl",
+    "_wrapped_call_impl",
+    "decorate_context",
+    "handle_torch_function",
+    "wrapper",
+    "custom_wrapper",
+    "wrapper_custom",
+    "outer_wrapper",
+})
+
+
+def _is_wrapper_frame(frame):
+    """Return True if *frame* is a wrapper/dispatch function that should be
+    skipped when searching outward for the dispatch entry point."""
+    for prefix in _WRAPPER_NAME_PREFIXES:
+        if frame.startswith(prefix):
+            return True
+    for pat in _WRAPPER_FILE_PATTERNS:
+        if pat in frame:
+            return True
+    # Extract function name from "path.py(line): func_name" format
+    if "): " in frame:
+        func_name = frame.split("): ")[-1]
+        if func_name in _WRAPPER_FUNC_NAMES:
+            return True
+    return False
+
+
 def _find_entry_point(call_stack_value, op_name):
-    """Find the first .py frame in the call stack whose function name contains
-    the op name (part after '::') as a substring. Returns blank if not found."""
+    """Find the dispatch entry point for a CPU op from its call stack.
+
+    Strategy:
+    1. **Inward matching** – search the call stack for a .py frame whose
+       function name contains the op name (part after '::').
+    2. **Outward matching** (fallback) – if inward matching fails, walk the
+       call stack from innermost frame outward, skip wrapper/dispatch
+       functions, and return the first non-wrapper .py frame.
+    """
     try:
         stack = ast.literal_eval(str(call_stack_value))
         if not isinstance(stack, list):
@@ -39,20 +96,44 @@ def _find_entry_point(call_stack_value, op_name):
     # Use the local name part after '::' if present
     local_name = op_name.split("::")[-1].lower() if "::" in op_name else op_name.lower()
 
-    def search(frames):
+    # --- Inward matching: find a .py frame whose function name contains the op name ---
+    def search_inward(frames):
         for frame in frames:
             if isinstance(frame, list):
-                result = search(frame)
+                result = search_inward(frame)
                 if result:
                     return result
             elif ".py" in frame:
-                # Match local_name only against the function name part (after '): ')
                 func_name = frame.split("): ")[-1].lower() if "): " in frame else frame.lower()
                 if local_name in func_name:
                     return frame
         return ""
 
-    return search(stack)
+    result = search_inward(stack)
+    if result:
+        return result
+
+    # --- Outward matching (fallback): flatten the stack, walk from innermost
+    #     frame outward, skip wrappers, return first non-wrapper .py frame ---
+    def flatten(frames):
+        flat = []
+        for frame in frames:
+            if isinstance(frame, list):
+                flat.extend(flatten(frame))
+            else:
+                flat.append(frame)
+        return flat
+
+    flat_stack = flatten(stack)
+    # Walk from innermost (end) toward root (start)
+    for frame in reversed(flat_stack):
+        if ".py" not in frame:
+            continue
+        if _is_wrapper_frame(frame):
+            continue
+        return frame
+
+    return ""
 
 
 

--- a/TraceLens/Reporting/generate_perf_report_pytorch.py
+++ b/TraceLens/Reporting/generate_perf_report_pytorch.py
@@ -45,8 +45,11 @@ def _find_entry_point(call_stack_value, op_name):
                 result = search(frame)
                 if result:
                     return result
-            elif ".py" in frame and local_name in frame.lower():
-                return frame
+            elif ".py" in frame:
+                # Match local_name only against the function name part (after '): ')
+                func_name = frame.split("): ")[-1].lower() if "): " in frame else frame.lower()
+                if local_name in func_name:
+                    return frame
         return ""
 
     return search(stack)

--- a/TraceLens/Reporting/generate_perf_report_pytorch.py
+++ b/TraceLens/Reporting/generate_perf_report_pytorch.py
@@ -115,7 +115,7 @@ def _find_entry_point(call_stack_value, op_name):
     # Use the local name part after '::' if present
     local_name = op_name.split("::")[-1].lower() if "::" in op_name else op_name.lower()
 
-    # Find the CPU op position in the flat stack (search from end for the exact op_name)
+    # Find the CPU op position in the flat stack (search from end for exact match)
     op_idx = -1
     for i in range(len(flat_stack) - 1, -1, -1):
         if flat_stack[i] == op_name:

--- a/TraceLens/Reporting/generate_perf_report_pytorch.py
+++ b/TraceLens/Reporting/generate_perf_report_pytorch.py
@@ -94,7 +94,7 @@ def _find_entry_point(call_stack_value, op_name):
        call stack from innermost frame outward, skip wrapper/dispatch
        functions, and return the first non-wrapper .py frame.
     """
-    empty = {"entry_point": "Not Identifiable", "num_wrappers": -1, "traversal": "", "wrappers": ""}
+    empty = {"entry_point": "Not found", "num_wrappers": -1, "traversal": "", "wrappers": ""}
     try:
         stack = ast.literal_eval(str(call_stack_value))
         if not isinstance(stack, list):

--- a/TraceLens/Reporting/generate_perf_report_pytorch.py
+++ b/TraceLens/Reporting/generate_perf_report_pytorch.py
@@ -29,16 +29,16 @@ from TraceLens.Reporting.reporting_utils import (
 
 _WRAPPER_FILE_PATTERNS = (
     "torch/_ops.py",
-    "torch/nn/modules/",
+    "torch/nn/modules/module.py",
     "torch/utils/_contextlib.py",
     "torch/utils/_device.py",
     "torch/_tensor.py",
-    "torch/nn/functional.py",
     "torch/functional.py",
     "torch/overrides.py",
     "torch/_inductor/",
     "torch/_functorch/",
     "torch/distributed/c10d_logger.py",
+    "triton/backends/",
 )
 
 _WRAPPER_NAME_PREFIXES = (

--- a/TraceLens/Reporting/generate_perf_report_pytorch.py
+++ b/TraceLens/Reporting/generate_perf_report_pytorch.py
@@ -52,6 +52,7 @@ _WRAPPER_FUNC_NAMES = frozenset({
     "_call_impl",
     "_wrapped_call_impl",
     "decorate_context",
+    "dispatch_wrapper",
     "handle_torch_function",
     "wrapper",
     "custom_wrapper",
@@ -115,12 +116,22 @@ def _find_entry_point(call_stack_value, op_name):
     # Use the local name part after '::' if present
     local_name = op_name.split("::")[-1].lower() if "::" in op_name else op_name.lower()
 
-    # Find the CPU op position in the flat stack (search from end for exact match)
+    # Find the CPU op position in the flat stack (search from end for exact match).
+    # If exact match fails, try with trailing numeric suffix stripped — the call
+    # stack builder applies re.sub(r"_\d+", "") to frame names for deduplication,
+    # so e.g. "sglang_profiler::foo_triton_340" is stored as "sglang_profiler::foo_triton".
     op_idx = -1
     for i in range(len(flat_stack) - 1, -1, -1):
         if flat_stack[i] == op_name:
             op_idx = i
             break
+    if op_idx == -1:
+        stripped_op_name = re.sub(r"_\d+$", "", op_name)
+        if stripped_op_name != op_name:
+            for i in range(len(flat_stack) - 1, -1, -1):
+                if flat_stack[i] == stripped_op_name:
+                    op_idx = i
+                    break
     if op_idx == -1:
         return empty
 

--- a/TraceLens/Reporting/generate_perf_report_pytorch.py
+++ b/TraceLens/Reporting/generate_perf_report_pytorch.py
@@ -5,9 +5,11 @@
 ###############################################################################
 
 import argparse
+import ast
 import importlib.util
 import json
 import os
+import re
 import subprocess
 import sys
 import warnings
@@ -23,6 +25,32 @@ from TraceLens.Reporting.reporting_utils import (
     request_install,
     resolve_gpu_arch,
 )
+
+
+def _find_entry_point(call_stack_value, op_name):
+    """Find the first .py frame in the call stack whose function name contains
+    the op name (part after '::') as a substring. Returns blank if not found."""
+    try:
+        stack = ast.literal_eval(str(call_stack_value))
+        if not isinstance(stack, list):
+            return ""
+    except Exception:
+        return ""
+    # Use the local name part after '::' if present
+    local_name = op_name.split("::")[-1].lower() if "::" in op_name else op_name.lower()
+
+    def search(frames):
+        for frame in frames:
+            if isinstance(frame, list):
+                result = search(frame)
+                if result:
+                    return result
+            elif ".py" in frame and local_name in frame.lower():
+                return frame
+        return ""
+
+    return search(stack)
+
 
 
 def get_dfs_short_kernels(
@@ -661,24 +689,15 @@ def generate_perf_report_pytorch(
                     source_col="kernel_details_summary",
                     new_col_name="trunc_kernel_details",
                 )
-                if "call_stack" in df_unified_perf_summary.columns:
-                    df_callstacks = df_unified_perf_summary[
-                        ["name", "op category", "call_stack"]
-                    ].copy()
-                    df_callstacks.insert(0, "row_id", range(len(df_callstacks)))
-                    dict_name2df["unified_perf_callstacks"] = df_callstacks
-
-                    n_frames = 4  # op name + 3 parent frames
-                    cs_col = df_unified_perf_summary.columns.get_loc("call_stack")
+                if "call_stack_full" in df_unified_perf_summary.columns:
+                    cs_col = df_unified_perf_summary.columns.get_loc("call_stack_full")
                     df_unified_perf_summary.insert(
                         cs_col,
-                        "trunc_call_stack",
-                        df_unified_perf_summary["call_stack"].apply(
-                            lambda s: " => ".join(str(s).split(" => ")[:n_frames])
+                        "entry_point",
+                        df_unified_perf_summary.apply(
+                            lambda row: _find_entry_point(row["call_stack_full"], row["name"]),
+                            axis=1,
                         ),
-                    )
-                    df_unified_perf_summary = df_unified_perf_summary.drop(
-                        columns=["call_stack"]
                     )
                 dict_name2df["unified_perf_summary"] = df_unified_perf_summary
 
@@ -1038,7 +1057,7 @@ def main():
         "--include_call_stack",
         action="store_true",
         default=False,
-        help="Add trunc_call_stack to unified_perf_summary and write unified_perf_callstacks with full call stacks.",
+        help="Add call_stack_trimmed and call_stack_full columns to unified_perf_summary.",
     )
 
     args = parser.parse_args()

--- a/TraceLens/Reporting/generate_perf_report_pytorch.py
+++ b/TraceLens/Reporting/generate_perf_report_pytorch.py
@@ -94,7 +94,7 @@ def _find_entry_point(call_stack_value, op_name):
        call stack from innermost frame outward, skip wrapper/dispatch
        functions, and return the first non-wrapper .py frame.
     """
-    empty = {"entry_point": "", "num_wrappers": -1, "traversal": "", "wrappers": ""}
+    empty = {"entry_point": "Not Identifiable", "num_wrappers": -1, "traversal": "", "wrappers": ""}
     try:
         stack = ast.literal_eval(str(call_stack_value))
         if not isinstance(stack, list):

--- a/TraceLens/Reporting/generate_perf_report_pytorch_inference.py
+++ b/TraceLens/Reporting/generate_perf_report_pytorch_inference.py
@@ -24,6 +24,7 @@ import zipfile
 
 from TraceLens import NcclAnalyser, TraceToTree, TraceDiff, TreePerfAnalyzer
 from TraceLens.PerfModel.torch_op_mapping import build_sheet_category_to_op_names
+from TraceLens.Reporting.generate_perf_report_pytorch import _find_entry_point
 from TraceLens.Reporting.reporting_utils import (
     add_gpu_arch_cli_args,
     request_install,
@@ -950,24 +951,15 @@ def generate_perf_report_pytorch(
                     source_col="kernel_details_summary",
                     new_col_name="trunc_kernel_details",
                 )
-                if "call_stack" in df_unified_perf_summary.columns:
-                    df_callstacks = df_unified_perf_summary[
-                        ["name", "op category", "call_stack"]
-                    ].copy()
-                    df_callstacks.insert(0, "row_id", range(len(df_callstacks)))
-                    dict_name2df["unified_perf_callstacks"] = df_callstacks
-
-                    n_frames = 4  # op name + 3 parent frames
-                    cs_col = df_unified_perf_summary.columns.get_loc("call_stack")
+                if "call_stack_full" in df_unified_perf_summary.columns:
+                    cs_col = df_unified_perf_summary.columns.get_loc("call_stack_full")
                     df_unified_perf_summary.insert(
                         cs_col,
-                        "trunc_call_stack",
-                        df_unified_perf_summary["call_stack"].apply(
-                            lambda s: " => ".join(str(s).split(" => ")[:n_frames])
+                        "entry_point",
+                        df_unified_perf_summary.apply(
+                            lambda row: _find_entry_point(row["call_stack_full"], row["name"]),
+                            axis=1,
                         ),
-                    )
-                    df_unified_perf_summary = df_unified_perf_summary.drop(
-                        columns=["call_stack"]
                     )
                 dict_name2df["unified_perf_summary"] = df_unified_perf_summary
 

--- a/TraceLens/Trace2Tree/trace_to_tree.py
+++ b/TraceLens/Trace2Tree/trace_to_tree.py
@@ -936,7 +936,7 @@ class TraceToTree(BaseTraceToTree):
         follow_fwd_link: bool = False,
     ):
         """
-        Traverses the parent nodes and returns a string representation of the call stack.
+        Traverses the parent nodes and returns a list representation of the call stack.
 
         Args:
             node (Dict[str, Any]): The event node from which to start traversing upwards.
@@ -945,36 +945,34 @@ class TraceToTree(BaseTraceToTree):
                 follow the fwd_event link to continue traversing the forward call stack.
 
         Returns:
-            str: The call stack as a string with " => " separators.
+            list: The call stack as a list of frame strings, starting from the node itself.
         """
         depth = 0
-        print_str = node["name"] + " => "
-        while True:
+        frames = [node["name"]]
+        # Move to parent immediately so we don't re-add the starting node
+        node = self.get_parent_event(node)
+        while node is not None:
             name = node.get(TraceLens.util.TraceEventUtils.TraceKeys.Name, "Unknown")
             max_len = 256
             if len(name) > max_len:
                 name = name[:max_len] + ".."
             if filter is None:
-                print_str += f"{name} => "
+                frames.append(name)
             else:
                 if any(filter_str in name for filter_str in filter):
-                    print_str += f"{name} => "
-            # Move to the parent node
+                    frames.append(name)
             parent_node = self.get_parent_event(node)
-            if parent_node is None:
-                # Check if we should follow the fwd_event link for backward events
-                if follow_fwd_link and "fwd_event" in node:
-                    fwd_uid = node["fwd_event"]
-                    fwd_node = self.get_UID2event(fwd_uid)
-                    print_str += "[FWD] => "
-                    # Continue traversing the forward event's parent chain
-                    fwd_callstack = self.traverse_parents_and_get_callstack(
-                        fwd_node, filter, follow_fwd_link=False
-                    )
-                    return print_str + fwd_callstack
-                return print_str.strip(" => ").strip(" ")
+            if parent_node is None and follow_fwd_link and "fwd_event" in node:
+                fwd_uid = node["fwd_event"]
+                fwd_node = self.get_UID2event(fwd_uid)
+                frames.append("[FWD]")
+                fwd_callstack = self.traverse_parents_and_get_callstack(
+                    fwd_node, filter, follow_fwd_link=False
+                )
+                return frames + fwd_callstack
             node = parent_node
             depth += 1
+        return frames
 
     def traverse_parents_and_print(
         self,

--- a/TraceLens/TreePerf/tree_perf.py
+++ b/TraceLens/TreePerf/tree_perf.py
@@ -1811,7 +1811,7 @@ class TreePerfAnalyzer:
                 name = event.get("name", "")
                 if call_stack is None:
                     call_stack = []
-                if any(f in name for f in ["nn.Module", "::", "/"]):
+                if any(f in name for f in ["nn.Module", "::", "/"]) or self.event_to_category(event) == "cpu_op":
                     call_stack = call_stack + [re.sub(r"_\d+", "", name)]
 
             # Skip non-cpu_op events
@@ -2095,7 +2095,7 @@ class TreePerfAnalyzer:
                             cur = self.tree.get_parent_event(gpu_event)
                             while cur is not None and cur.get("UID") != event_uid:
                                 cname = cur.get("name", "")
-                                if any(f in cname for f in ["nn.Module", "::", "/"]):
+                                if any(f in cname for f in ["nn.Module", "::", "/"]) or self.event_to_category(cur) == "cpu_op":
                                     suffix.append(re.sub(r"_\d+", "", cname))
                                 cur = self.tree.get_parent_event(cur)
                             suffix.reverse()

--- a/TraceLens/TreePerf/tree_perf.py
+++ b/TraceLens/TreePerf/tree_perf.py
@@ -1120,7 +1120,7 @@ class TreePerfAnalyzer:
                     )
                     metrics_event["call_stack"] = call_stack
                     metrics_event["parent_module"] = re.sub(
-                        r"_\d+", "", (call_stack.split("=>") + ["NA", "NA"])[1]
+                        r"_\d+", "", (call_stack + ["NA", "NA"])[1]
                     ).strip("")
             thread_metadata = self.tree.metadata.get(event["pid"], {}).get(
                 event["tid"], {}
@@ -2399,17 +2399,28 @@ class TreePerfAnalyzer:
 
         if include_call_stack and tree is not None and "ex_UID" in df_summary.columns:
 
-            def _get_call_stack(ex_uid):
+            def _get_call_stack(row):
+                """Get call stack from root down to CPU op and then to kernels."""
                 try:
-                    event = tree.get_UID2event(int(ex_uid))
-                    cs = tree.traverse_parents_and_get_callstack(
+                    event = tree.get_UID2event(int(row["ex_UID"]))
+                    frames = tree.traverse_parents_and_get_callstack(
                         event, filter=["nn.Module", "::", "/"]
                     )
-                    return re.sub(r"_\d+", "", cs)
+                    # Reverse so it goes root -> CPU op
+                    frames = [re.sub(r"_\d+", "", f) for f in reversed(frames)]
+                    # Append kernel names from kernel_details_summary
+                    kd = row.get("kernel_details_summary")
+                    if isinstance(kd, list) and kd:
+                        kernels = [k["name"] for k in kd if k.get("name")]
+                        if len(kernels) == 1:
+                            frames.append(kernels[0])
+                        elif len(kernels) > 1:
+                            frames.append(kernels)
+                    return str(frames)
                 except Exception:
                     return "Not found"
 
-            df_summary["call_stack"] = df_summary["ex_UID"].apply(_get_call_stack)
+            df_summary["call_stack_full"] = df_summary.apply(_get_call_stack, axis=1)
         elif include_call_stack and tree is None:
             warnings.warn(
                 "include_call_stack=True but tree=None; skipping call stack column."

--- a/TraceLens/TreePerf/tree_perf.py
+++ b/TraceLens/TreePerf/tree_perf.py
@@ -1380,6 +1380,7 @@ class TreePerfAnalyzer:
             dur_arr = np.array(durations_for_this_index)
 
             del kernel_summary["dur"]
+            kernel_summary.pop("gpu_op_uid", None)
 
             kernel_summary["count"] = len(dur_arr)
             kernel_summary["total_duration_us"] = np.sum(
@@ -1806,11 +1807,12 @@ class TreePerfAnalyzer:
 
             event = self.tree.get_UID2event(event_uid)
             # Build running call stack: append this event's name if it matches the filter
-            name = event.get("name", "")
-            if call_stack is None:
-                call_stack = []
-            if any(f in name for f in ["nn.Module", "::", "/"]):
-                call_stack = call_stack + [re.sub(r"_\d+", "", name)]
+            if self.add_python_func:
+                name = event.get("name", "")
+                if call_stack is None:
+                    call_stack = []
+                if any(f in name for f in ["nn.Module", "::", "/"]):
+                    call_stack = call_stack + [re.sub(r"_\d+", "", name)]
 
             # Skip non-cpu_op events
             if not self.add_python_func and self.event_to_category(event) != "cpu_op":
@@ -1825,7 +1827,8 @@ class TreePerfAnalyzer:
 
             # Exit condition 1: Has perf model - collect and stop
             if self._has_perf_model(event):
-                event["_call_stack"] = call_stack
+                if self.add_python_func:
+                    event["_call_stack"] = call_stack
                 collected.append(event)
                 return
 
@@ -1837,7 +1840,8 @@ class TreePerfAnalyzer:
                     for child_uid in event.get("children", []):
                         traverse(child_uid, call_stack)
                     return
-                event["_call_stack"] = call_stack
+                if self.add_python_func:
+                    event["_call_stack"] = call_stack
                 collected.append(event)
                 return
 
@@ -1863,7 +1867,8 @@ class TreePerfAnalyzer:
                     # No children with perf models - collect this leaf
                     if not include_nccl and self._is_nccl_event(event):
                         return
-                    event["_call_stack"] = call_stack
+                    if self.add_python_func:
+                        event["_call_stack"] = call_stack
                     collected.append(event)
                 return
 
@@ -2070,7 +2075,8 @@ class TreePerfAnalyzer:
                 gpu_event_uids = event.get("gpu_events", [])
                 kernel_details = []
                 event_uid = event.get("UID")
-                base_call_stack = event.get("_call_stack", [])
+                has_call_stack = "_call_stack" in event
+                base_call_stack = event.get("_call_stack", []) if has_call_stack else []
                 for gpu_uid in gpu_event_uids:
                     gpu_event = self.tree.get_UID2event(gpu_uid)
                     if gpu_event and self.event_to_category(gpu_event) in {
@@ -2078,23 +2084,23 @@ class TreePerfAnalyzer:
                         "gpu_memcpy",
                         "gpu_memset",
                     }:
-                        suffix = []
-                        cur = self.tree.get_parent_event(gpu_event)
-                        while cur is not None and cur.get("UID") != event_uid:
-                            cname = cur.get("name", "")
-                            if any(f in cname for f in ["nn.Module", "::", "/"]):
-                                suffix.append(re.sub(r"_\d+", "", cname))
-                            cur = self.tree.get_parent_event(cur)
-                        suffix.reverse()
-                        kernel_details.append(
-                            {
-                                "name": gpu_event.get("name"),
-                                "dur": gpu_event.get("dur"),
-                                "stream": gpu_event.get("args", {}).get("stream"),
-                                "gpu_op_uid": gpu_event.get("UID"),
-                                "call_stack": base_call_stack + suffix,
-                            }
-                        )
+                        kd = {
+                            "name": gpu_event.get("name"),
+                            "dur": gpu_event.get("dur"),
+                            "stream": gpu_event.get("args", {}).get("stream"),
+                            "gpu_op_uid": gpu_event.get("UID"),
+                        }
+                        if has_call_stack:
+                            suffix = []
+                            cur = self.tree.get_parent_event(gpu_event)
+                            while cur is not None and cur.get("UID") != event_uid:
+                                cname = cur.get("name", "")
+                                if any(f in cname for f in ["nn.Module", "::", "/"]):
+                                    suffix.append(re.sub(r"_\d+", "", cname))
+                                cur = self.tree.get_parent_event(cur)
+                            suffix.reverse()
+                            kd["call_stack"] = base_call_stack + suffix
+                        kernel_details.append(kd)
                 row["kernel_details"] = kernel_details if kernel_details else None
 
             # Add perf metrics if available

--- a/TraceLens/TreePerf/tree_perf.py
+++ b/TraceLens/TreePerf/tree_perf.py
@@ -1872,7 +1872,18 @@ class TreePerfAnalyzer:
             for child_uid in event.get("children", []):
                 traverse(child_uid, call_stack)
 
-        # Start from cpu_root_nodes
+        # When python_function events are in the tree, start from
+        # parentless python_function roots that have GPU work
+        if self.add_python_func:
+            for evt in self.tree.events:
+                if (
+                    self.event_to_category(evt) == "python_function"
+                    and evt.get("parent") is None
+                    and evt.get("gpu_events")
+                ):
+                    traverse(evt["UID"])
+
+        # Start from cpu_root_nodes (any not already visited via python roots)
         for root_uid in self.tree.cpu_root_nodes:
             traverse(root_uid)
 

--- a/TraceLens/TreePerf/tree_perf.py
+++ b/TraceLens/TreePerf/tree_perf.py
@@ -1380,7 +1380,6 @@ class TreePerfAnalyzer:
             dur_arr = np.array(durations_for_this_index)
 
             del kernel_summary["dur"]
-            kernel_summary.pop("gpu_op_uid", None)
 
             kernel_summary["count"] = len(dur_arr)
             kernel_summary["total_duration_us"] = np.sum(
@@ -1800,12 +1799,18 @@ class TreePerfAnalyzer:
         collected = []
         visited = set()
 
-        def traverse(event_uid):
+        def traverse(event_uid, call_stack=None):
             if event_uid in visited:
                 return
             visited.add(event_uid)
 
             event = self.tree.get_UID2event(event_uid)
+            # Build running call stack: append this event's name if it matches the filter
+            name = event.get("name", "")
+            if call_stack is None:
+                call_stack = []
+            if any(f in name for f in ["nn.Module", "::", "/"]):
+                call_stack = call_stack + [re.sub(r"_\d+", "", name)]
 
             # Skip non-cpu_op events
             if not self.add_python_func and self.event_to_category(event) != "cpu_op":
@@ -1820,6 +1825,7 @@ class TreePerfAnalyzer:
 
             # Exit condition 1: Has perf model - collect and stop
             if self._has_perf_model(event):
+                event["_call_stack"] = call_stack
                 collected.append(event)
                 return
 
@@ -1829,8 +1835,9 @@ class TreePerfAnalyzer:
             if self._is_sole_bwd_with_fwd_perf_model(event):
                 if self._has_descendant_cpu_op_with_own_perf_model(event):
                     for child_uid in event.get("children", []):
-                        traverse(child_uid)
+                        traverse(child_uid, call_stack)
                     return
+                event["_call_stack"] = call_stack
                 collected.append(event)
                 return
 
@@ -1851,18 +1858,19 @@ class TreePerfAnalyzer:
                 if cpu_op_children_with_perf_model:
                     # Traverse children with perf models instead of collecting this leaf
                     for child_uid in cpu_op_children_with_perf_model:
-                        traverse(child_uid)
+                        traverse(child_uid, call_stack)
                 else:
                     # No children with perf models - collect this leaf
                     if not include_nccl and self._is_nccl_event(event):
                         return
+                    event["_call_stack"] = call_stack
                     collected.append(event)
                 return
 
             # Non-leaf with GPU kernels in subtree but no perf model
             # Traverse children to find more granular ops
             for child_uid in event.get("children", []):
-                traverse(child_uid)
+                traverse(child_uid, call_stack)
 
         # Start from cpu_root_nodes
         for root_uid in self.tree.cpu_root_nodes:
@@ -2050,6 +2058,8 @@ class TreePerfAnalyzer:
             if include_kernel_details:
                 gpu_event_uids = event.get("gpu_events", [])
                 kernel_details = []
+                event_uid = event.get("UID")
+                base_call_stack = event.get("_call_stack", [])
                 for gpu_uid in gpu_event_uids:
                     gpu_event = self.tree.get_UID2event(gpu_uid)
                     if gpu_event and self.event_to_category(gpu_event) in {
@@ -2057,12 +2067,21 @@ class TreePerfAnalyzer:
                         "gpu_memcpy",
                         "gpu_memset",
                     }:
+                        suffix = []
+                        cur = self.tree.get_parent_event(gpu_event)
+                        while cur is not None and cur.get("UID") != event_uid:
+                            cname = cur.get("name", "")
+                            if any(f in cname for f in ["nn.Module", "::", "/"]):
+                                suffix.append(re.sub(r"_\d+", "", cname))
+                            cur = self.tree.get_parent_event(cur)
+                        suffix.reverse()
                         kernel_details.append(
                             {
                                 "name": gpu_event.get("name"),
                                 "dur": gpu_event.get("dur"),
                                 "stream": gpu_event.get("args", {}).get("stream"),
                                 "gpu_op_uid": gpu_event.get("UID"),
+                                "call_stack": base_call_stack + suffix,
                             }
                         )
                 row["kernel_details"] = kernel_details if kernel_details else None
@@ -2397,30 +2416,65 @@ class TreePerfAnalyzer:
 
         df_summary = df_summary.rename(columns=rename_map)
 
-        if include_call_stack and tree is not None and "ex_UID" in df_summary.columns:
+        if include_call_stack and "kernel_details_summary" in df_summary.columns:
 
-            def _get_call_stack(row):
-                """Get call stack from root down to CPU op and then to kernels."""
+            def _get_call_stack(kd):
+                """Build call_stack_full from pre-computed per-kernel call stacks.
+
+                Single kernel: flat list from root to kernel.
+                Multiple kernels: common prefix as flat elements, then each
+                diverging tail as its own flat sublist (no double-nesting).
+                """
                 try:
-                    event = tree.get_UID2event(int(row["ex_UID"]))
-                    frames = tree.traverse_parents_and_get_callstack(
-                        event, filter=["nn.Module", "::", "/"]
-                    )
-                    # Reverse so it goes root -> CPU op
-                    frames = [re.sub(r"_\d+", "", f) for f in reversed(frames)]
-                    # Append kernel names from kernel_details_summary
-                    kd = row.get("kernel_details_summary")
-                    if isinstance(kd, list) and kd:
-                        kernels = [k["name"] for k in kd if k.get("name")]
-                        if len(kernels) == 1:
-                            frames.append(kernels[0])
-                        elif len(kernels) > 1:
-                            frames.append(kernels)
-                    return str(frames)
+                    if not isinstance(kd, list) or not kd:
+                        return "Not found"
+
+                    per_kernel = []
+                    for k in kd:
+                        chain = list(k.get("call_stack", [])) + [k.get("name", "Unknown")]
+                        per_kernel.append(chain)
+
+                    if len(per_kernel) == 1:
+                        return str(per_kernel[0])
+
+                    # Find common prefix across all chains
+                    min_len = min(len(c) for c in per_kernel)
+                    prefix_len = 0
+                    for idx in range(min_len):
+                        if len(set(c[idx] for c in per_kernel)) == 1:
+                            prefix_len = idx + 1
+                        else:
+                            break
+
+                    common = per_kernel[0][:prefix_len]
+                    tails = [c[prefix_len:] for c in per_kernel]
+                    # Deduplicate tails while preserving order
+                    seen = set()
+                    unique_tails = []
+                    for t in tails:
+                        key = tuple(t)
+                        if key not in seen:
+                            seen.add(key)
+                            unique_tails.append(t)
+                    return str(common + unique_tails)
                 except Exception:
                     return "Not found"
 
-            df_summary["call_stack_full"] = df_summary.apply(_get_call_stack, axis=1)
+            df_summary["call_stack_full"] = df_summary["kernel_details_summary"].apply(
+                _get_call_stack
+            )
+
+            # Drop call_stack and gpu_op_uid from kernel_details_summary
+            if "kernel_details_summary" in df_summary.columns:
+                def _drop_internal_fields(kd):
+                    if isinstance(kd, list):
+                        for k in kd:
+                            k.pop("call_stack", None)
+                            k.pop("gpu_op_uid", None)
+                    return kd
+                df_summary["kernel_details_summary"] = df_summary[
+                    "kernel_details_summary"
+                ].apply(_drop_internal_fields)
         elif include_call_stack and tree is None:
             warnings.warn(
                 "include_call_stack=True but tree=None; skipping call stack column."


### PR DESCRIPTION
## Summary

Replace the heuristic `_extract_launcher_path()` with the pre-computed `entry_point` column from `unified_perf_summary`, and switch `module_chain`/`call_chain` extraction to parse the new `call_stack_full` format.
This PR accompanies https://github.com/AMD-AGI/TraceLens/pull/743. All changes in https://github.com/AMD-AGI/TraceLens/pull/743 are in this PR.

---

## Problem

The agent's `_extract_launcher_path()` re-derived the dispatch entry point at analysis time by walking the old `" => "`-delimited `call_stack` string from `unified_perf_callstacks.csv`.

Now that `unified_perf_callstacks.csv` has been replaced by two columns `entry_point` and `call_stack_full` in `unified_perf_summary`, the agent can use `entry_point` for the `Kernel Path` column in the tables. `extract_module_chain` and `extract_call_chain` can use `call_stack_full`.

## Changes

**`orchestrator_prepare.py`** — Removed the `unified_perf_callstacks.csv` join block. `entry_point` and `call_stack_full` are now columns in `unified_perf_summary.csv` and flow directly to per-category CSVs.

**`analysis_utils.py`**:
- `build_operation_metrics()`: reads `row["entry_point"]` as primary `launcher_path`. When `entry_point` is `"Not found"`, falls back to module chain (`"LlamaModel > LlamaDecoderLayer > LlamaMLP"`), then library name (`"Triton (vendor)"`), then `"Not found"`. Reads `row["call_stack_full"]` for `module_chain`/`call_chain`.
- Added `_parse_call_stack()`: parses `call_stack_full` (Python list repr) via `ast.literal_eval`, keeping only top-level string frames and discarding nested sublists. The sublists represent diverging kernel tails in multi-kernel ops — they contain GPU kernel names that the agent doesn't use in prose context.
- Deleted `_extract_launcher_path()`, `_extract_backward_context()`, and `_SKIP_PY_PATTERNS`.