### PR TITLE
Fix magpie profiler flags

### DIFF
--- a/TraceLens/Agent/Profiling/.cursor/skills/magpie-benchmark-profiling.md
+++ b/TraceLens/Agent/Profiling/.cursor/skills/magpie-benchmark-profiling.md
@@ -177,12 +177,14 @@ Add these flags to `EXTRA_VLLM_ARGS` in the user's YAML config (append to any ex
 ```yaml
 benchmark:
   envs:
-    EXTRA_VLLM_ARGS: "... --profiler-config.capture_torch_profiler_dir /workspace/torch_trace/capture_traces --profiler-config.detailed_trace_annotation True"
+    EXTRA_VLLM_ARGS: "... --profiler-config.profiler torch --profiler-config.torch_profiler_dir /workspace/torch_trace --profiler-config.capture_torch_profiler_dir /workspace/torch_trace/capture_traces --profiler-config.detailed_trace_annotation True"
 ```
 
-Use the literal path `/workspace/torch_trace/capture_traces` rather than `${TRACE_DIR}/capture_traces`. Bash does not recursively expand variables — `$EXTRA_VLLM_ARGS` is word-split but its contents are not re-evaluated for variable references, so `${TRACE_DIR}` would be passed as a literal string to vLLM. For `--run-mode local`, replace `/workspace/torch_trace` with the actual host-side trace directory.
+Use the literal path `/workspace/torch_trace` rather than `${TRACE_DIR}`. Bash does not recursively expand variables — `$EXTRA_VLLM_ARGS` is word-split but its contents are not re-evaluated for variable references, so `${TRACE_DIR}` would be passed as a literal string to vLLM. For `--run-mode local`, replace `/workspace/torch_trace` with the actual host-side trace directory.
 
-- `--profiler-config.capture_torch_profiler_dir /workspace/torch_trace/capture_traces` — enables graph-capture tracing. vLLM writes separate traces for CUDA graph capture phases into this directory, which are needed for downstream TraceLens analysis of graph-replayed operations.
+- `--profiler-config.profiler torch` — selects the torch profiler backend. **Required prerequisite**: the `ProfilerConfig` validator raises a pydantic `ValueError` and aborts server startup if `capture_torch_profiler_dir` is set without `profiler` being `"torch"`.
+- `--profiler-config.torch_profiler_dir /workspace/torch_trace` — sets the output directory for the main inference trace. **Required prerequisite** when `profiler=torch`: vLLM raises a pydantic `ValueError` at startup if this is not set.
+- `--profiler-config.capture_torch_profiler_dir /workspace/torch_trace/capture_traces` — enables graph-capture tracing and sets the directory where capture traces are written. vLLM writes separate traces for CUDA graph capture phases into this directory, which are needed for downstream TraceLens analysis of graph-replayed operations.
 - `--profiler-config.detailed_trace_annotation True` — enables detailed annotations in the trace (iteration boundaries, phase labels, scheduling metadata). These annotations are required by `split_inference_trace_annotation` for accurate trace splitting.
 
 ##### Common SGLang flags

--- a/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.14.0.patch
+++ b/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.14.0.patch
@@ -65,7 +65,7 @@ index 525ad5db4..bb182e02e 100644
 +        enable_profiler = (local_rank == 0) and self.vllm_config.profiler_config.capture_torch_profiler_dir
 +
 +        if enable_profiler:
