### PR TITLE
Read nn.module names for model identification

### DIFF
--- a/TraceLens/Agent/Analysis/.cursor/agents/model-identification-agent.md
+++ b/TraceLens/Agent/Analysis/.cursor/agents/model-identification-agent.md
@@ -56,19 +56,24 @@ Execute the Python script to extract the **name**, **Input type**, and **Input D
 ```bash
 <prefix> python3 -c "
 import sys
-from TraceLens.Agent.Analysis.utils.report_utils import extract_condensed_op_info
-if not extract_condensed_op_info('<output_dir>', '<comparison_scope>'):
+from TraceLens.Agent.Analysis.utils.report_utils import prepare_model_identification_data
+if not prepare_model_identification_data('<output_dir>', '<comparison_scope>'):
     sys.exit(1)
 "
 ```
 
 The script does **not** perform any inference. It only produces the CSV for you to analyze.
 
-### Step 2: Analyze condensed_op_info.csv and write model_info.json
+### Step 2: Read nn_modules.txt for model identity
+
+If `<output_dir>/metadata/nn_modules.txt` exists and is non-empty, use it to infer **model**.
+
+If the file is absent or empty, skip this step and infer **model** from `condensed_op_info.csv` in Step 3.
+
+### Step 3: Analyze condensed_op_info.csv and write model_info.json
 
 Open `<output_dir>/metadata/condensed_op_info.csv` and analyze the **name**, **Input type**, and **Input Dims** values across the rows. Infer:
-
-- **model**
+- **model** (if not already determined in Step 2)
 - **architecture**
 - **scale**
 - **precision**
@@ -82,7 +87,7 @@ Write `<output_dir>/metadata/model_info.json` with these four keys. **Use "Canno
 - **Precision**: From **Input type** — e.g. `c10::BFloat16` → BF16, `float` → FP32, `float8`/FP8 → FP8.
 - **Architecture**: From **name** and **Input Dims** — e.g. convolution → CNN; bmm + softmax + (batch, heads, seq, seq) → Transformer.
 - **Scale**: From typical hidden/embed sizes in **Input Dims**
-- **Model**: From combination of op **name** and **Input Dims**
+- **Model**: Prefer `nn_modules.txt` (Step 2) over op-name inference.
 
 ---
 

