### PR TITLE
fix: add fallback for FP8 dtype-to-bytes mapping in JAX TreePerf

### DIFF
--- a/TraceLens/TreePerf/tree_perf.py
+++ b/TraceLens/TreePerf/tree_perf.py
@@ -3247,9 +3247,15 @@ class JaxTreePerfAnalyzer(TreePerfAnalyzer):
             for operand in operands:
                 dtype, shape, layout = parse_dtype_shape_layout(operand)
                 if shape and dtype:
-                    total_input_bytes = (
-                        total_input_bytes + np.prod(shape) * dtype_to_bytes[dtype]
+                    nbytes = dtype_to_bytes.get(dtype) or (
+                        1 if dtype.startswith(("f8", "s8")) else None
                     )
+                    if nbytes is None:
+                        logger.warning(
+                            "Unknown dtype '%s' in operand, skipping byte count", dtype
+                        )
+                        continue
+                    total_input_bytes = total_input_bytes + np.prod(shape) * nbytes
 
             total_input_bytes_list.append(total_input_bytes)
 

--- a/TraceLens/TreePerf/tree_perf.py
+++ b/TraceLens/TreePerf/tree_perf.py
@@ -3247,8 +3247,7 @@ class JaxTreePerfAnalyzer(TreePerfAnalyzer):
             for operand in operands:
                 dtype, shape, layout = parse_dtype_shape_layout(operand)
                 if shape and dtype:
-                    nbytes = dtype_to_bytes.get(dtype) or (
-                        1 if dtype.startswith(("f8", "s8")) else None
+                    nbytes = dtype_to_bytes.get(dtype, 1 if dtype.startswith(("f8", "s8")) else None
                     )
                     if nbytes is None:
                         logger.warning(


### PR DESCRIPTION
# PR: Add fallback for FP8/S8 dtypes in `dtype_to_bytes` lookup

## Summary

Replace the direct `dtype_to_bytes[dtype]` lookup with `dtype_to_bytes.get(dtype)` and an inline fallback. Dtypes starting with `f8` or `s8` map to 1 byte. Truly unknown dtypes log a warning and the operand is skipped.

**File:** `TraceLens/TreePerf/tree_perf.py`, around line 3249

Before:
```python
if shape and dtype:
    total_input_bytes = (
        total_input_bytes + np.prod(shape) * dtype_to_bytes[dtype]
    )
```

After:
```python
if shape and dtype:
    nbytes = dtype_to_bytes.get(dtype) or (
        1 if dtype.startswith(("f8", "s8")) else None
    )
    if nbytes is None:
        logger.warning(
            "Unknown dtype '%s' in operand, skipping byte count", dtype
        )
        continue
    total_input_bytes = total_input_bytes + np.prod(shape) * nbytes
```

## Testing

- Ran report generation against an FP8 Mixtral trace that was previously crashing with a `KeyError`. Report generated successfully with correct byte counts.
- All 13 regression tests in the suite passed.

<!--
Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.

See LICENSE for license information.
-->

# Pull Request Template

> **Note to AMDers:**  
> This is a public repository. Please do **not** upload any confidential or customer data. Make sure all such data has been anonymized or removed before making this PR. If you need to attach any private files or links, please insert a Internal OneDrive Link or a Jira Ticket Link instead.
