### PR TITLE
New perf models for RoPE, MoE Aux and Quantization

### DIFF
--- a/TraceLens/PerfModel/extensions/__init__.py
+++ b/TraceLens/PerfModel/extensions/__init__.py
@@ -19,6 +19,7 @@ from .moe_perf_model_extensions import (
     moe_gptq_awq_down,
     moe_flydsl_stage1,
     moe_flydsl_stage2,
+    sglang_fused_append_shared_experts,
 )
 from .attention_perf_model_extensions import (
     InferenceAttention,
@@ -32,6 +33,10 @@ from .perf_model_extensions import (
     gemm_a8w8_blockscale,
     aiter_gelu_and_mul,
     aiter_gelu_tanh_and_mul,
+    aiter_fused_qk_rope_cat_and_cache_mla,
+    sglang_quant_dynamic_mxfp4_quant,
+    aiter_fused_dynamic_mxfp4_quant_moe_sort_hip,
+    aiter_dynamic_per_group_scaled_quant_fp4,
 )
 from .rmsnorm_perf_model_extensions import (
     aiter_rms_norm,
@@ -75,6 +80,11 @@ __all__ = [
     "gemm_a8w8_blockscale",
     "aiter_gelu_and_mul",
     "aiter_gelu_tanh_and_mul",
+    "aiter_fused_qk_rope_cat_and_cache_mla",
+    "sglang_quant_dynamic_mxfp4_quant",
+    "aiter_fused_dynamic_mxfp4_quant_moe_sort_hip",
+    "aiter_dynamic_per_group_scaled_quant_fp4",
+    "sglang_fused_append_shared_experts",
     # RMSNorm classes
     "aiter_rms_norm",
     "aiter_rmsnorm",

--- a/TraceLens/PerfModel/extensions/moe_perf_model_extensions.py
+++ b/TraceLens/PerfModel/extensions/moe_perf_model_extensions.py
@@ -8,7 +8,10 @@
 Performance models for pseudo-op extensions.
 """
 
-from TraceLens.PerfModel.utils import torch_dtype_map
+from math import prod
+
+from TraceLens.PerfModel.utils import torch_dtype_map, name2bpe
+from TraceLens.PerfModel.perf_model import BinaryElementwise
 
 DTYPE_TO_BYTES = {
     "Float8_e4m3fn": 1,
@@ -1714,3 +1717,70 @@ class moe_gptq_awq_down(UnfusedMoE_Down):
 
     def get_maf_type(self):
         return "matrix"
+
+
+class sglang_fused_append_shared_experts(BinaryElementwise):
+    """
+    Performance model for
+    sglang_profiler::fused_moe_triton_kernels_fused_append_shared_experts.
+
+    Reference implementation:
+        sglang/python/sglang/srt/layers/moe/fused_moe_triton/
+        fused_moe_triton_kernels.py (fused_append_shared_experts)
+        called from sglang/srt/layers/moe/topk.py:1264 (_post_process_topk_ids)
+
+    Appends shared-expert routing entries onto the per-token (topk_ids,
+    topk_weights) tensors produced by the router. This is a routing/metadata op:
+    no GEMM-style arithmetic, dominated by reading + rewriting the small
+    (num_tokens, topk) id/weight tensors.
+
+    Expected Input Dims from trace:
+        [0] = (M, topk)   ids      (int32)
+        [1] = (M, topk)   weights  (float32)
+
+    Roofline -- FLOPs:
+        ~0 (index/weight gather + write); modeled as 1 op/element for a
+        non-zero roofline floor.
+
+    Roofline -- bytes moved:
+        read + write both id and weight tensors:
+        2 * (M*topk*bpe_ids + M*topk*bpe_wts)
+
+    Reuses core BinaryElementwise (2-input machinery, get_maf_type);
+    overrides the roofline for the read+write pattern.
+    """
+
+    category = "MoE_aux"
+    bwd_category = None
+    sheet_category = "MoE_aux"
+
+    @staticmethod
+    def get_param_details(event):
+        dims = event["args"]["Input Dims"]
+        types = event["args"]["Input type"]
+        ids_shape = tuple(dims[0])
+        wts_shape = tuple(dims[1]) if len(dims) > 1 and dims[1] else ids_shape
+        dtype_ids = types[0] if types else "int"
+        dtype_wts = types[1] if len(types) > 1 else "float"
+        return {
+            "shape_in1": ids_shape,
+            "shape_in2": wts_shape,
+            "dtype_in1_in2_out": (dtype_ids, dtype_wts, dtype_wts),
+            "stride_input1": None,
+            "stride_input2": None,
+            "stride_output": None,
+        }
+
+    def flops(self):
+        return prod(self.param_details["shape_in1"])
+
+    def bytes(self):
+        n_ids = self.nelems_in1
+        n_wts = self.nelems_in2
+        bpe_ids = self.bpe_in1 or 4
+        bpe_wts = self.bpe_in2 or 4
+        return 2 * (n_ids * bpe_ids + n_wts * bpe_wts)
+
+    def get_compute_precision(self):
+        dtype = self.param_details["dtype_in1_in2_out"][1]
+        return torch_dtype_map(dtype) if dtype else None

--- a/TraceLens/PerfModel/extensions/perf_model_extensions.py
+++ b/TraceLens/PerfModel/extensions/perf_model_extensions.py
@@ -956,3 +956,191 @@ class sglang_store_cache:
     def get_compute_precision(self):
         dtype = self.param_details.get("dtype")
         return torch_dtype_map(dtype) if dtype else None
+
+
+class aiter_fused_qk_rope_cat_and_cache_mla(FusedRoPE):
+    """
+    Performance model for aiter::fused_qk_rope_cat_and_cache_mla
+    (RoPE on q_pe/k_pe + KV-cache write).
+
+    Reference implementation:
+        aiter/aiter/ops/triton/fusions/fused_kv_cache.py:88
+        (kernel _fused_qk_rope_cat_and_cache_mla_kernel)
+
+    Applies rotary position embedding to the rope (pe) slices of Q and K,
+    concatenates the nope + pe parts into a single head dim, returns the rotated
+    Q, and writes the concatenated K (nope || pe) into kv_cache in place at the
+    slots given by slot_mapping.
+
+    Expected Input Dims from trace:
+        [0] q_nope   = (T, QH, D_lora)
+        [1] q_pe     = (T, QH, D_pe)
+        [2] k_nope   = (T, KH, D_lora)
+        [3] k_pe     = (T, KH, D_pe)
+        [4] kv_cache = (B_cache, KH, D_lora + D_pe)
+        ...
+
+    Expected Input type from trace:
+        [bf16, bf16, bf16, bf16, <kv_cache dtype, e.g. fp8>, ...]
+
+    Roofline -- FLOPs:
+        RoPE rotates only the pe slices of Q and K. ~3 FLOPs/element.
+        flops = 3 * (T*QH*D_pe + T*KH*D_pe)
+
+    Roofline -- bytes moved:
+        read  q_nope + q_pe + k_nope + k_pe : nelems * bpe_in
+        write q_out  (T, QH, D_lora+D_pe)   : T*QH*(D_lora+D_pe) * bpe_out
+        write kv rows (T tokens written)    : T*KH*(D_lora+D_pe) * bpe_kv
+        cos/sin/pos are small + cache-resident; omitted.
+
+    """
+
+    sheet_category = "FusedRoPE"
+
+    def __init__(self, event, arch=None, python_path=None, **kwargs):
+        self.event = event
+        self.arch = arch
+        self.python_path = python_path
+        self.param_details = self.get_param_details(event)
+        self.bpe_in = name2bpe(self.param_details["dtype_in"])
+        self.bpe_kv = name2bpe(self.param_details["dtype_kv"])
+
+    @staticmethod
+    def get_param_details(event):
+        dims = event["args"]["Input Dims"]
+        types = event["args"]["Input type"]
+        q_nope = tuple(dims[0])
+        q_pe = tuple(dims[1])
+        k_nope = tuple(dims[2])
+        T, QH, D_lora = q_nope
+        D_pe = q_pe[2]
+        KH = k_nope[1]
+        dtype_in = types[0]
+        dtype_kv = types[4] if len(types) > 4 and types[4] else dtype_in
+        return {
+            "T": T,
+            "QH": QH,
+            "KH": KH,
+            "D_lora": D_lora,
+            "D_pe": D_pe,
+            "dtype_in": dtype_in,
+            "dtype_kv": dtype_kv,
+        }
+
+    def flops(self):
+        p = self.param_details
+        return 3 * (p["T"] * p["QH"] * p["D_pe"] + p["T"] * p["KH"] * p["D_pe"])
+
+    def bytes(self):
+        p = self.param_details
+        T, QH, KH, D_lora, D_pe = (p["T"], p["QH"], p["KH"], p["D_lora"], p["D_pe"])
+        bpe_in = self.bpe_in
+        if bpe_in is None:
+            return None
+        bpe_out = bpe_in  # q_out keeps the Q input dtype
+        bpe_kv = self.bpe_kv if self.bpe_kv is not None else bpe_in
+        read_q = (T * QH * D_lora + T * QH * D_pe) * bpe_in
+        read_k = (T * KH * D_lora + T * KH * D_pe) * bpe_in
+        write_q = T * QH * (D_lora + D_pe) * bpe_out
+        write_kv = T * KH * (D_lora + D_pe) * bpe_kv
+        return read_q + read_k + write_q + write_kv
+
+    def get_compute_precision(self):
+        return torch_dtype_map(self.param_details["dtype_in"])
+
+
+class sglang_quant_dynamic_mxfp4_quant(fused_flatten_mxfp4_quant):
+    """
+    Performance model for sglang_profiler::quant_dynamic_mxfp4_quant.
+
+    Reference implementation:
+        aiter/aiter/ops/triton/quant/... dynamic_mxfp4_quant
+        (sglang quark w4a4 mxfp4 scheme).
+
+    Dynamic MXFP4 activation quant. Single BF16 input (M, N); output is packed
+    FP4 + per-32-element E8M0 scales. Shares the MXFP4 quant roofline of
+    fused_flatten_mxfp4_quant (read x + write 0.5 B/elem FP4 + 1/32 B/elem scales).
+
+    Expected Input Dims from trace:
+        [0] = (M, N)   (>2D inputs are flattened along the leading dims)
+    Expected Input type from trace:
+        [bf16]
+    """
+
+    @staticmethod
+    def get_param_details(event):
+        dims = event["args"]["Input Dims"]
+        types = event["args"]["Input type"]
+        op_shape = tuple(dims[0])
+        dtype_in = types[0]
+        return {
+            "op_shape": op_shape,
+            "dtype_in_out": (dtype_in, dtype_in),
+            "stride_input": None,
+            "stride_output": None,
+        }
+
+
+class aiter_fused_dynamic_mxfp4_quant_moe_sort_hip(fused_flatten_mxfp4_quant):
+    """
+    Performance model for aiter::fused_dynamic_mxfp4_quant_moe_sort_hip.
+
+    Reference implementation:
+        aiter/aiter/ops/quant.py:1103 (fused_dynamic_mxfp4_quant_moe_sort ->
+        fused_dynamic_mx_quant_moe_sort; HIP kernel mxfp4_quant_moe_sort_kernel)
+
+    Fuses dynamic MXFP4 activation quant with MoE token sorting. The sort only
+    touches small index tensors (metadata) and is negligible relative to the
+    activation quant traffic.
+
+    Expected Input Dims from trace:
+        [0] out_fp4   = (M, N // 2)        packed FP4
+        [1] out_scale = (pad_rows, N // 32) E8M0 (sorted layout)
+        [2] input     = (M, N)             BF16   <- modeled input
+        [3] sorted_ids, [4] num_valid_ids  (metadata)
+    """
+
+    @staticmethod
+    def get_param_details(event):
+        dims = event["args"]["Input Dims"]
+        types = event["args"]["Input type"]
+        op_shape = tuple(dims[2])
+        dtype_in = types[2]
+        return {
+            "op_shape": op_shape,
+            "dtype_in_out": (dtype_in, dtype_in),
+            "stride_input": None,
+            "stride_output": None,
+        }
+
+
+class aiter_dynamic_per_group_scaled_quant_fp4(fused_flatten_mxfp4_quant):
+    """
+    Performance model for aiter::dynamic_per_group_scaled_quant_fp4.
+
+    Reference implementation:
+        aiter/aiter/ops/quant.py:744 (dynamic_per_group_scaled_quant_fp4 ->
+        dynamic_per_group_scaled_quant; HIP kernel
+        dynamic_per_group_scaled_quant_kernel<bf16, fp4_t, 32>).
+
+    Dynamic per-group (group_size=32) FP4 quant of a BF16 activation. The OUTPUT
+    tensor is Input Dims[0] and the BF16 input is Input Dims[1]
+
+    Expected Input Dims from trace:
+        [0] out    = (M, N // 2)   packed FP4
+        [1] input  = (M, N)        BF16   <- modeled input
+        [2] scales = (M, N // 32)  E8M0
+    """
+
+    @staticmethod
+    def get_param_details(event):
+        dims = event["args"]["Input Dims"]
+        types = event["args"]["Input type"]
+        op_shape = tuple(dims[1])
+        dtype_in = types[1]
+        return {
+            "op_shape": op_shape,
+            "dtype_in_out": (dtype_in, dtype_in),
+            "stride_input": None,
+            "stride_output": None,
+        }

--- a/TraceLens/PerfModel/extensions/pseudo_ops_perf_utils.py
+++ b/TraceLens/PerfModel/extensions/pseudo_ops_perf_utils.py
@@ -116,6 +116,11 @@ def get_pseudo_op_mappings():
         "aiter::linear_attention_with_output_base": attention_perf_model_extensions.gdn_attention_core,
         ## KV cache ops
         "sglang::store_cache": perf_model_extensions.sglang_store_cache,
+        "aiter::fused_qk_rope_cat_and_cache_mla": perf_model_extensions.aiter_fused_qk_rope_cat_and_cache_mla,
+        "sglang_profiler::fused_moe_triton_kernels_fused_append_shared_experts": moe_perf_model_extensions.sglang_fused_append_shared_experts,
+        "sglang_profiler::quant_dynamic_mxfp4_quant": perf_model_extensions.sglang_quant_dynamic_mxfp4_quant,
+        "aiter::fused_dynamic_mxfp4_quant_moe_sort_hip": perf_model_extensions.aiter_fused_dynamic_mxfp4_quant_moe_sort_hip,
+        "aiter::dynamic_per_group_scaled_quant_fp4": perf_model_extensions.aiter_dynamic_per_group_scaled_quant_fp4,
     }
 
     return pseudo_op_mappings
@@ -133,10 +138,7 @@ def get_pseudo_op_category_only_mappings():
     """
 
     return {
-        # MoE sorting / permutation auxiliary kernels.
-        # Reference: aiter/aiter/ops/triton/moe_op_mxfp4.py (mxfp4_moe_sort_hip,
-        # fused_dynamic_mxfp4_quant_moe_sort_hip). Memory-bound shuffle/sort ops
-        # with negligible FLOPs; we only classify them.
+        # MoE sorting / permutation auxiliary kernel.
+        # Reference: aiter/aiter/ops/triton/moe_op_mxfp4.py (mxfp4_moe_sort_hip).
         "aiter::mxfp4_moe_sort_hip": "MoE_aux",
-        "aiter::fused_dynamic_mxfp4_quant_moe_sort_hip": "MoE_aux",
     }


### PR DESCRIPTION
This pull request adds several new performance model extension classes to support additional pseudo-ops in the TraceLens performance modeling system, particularly for MoE (Mixture of Experts), quantization, and fused attention/embedding operations. It also updates the registration and export logic to integrate these new models, and makes minor improvements to the pseudo-op category mapping.

**New performance model extensions:**

*MoE and routing ops:*
- Added `sglang_fused_append_shared_experts` class to model the performance of shared-expert routing tensor appends in MoE, including custom FLOP and byte movement calculations.

*Quantization ops:*
- Added `sglang_quant_dynamic_mxfp4_quant` for dynamic MXFP4 quantization, `aiter_fused_dynamic_mxfp4_quant_moe_sort_hip` for fused quantization and MoE token sorting, and `aiter_dynamic_per_group_scaled_quant_fp4` for per-group scaled FP4 quantization.

*Fused attention/embedding ops:*
- Added `aiter_fused_qk_rope_cat_and_cache_mla` to model fused rotary position embedding and KV-cache writing.

**Integration and registration:**

- Registered all new classes in the `__init__.py` export list and import statements for `TraceLens/PerfModel/extensions`, making them available for use. [[1]](diffhunk://#diff-e03d1c0a173269db65bf1bfc351afb58495b3f719c6eac8d35a0664ac43d7e9eR22) [[2]](diffhunk://#diff-e03d1c0a173269db65bf1bfc351afb58495b3f719c6eac8d35a0664ac43d7e9eR36-R39) [[3]](diffhunk://#diff-e03d1c0a173269db65bf1bfc351afb58495b3f719c6eac8d35a0664ac43d7e9eR83-R87)
- Updated `get_pseudo_op_mappings` in `pseudo_ops_perf_utils.py` to map new pseudo-op names to their corresponding model classes.
- Cleaned up the category-only mapping for MoE auxiliary kernels, removing a mapping now handled by a full model.
<!--
Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.

See LICENSE for license information.
-->