--- a/TraceLens/Agent/Analysis/utils/__init__.py
+++ b/TraceLens/Agent/Analysis/utils/__init__.py
@@ -16,7 +16,7 @@ from .plot_utils import (
     generate_perf_plot,
 )
 from .report_utils import (
-    extract_condensed_op_info,
+    prepare_model_identification_data,
     generate_priority_data,
     load_findings,
     load_manifest,
@@ -30,7 +30,7 @@ from .validation_utils import (
 
 __all__ = [
     "build_category_findings",
-    "extract_condensed_op_info",
+    "prepare_model_identification_data",
     "generate_and_embed_plot",
     "generate_perf_plot",
     "generate_priority_data",

--- a/TraceLens/Agent/Analysis/utils/report_utils.py
+++ b/TraceLens/Agent/Analysis/utils/report_utils.py
@@ -33,7 +33,7 @@ def prepare_model_identification_data(
 
     Reads unified_perf_summary.csv and writes two files under metadata/:
     - condensed_op_info.csv: name, Input type, Input Dims columns for op-level inference.
-    - nn_modules.txt: unique nn.Module class names from call_stack_full (best-effort).
+    - nn_modules.txt: unique nn.Module class names from trace.
 
     Args:
         output_dir: Base analysis output directory.
@@ -54,14 +54,18 @@ def prepare_model_identification_data(
         return False
 
     try:
-        df = pd.read_csv(csv_path, usecols=["name", "Input type", "Input Dims", "call_stack_full"])
+        df = pd.read_csv(
+            csv_path, usecols=["name", "Input type", "Input Dims", "call_stack_full"]
+        )
     except (ValueError, KeyError):
         return False
 
     metadata_dir = os.path.join(output_dir, "metadata")
     os.makedirs(metadata_dir, exist_ok=True)
 
-    df[["name", "Input type", "Input Dims"]].to_csv(os.path.join(metadata_dir, "condensed_op_info.csv"), index=False)
+    df[["name", "Input type", "Input Dims"]].to_csv(
+        os.path.join(metadata_dir, "condensed_op_info.csv"), index=False
+    )
 
     nn_modules = sorted(
         {

--- a/TraceLens/Agent/Analysis/utils/report_utils.py
+++ b/TraceLens/Agent/Analysis/utils/report_utils.py
@@ -15,7 +15,7 @@ import json
 import os
 from collections import defaultdict
 from typing import List
-
+import re
 import pandas as pd
 
 
@@ -26,22 +26,24 @@ def load_manifest(output_dir: str) -> dict:
         return json.load(f)
 
 
-def extract_condensed_op_info(
+def prepare_model_identification_data(
     output_dir: str, comparison_scope: str = "standalone"
 ) -> bool:
-    """Extract name, Input type, Input Dims to metadata/condensed_op_info.csv.
+    """Prepare metadata files for the model-identification subagent.
 
-    Reads unified_perf_summary.csv from the appropriate perf report CSV
-    directory and writes the three columns for the model-identification
-    subagent.  Returns True on success.
+    Reads unified_perf_summary.csv and writes two files under metadata/:
+    - condensed_op_info.csv: name, Input type, Input Dims columns for op-level inference.
+    - nn_modules.txt: unique nn.Module class names from call_stack_full (best-effort).
 
     Args:
         output_dir: Base analysis output directory.
-        comparison_scope: ``"standalone"`` (default) reads from
-            ``perf_report_csvs/``; ``"comparative"`` reads from
-            ``perf_report_trace1_csvs/``.
+        comparison_scope: ``"standalone"`` reads from ``perf_report_csvs/``;
+            ``"comparative"`` reads from ``perf_report_trace1_csvs/``.
+
+    Returns:
+        True on success, False if unified_perf_summary.csv is missing or unreadable.
     """
-    _CONDENSED_OP_INFO_COLUMNS = ("name", "Input type", "Input Dims")
+
     csv_dir = (
         "perf_report_trace1_csvs"
         if comparison_scope == "comparative"
@@ -50,13 +52,27 @@ def extract_condensed_op_info(
     csv_path = os.path.join(output_dir, csv_dir, "unified_perf_summary.csv")
     if not os.path.isfile(csv_path):
         return False
+
     try:
-        df = pd.read_csv(csv_path, usecols=list(_CONDENSED_OP_INFO_COLUMNS))
+        df = pd.read_csv(csv_path, usecols=["name", "Input type", "Input Dims", "call_stack_full"])
     except (ValueError, KeyError):
         return False
-    out_path = os.path.join(output_dir, "metadata", "condensed_op_info.csv")
-    os.makedirs(os.path.dirname(out_path), exist_ok=True)
-    df.to_csv(out_path, index=False)
+
+    metadata_dir = os.path.join(output_dir, "metadata")
+    os.makedirs(metadata_dir, exist_ok=True)
+
+    df[["name", "Input type", "Input Dims"]].to_csv(os.path.join(metadata_dir, "condensed_op_info.csv"), index=False)
+
+    nn_modules = sorted(
+        {
+            m
+            for cell in df["call_stack_full"].dropna()
+            for m in re.findall(r"nn\.Module:\s*([^\s',\]]+)", str(cell))
+        }
+    )
+    with open(os.path.join(metadata_dir, "nn_modules.txt"), "w") as f:
+        f.write("\n".join(nn_modules) + "\n" if nn_modules else "")
+
     return True
 
 


### PR DESCRIPTION
This PR makes model identification more robust.
Previously, when determining the model that a trace was ran on, the agent would only look at operation names and input dimensions for operations. However, the agent would occasionally misclassify traces if two models have a very similar architecture (Kimi-K2 and DeepseekvV3). 

Now, the agent looks at the names of the nn.Modules as well (when available).

The agent now correctly classifies Kimi-K2 traces. Verified that the agent still correctly classifies all the traces in the standalone tests.