### PR TITLE
fix: resolve relative path in JAX protobuf file processing

### DIFF
--- a/TraceLens/util.py
+++ b/TraceLens/util.py
@@ -105,7 +105,7 @@ class JaxProfileProcessor:
                 raw_to_tool_data as convert,
             )
 
-        dir_name = os.path.dirname(protobuf_file_name) + "/"
+        dir_name = os.path.dirname(os.path.abspath(protobuf_file_name)) + "/"
         hlo_filename = glob.glob(dir_name + os.path.sep + module_name + "*hlo_proto.pb")
         if len(hlo_filename) != 1:
             convert.xspace_to_tool_names([protobuf_file_name])


### PR DESCRIPTION
# PR: Fix relative path resolution for protobuf sidecar file lookup

## Summary

Wrap `protobuf_file_name` with `os.path.abspath` before calling `os.path.dirname` in `JaxProfileProcessor.process_protobuf_file`.

**File:** `TraceLens/util.py`, line 108

Before:
```python
dir_name = os.path.dirname(protobuf_file_name) + "/"
```

After:
```python
dir_name = os.path.dirname(os.path.abspath(protobuf_file_name)) + "/"
```

`os.path.abspath` normalizes a bare filename to an absolute path, so `os.path.dirname` returns the correct directory. This ensures `glob.glob` searches the right location for HLO `.pb` sidecar files.

## Testing

- Ran the fix against an FP8 Mixtral trace that was previously failing when invoked with a relative path. Report generated successfully.
- All 13 regression tests in the suite passed.

<!--
Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.

See LICENSE for license information.
-->

# Pull Request Template

> **Note to AMDers:**  
> This is a public repository. Please do **not** upload any confidential or customer data. Make sure all such data has been anonymized or removed before making this PR. If you need to attach any private files or links, please insert a Internal OneDrive Link or a Jira Ticket Link instead.