-+            trace_dir = self.vllm_config.profiler_config.torch_profiler_dir + "/capture_traces"
++            trace_dir = self.vllm_config.profiler_config.capture_torch_profiler_dir
 +            profiler = torch.profiler.profile(
 +                activities=[
 +                    torch.profiler.ProfilerActivity.CPU,

--- a/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.15.0.patch
+++ b/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.15.0.patch
@@ -59,7 +59,7 @@ index 64f6263cc..9eb356b5f 100644
 +        enable_profiler = (local_rank == 0) and self.vllm_config.profiler_config.capture_torch_profiler_dir
 +        
 +        if enable_profiler:
-+            trace_dir = self.vllm_config.profiler_config.torch_profiler_dir + "/capture_traces"
++            trace_dir = self.vllm_config.profiler_config.capture_torch_profiler_dir
 +            profiler = torch.profiler.profile(
 +                activities=[
 +                    torch.profiler.ProfilerActivity.CPU,

--- a/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.16.0.patch
+++ b/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.16.0.patch
@@ -59,7 +59,7 @@ index a7c2a8800..4b2e16fbc 100644
 +        enable_profiler = (local_rank == 0) and self.vllm_config.profiler_config.capture_torch_profiler_dir
 +        
 +        if enable_profiler:
-+            trace_dir = self.vllm_config.profiler_config.torch_profiler_dir + "/capture_traces"
++            trace_dir = self.vllm_config.profiler_config.capture_torch_profiler_dir
 +            profiler = torch.profiler.profile(
 +                activities=[
 +                    torch.profiler.ProfilerActivity.CPU,

--- a/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.17.0.patch
+++ b/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.17.0.patch
@@ -59,7 +59,7 @@ index e4ddefc81..3942904f9 100644
 +        enable_profiler = (local_rank == 0) and self.vllm_config.profiler_config.capture_torch_profiler_dir
 +        
 +        if enable_profiler:
-+            trace_dir = self.vllm_config.profiler_config.torch_profiler_dir + "/capture_traces"
++            trace_dir = self.vllm_config.profiler_config.capture_torch_profiler_dir
 +            profiler = torch.profiler.profile(
 +                activities=[
 +                    torch.profiler.ProfilerActivity.CPU,

--- a/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.18.0.patch
+++ b/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.18.0.patch
@@ -59,7 +59,7 @@ index 98e1dab36..a22fcc79d 100644
 +        local_rank = get_world_group().local_rank
 +        enable_profiler = (local_rank == 0) and self.vllm_config.profiler_config.capture_torch_profiler_dir
 +        if enable_profiler:
-+            trace_dir = self.vllm_config.profiler_config.torch_profiler_dir + "/capture_traces"
++            trace_dir = self.vllm_config.profiler_config.capture_torch_profiler_dir
 +            profiler = torch.profiler.profile(
 +                activities=[
 +                    torch.profiler.ProfilerActivity.CPU,

--- a/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.19.0.patch
+++ b/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.19.0.patch
@@ -59,7 +59,7 @@ index 2e62206da..3194ea16f 100644
 +        local_rank = get_world_group().local_rank
 +        enable_profiler = (local_rank == 0) and self.vllm_config.profiler_config.capture_torch_profiler_dir
 +        if enable_profiler:
-+            trace_dir = self.vllm_config.profiler_config.torch_profiler_dir + "/capture_traces"
++            trace_dir = self.vllm_config.profiler_config.capture_torch_profiler_dir
 +            profiler = torch.profiler.profile(
 +                activities=[
 +                    torch.profiler.ProfilerActivity.CPU,

--- a/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.20.0.patch
+++ b/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.20.0.patch
@@ -58,7 +58,7 @@ index a0ba47f..e8150c6 100644
 +        local_rank = get_world_group().local_rank
 +        enable_profiler = (local_rank == 0) and self.vllm_config.profiler_config.capture_torch_profiler_dir
 +        if enable_profiler:
-+            trace_dir = self.vllm_config.profiler_config.torch_profiler_dir + "/capture_traces"
++            trace_dir = self.vllm_config.profiler_config.capture_torch_profiler_dir
 +            profiler = torch.profiler.profile(
 +                activities=[
 +                    torch.profiler.ProfilerActivity.CPU,

--- a/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.21.0.patch
+++ b/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.21.0.patch
@@ -58,7 +58,7 @@ index 98b2fbf12..d7f1f5179 100644
 +        local_rank = get_world_group().local_rank
 +        enable_profiler = (local_rank == 0) and self.vllm_config.profiler_config.capture_torch_profiler_dir
 +        if enable_profiler:
-+            trace_dir = self.vllm_config.profiler_config.torch_profiler_dir + "/capture_traces"
++            trace_dir = self.vllm_config.profiler_config.capture_torch_profiler_dir
 +            profiler = torch.profiler.profile(
 +                activities=[
 +                    torch.profiler.ProfilerActivity.CPU,


### PR DESCRIPTION
The `profiler` flag and `profiler_dir` need to be set but are currently not required in the skill file, causing the profiling to fail before the agent corrects itself.

From vllm/config/profiler.py that TraceLens patches:

```
if self.profiler == "torch" and not profiler_dir:
      raise ValueError("torch_profiler_dir must be set when profiler is 'torch'")
```
and
```
if capture_dir and self.profiler != "torch":
    raise ValueError(
        "capture_torch_profiler_dir is only applicable when profiler is set to 'torch'"
    )
```

Now the flags are correctly passed into `EXTRA_VLLM_ARGS`. 

Additionally, previously the patches ignored whatever `profiler-config.capture_torch_profiler_dir` was set to and always set it to torch_profiler_dir + "/capture_traces". Now, `profiler-config.capture_torch_profiler_dir` properly sets the capture trace directory