### PR TITLE
Allow csvs and excel to written in one command

### DIFF
--- a/TraceLens/Reporting/generate_perf_report_pytorch_inference.py
+++ b/TraceLens/Reporting/generate_perf_report_pytorch_inference.py
@@ -1157,15 +1157,14 @@ def generate_perf_report_pytorch(
 
     # Write CSVs and/or Excel (independent options)
     if output_csvs_dir:
-        # Ensure the output directory exists
         os.makedirs(output_csvs_dir, exist_ok=True)
         for sheet_name, df in dict_name2df.items():
             csv_path = os.path.join(output_csvs_dir, f"{sheet_name}.csv")
             df.to_csv(csv_path, index=False)
             print(f"DataFrame '{sheet_name}' written to {csv_path}")
-    else:
+
+    if output_xlsx_path is not None or output_csvs_dir is None:
         if output_xlsx_path is None:
-            # split input path at 'json' and take the first part and append '.xlsx'
             base_path = profile_json_path.rsplit(".json", 1)[0]
             output_xlsx_path = base_path + "_perf_report.xlsx"
         try:


### PR DESCRIPTION
Allows csvs and excel reports to be written in one command (as opposed to only one vs the other). Replicates existing logic in generate_perf_report_pytorch.py