### PR TITLE
Added support for packed activation scenario

### DIFF
--- a/TraceLens/PerfModel/extensions/moe_perf_model_extensions.py
+++ b/TraceLens/PerfModel/extensions/moe_perf_model_extensions.py
@@ -1063,7 +1063,7 @@ class moe_aiter_ck_stage1(UnfusedMoE_Up):
         Extract MoE dimensions and data types from event args.
 
         Expected Input Dims format (from aiter::ck_moe_stage1):
-        [[tokens, hidden_dim], [E, N, K_packed], [E, hidden_dim, inter_dim_packed],
+        [[tokens, hidden_dim_packed], [E, N, K_packed], [E, hidden_dim, inter_dim_packed],
          [sorted_ids], [sorted_expert_ids], [num_valid_ids],
          [tokens, topk, inter_dim], ...]
 
@@ -1079,12 +1079,13 @@ class moe_aiter_ck_stage1(UnfusedMoE_Up):
         out_shape = kernel_input_shape[6]
 
         num_tokens = input_shape[0]
-        hidden_dim = input_shape[1]
 
-        E, hidden_dim_w2, inter_dim = w2_shape
+        E, hidden_dim, inter_dim = w2_shape
 
-        # Account for INT4 weight packing: w1's K dim may be compressed
-        int4_war = hidden_dim_w2 // w1_shape[-1]
+        # Account for FP4/INT4 weight packing: w1's K dim may be compressed.
+        # The packing factor is the ratio of the unpacked hidden_dim (from w2)
+        # to w1's packed K dim, and also applies to inter_dim.
+        int4_war = hidden_dim // w1_shape[-1]
         inter_dim *= int4_war
 
         num_experts = E
@@ -1166,7 +1167,7 @@ class moe_aiter_ck_stage2(UnfusedMoE_Down):
         Extract MoE dimensions and data types from event args.
 
         Expected Input Dims format (from aiter::ck_moe_stage2):
-        [[tokens, topk, inter_dim], [E, N, K], [E, hidden_dim, inter_dim_packed],
+        [[tokens, topk, inter_dim_packed], [E, N, K_packed], [E, hidden_dim, inter_dim_packed],
          [sorted_ids], [sorted_expert_ids], [num_valid_ids],
          [tokens, hidden_dim], ...]
 
@@ -1177,10 +1178,17 @@ class moe_aiter_ck_stage2(UnfusedMoE_Down):
 
         kernel_input_shape = args["Input Dims"]
         input_shape = kernel_input_shape[0]
+        w1_shape = kernel_input_shape[1]
         w2_shape = kernel_input_shape[2]
 
         num_tokens, topk, inter_dim = input_shape
         num_experts, hidden_dim, _ = w2_shape
+
+        # Account for FP4/INT4 packing: inter_states' last dim (and w2's last
+        # dim) may be packed. The packing factor is the ratio of the unpacked
+        # hidden_dim (w2's middle dim) to w1's packed K dim.
+        int4_war = hidden_dim // w1_shape[-1] if w1_shape else 1
+        inter_dim *= int4_war
 
         input_dtype = args["Input type"][0]
         weight_dtype = args["Input type"][2]


### PR DESCRIPTION
This pull request updates the logic for extracting and handling packed dimensions in Mixture-of-Experts (MoE) model parameter parsing. The main focus is to ensure correct unpacking of dimensions when weights are stored in packed formats (such as INT4 or FP4), improving the accuracy of shape calculations.

**MoE input dimension handling improvements:**

* Updated expected input shapes in documentation comments for both Stage 1 and Stage 2 to clarify when dimensions are packed (e.g., `hidden_dim_packed`, `K_packed`, `inter_dim_packed`). [[1]](diffhunk://#diff-bbd7dd8b7937bd2539fa07abdcc2d00cd9a4b5443bd5a29508536b2c7d3ffb3aL1066-R1066) [[2]](diffhunk://#diff-bbd7dd8b7937bd2539fa07abdcc2d00cd9a4b5443bd5a29508536b2c7d3ffb3aL1169-R1170)

**Packed dimension unpacking logic:**

* Changed unpacking logic to consistently use the unpacked `hidden_dim` from `w2_shape` as the reference for calculating the packing factor (`int4_war`), ensuring correct scaling of `inter_dim` when weights are packed.
* For Stage 2, added extraction of `w1_shape` and adjusted the calculation of the packing factor and `inter_dim` accordingly, with a fallback to `1` if `w1_shape` is missing.

These changes improve the handling of packed weight shapes, reducing the risk of shape mismatches and ensuring the code accurately interprets packed model parameters.
<!--
Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.

See LICENSE for license information.
-->

