### PR TITLE
Added perf model for sliding window decode

### DIFF
--- a/TraceLens/PerfModel/extensions/__init__.py
+++ b/TraceLens/PerfModel/extensions/__init__.py
@@ -45,6 +45,7 @@ from .rmsnorm_perf_model_extensions import (
 )
 from .custom_collectives_perf_model_extensions import (
     aiter_fused_allreduce_rmsnorm,
+    aiter_fused_allreduce_rmsnorm_,
     custom_ar_all_reduce,
     aiter_reduce_scatter,
     aiter_all_gather_reg,
@@ -86,6 +87,7 @@ __all__ = [
     "vllm_rocm_aiter_triton_add_rmsnorm_pad",
     # Collective classes
     "aiter_fused_allreduce_rmsnorm",
+    "aiter_fused_allreduce_rmsnorm_",
     "custom_ar_all_reduce",
     "aiter_reduce_scatter",
     "aiter_all_gather_reg",

--- a/TraceLens/PerfModel/extensions/attention_perf_model_extensions.py
+++ b/TraceLens/PerfModel/extensions/attention_perf_model_extensions.py
@@ -283,6 +283,22 @@ class InferenceAttention:
     # Instance methods – work for any subclass with valid param_details
     # ------------------------------------------------------------------
 
+    def _cap_gen_kv(self, value):
+        """Cap a generation KV aggregate to the sliding window.
+
+        Opt-in via ``param_details["sliding_window"]`` (W). Generation (decode)
+        tokens have ``sq = 1``, so each attends to ``min(ctx_i, W)`` KV tokens.
+        With only aggregates available (``g_sk = Σ ctx``, ``g_sq = #requests``),
+        ``Σ min(ctx_i, W)`` is approximated by ``min(value, g_sq * W)`` -- exact
+        when all contexts are on one side of W (typical in steady-state decode),
+        an upper bound otherwise. No-op when ``sliding_window`` is unset or <= 0,
+        so non-windowed attention models are unaffected.
+        """
+        w = self.param_details.get("sliding_window")
+        if w and w > 0 and self.param_details.get("g_sq"):
+            return min(value, self.param_details["g_sq"] * w)
+        return value
+
     def flops(self):
         if self.param_details.get("_no_perf"):
             return None
@@ -296,7 +312,7 @@ class InferenceAttention:
             self.d_h_v,
             self.param_details["c_sqsk"],
             self.param_details["c_sqsq"],
-            self.param_details["g_sqsk"],
+            self._cap_gen_kv(self.param_details["g_sqsk"]),
         )
 
     def bytes(self, bytes_per_element=None):
@@ -316,7 +332,7 @@ class InferenceAttention:
             self.param_details["c_sq"],
             self.param_details["c_sk"],
             self.param_details["g_sq"],
-            self.param_details["g_sk"],
+            self._cap_gen_kv(self.param_details["g_sk"]),
             bpe,
             bpe_kv,
         )
@@ -494,6 +510,71 @@ class mla_tilelang_sparse_fwd(InferenceAttention):
 class vllm_unified_mla_attention_with_output(InferenceAttention):
     pass
 
+class pa_decode_gluon(InferenceAttention):
+    """
+    Performance model for ``aiter::pa_decode_gluon`` (gluon Triton kernel
+    ``paged_attention_decode_sliding_window``; inference: ATOM/vLLM).
+
+    Grouped-query paged decode attention over an FP8 E4M3 KV cache.
+
+    Decode-only kernel — it never processes prefill/context requests (a separate
+    extend kernel does). So ``get_param_details`` forces the context aggregates
+    (``c_*``) to 0, which collapses the inherited ``flops``/``bytes`` to the
+    generation-only roofline, and sets ``dtype_KV`` from the FP8 cache.
+
+    Sliding window: the ``sliding_window`` arg (``Concrete Inputs[19]``) caps the
+    KV each query attends to at ``min(ctx_i, W)``. It is surfaced as
+    ``param_details["sliding_window"]`` and the base roofline applies the cap
+    (aggregate approximation ``min(g_sk, g_sq*W)``). ``-1`` layers (full
+    attention) are unaffected.
+    """
+
+    @staticmethod
+    def get_param_details(event):
+        try:
+            annotation = str(event.get("annotation"))
+            stats = InferenceAttention._parse_chunk_stats(annotation)
+
+            dims = event["args"]["Input Dims"]
+            types = event["args"]["Input type"]
+            q_shape = dims[0]
+            N_Q, H_Q, d_h_qk = q_shape[0], q_shape[1], q_shape[2]
+            # k_cache: [num_blocks, H_KV, ...] -> H_KV at index 1
+            H_KV = dims[2][1]
+            d_h_v = d_h_qk  # logical V head dim matches Q for this kernel
+            # Decode-only kernel: it never processes prefill/context requests
+            stats["c_sq"] = stats["c_sk"] = stats["c_sqsq"] = stats["c_sqsk"] = 0
+            N_KV = stats["g_sk"]
+            dtype_Q = types[0]
+            dtype_KV = types[2] if len(types) > 2 else types[0]
+            # sliding_window is the positional `sliding_window` arg; <= 0 (e.g.
+            # -1) means full attention. Capping is applied by the base roofline.
+            conc = event["args"].get("Concrete Inputs") or []
+            try:
+                sliding_window = int(conc[19])
+            except (IndexError, ValueError, TypeError):
+                sliding_window = 0
+
+            return {
+                "B": 1,
+                "N_Q": N_Q,
+                "H_Q": H_Q,
+                "H_V": H_KV,
+                "H_K": H_KV,
+                "N_KV": N_KV,
+                "H_KV": H_KV,
+                "d_h_qk": d_h_qk,
+                "d_h_v": d_h_v,
+                "dropout": 0.0,
+                "causal": False,
+                "flash_impl": True,
+                **stats,
+                "dtype_Q": dtype_Q,
+                "dtype_KV": dtype_KV,
+                "sliding_window": sliding_window,
+            }
+        except (NotImplementedError, ValueError, IndexError, KeyError, TypeError):
+            return InferenceAttention.no_perf_param_details()
 
 class gdn_attention_core(InferenceAttention):
     """

--- a/TraceLens/PerfModel/extensions/custom_collectives_perf_model_extensions.py
+++ b/TraceLens/PerfModel/extensions/custom_collectives_perf_model_extensions.py
@@ -80,6 +80,37 @@ class aiter_fused_allreduce_rmsnorm(CustomCollective):
         return bytes_read + bytes_write
 
 
+class aiter_fused_allreduce_rmsnorm_(aiter_fused_allreduce_rmsnorm):
+    """
+    Performance model for the high-level Python op aiter::fused_allreduce_rmsnorm_.
+
+    Same fused AllReduce + residual-add + RMSNorm math as the base class, but the
+    recorded argument layout follows the Python wrapper's signature
+    (inp, res_inp, w, eps, group_name, prefill_support, x_pad_to_multiple, gemma_norm)
+    rather than the low-level C++ op's (ptr, reg, inp, res_inp, res_out, out, w, eps, ...).
+
+    Expected Input Dims from trace:
+        [inp_shape, res_inp_shape, w_shape, eps, group_name, prefill_support, x_pad_to_multiple]
+        e.g. ((64, 7168), (64, 7168), (7168,), (), (), (), ())
+
+    So inp is at index 0 and weight at index 2 (vs [2] / [6] in the base class).
+    __init__, flops(), and bytes() are inherited unchanged.
+    """
+
+    @staticmethod
+    def get_param_details(event):
+        op_shape = tuple(event["args"]["Input Dims"][0])  # inp: [M, N]
+        dtype_in = event["args"]["Input type"][0]  # BFloat16
+        stride_input = tuple(event["args"]["Input Strides"][0])
+        num_channels = event["args"]["Input Dims"][2][0]  # weight.shape[0] = N
+        return {
+            "op_shape": op_shape,
+            "dtype_in": dtype_in,
+            "stride_input": stride_input,
+            "num_channels": num_channels,
+        }
+
+
 class custom_ar_all_reduce(CustomCollective):
     """
     Performance model for _C_custom_ar::all_reduce.

--- a/TraceLens/PerfModel/extensions/perf_model_extensions.py
+++ b/TraceLens/PerfModel/extensions/perf_model_extensions.py
@@ -454,8 +454,8 @@ class per_group_quant(GroupQuant):
 
     def get_compute_precision(self):
         """Return the compute precision for this operation."""
-        # Use first input dtype as the compute precision
-        dtype = self.dtype_in1_in2_out[1] if self.dtype_in1_in2_out else None
+        # Use the input activation dtype (index 0) as the compute precision;
+        dtype = self.dtype_in1_in2_out[0] if self.dtype_in1_in2_out else None
         return torch_dtype_map(dtype) if dtype else None
 
 
@@ -956,3 +956,62 @@ class sglang_store_cache:
     def get_compute_precision(self):
         dtype = self.param_details.get("dtype")
         return torch_dtype_map(dtype) if dtype else None
+
+class mixed_sample_outer_exponential:
+    """
+    Performance model for ``aiter::mixed_sample_outer_exponential`` (ATOM
+    ``model_ops/sampler.py``, ``mix_sample_outer_exponential_kernel``).
+
+    Exponential-noise sampling: ``token_id[t] = argmax_v(logits[t,v] /
+    exp_noise[t,v])`` over the vocab dim. Memory-bound elementwise reduction.
+    Reads logits ``Input Dims[1]`` [T, V] and exp_noise ``Input Dims[2]``;
+    FLOPs = 2*T*V, bytes = read logits + read exp_noise + write T int32 ids.
+    """
+
+    category = "elementwise"
+    bwd_category = None
+
+    def __init__(self, event, arch=None, python_path=None):
+        self.event = event
+        self.arch = arch
+        self.python_path = python_path
+        self.param_details = self.get_param_details(event)
+        self.T = self.param_details["T"]
+        self.V = self.param_details["V"]
+        self.dtype_logits = self.param_details["dtype_logits"]
+        self.dtype_noise = self.param_details["dtype_noise"]
+
+    @staticmethod
+    def get_param_details(event):
+        dims = event["args"]["Input Dims"]
+        types = event["args"]["Input type"]
+        logits_shape = tuple(dims[1])
+        T = logits_shape[0] if len(logits_shape) >= 1 else 1
+        V = logits_shape[1] if len(logits_shape) >= 2 else 1
+        dtype_logits = types[1] if len(types) > 1 else "c10::bfloat16"
+        dtype_noise = types[2] if len(types) > 2 else "float"
+        return {
+            "T": T,
+            "V": V,
+            "dtype_logits": dtype_logits,
+            "dtype_noise": dtype_noise,
+        }
+
+    def flops(self):
+        return 2 * self.T * self.V
+
+    def bytes(self):
+        bpe_logits = name2bpe(self.dtype_logits)
+        bpe_noise = name2bpe(self.dtype_noise)
+        if bpe_logits is None or bpe_noise is None:
+            return None
+        read_logits = self.T * self.V * bpe_logits
+        read_noise = self.T * self.V * bpe_noise
+        write_ids = self.T * 4  # int32 token id per row
+        return read_logits + read_noise + write_ids
+
+    def get_maf_type(self):
+        return "vector"
+
+    def get_compute_precision(self):
+        return torch_dtype_map(self.dtype_logits) if self.dtype_logits else None

--- a/TraceLens/PerfModel/extensions/perf_model_extensions.py
+++ b/TraceLens/PerfModel/extensions/perf_model_extensions.py
@@ -827,6 +827,34 @@ class fused_flatten_mxfp4_quant(UnaryElementwise):
         return bytes_read + bytes_write_fp4 + bytes_write_scales
 
 
+class fused_dynamic_mx_quant_moe_sort_hip(fused_flatten_mxfp4_quant):
+    """
+    Performance model for aiter::fused_dynamic_mx_quant_moe_sort_hip
+    (kernel aiter::fused_mx_quant_moe_sort_kernel<bf16, fp4, ...>).
+
+    Fuses dynamic MXFP4 quantization of the BF16 activation with MoE token sort.
+    Trace arg layout differs from fused_flatten_mxfp4_quant only in input
+    position: [0] is the packed FP4 output (M, N/2), [1] the E8M0 block scales,
+    [2] the BF16 activation input (M, N), and [3]/[4] the int sort arrays.
+
+    Approximation: models the quant traffic over the activation input. The MoE
+    sort index permutation (small int arrays) and the padded sorted-layout rows
+    are runtime-dependent and excluded.
+    """
+
+    @staticmethod
+    def get_param_details(event):
+        op_shape = tuple(event["args"]["Input Dims"][2])
+        dtype_in = event["args"]["Input type"][2]
+        stride_input = tuple(event["args"]["Input Strides"][2])
+        return {
+            "op_shape": op_shape,
+            "dtype_in_out": (dtype_in, dtype_in),
+            "stride_input": stride_input,
+            "stride_output": None,
+        }
+
+
 class aiter_rope_cached_positions_2c_fwd_impl(FusedRoPE):
     """
     Performance model for aiter::rope_cached_positions_2c_fwd_impl.
@@ -1130,6 +1158,60 @@ class aiter_fused_qk_rope_cat_and_cache_mla(FusedRoPE):
 
     def get_compute_precision(self):
         return torch_dtype_map(self.param_details["dtype_in"])
+
+
+class fused_qk_rope_concat_and_cache_mla(aiter_fused_qk_rope_cat_and_cache_mla):
+    """
+    Performance model for aiter::fused_qk_rope_concat_and_cache_mla
+    (kernel fuse_qk_rope_concat_and_cache_mla_per_head_kernel; DeepSeek-V3.1 MLA).
+
+    RoPE on the pe slices of Q/K + static FP8 quant + paged KV-cache write.
+    Trace arg layout: [0] q_nope (T, QH, D_lora), [1] q_pe (T, QH, D_pe),
+    [2] kv_c (T, D_lora), [3] k_pe (T, D_pe), [4] kv_cache (FP8 paged),
+    [5] q_out (T, QH, D_lora + D_pe), FP8.
+
+    the KV is the single MLA latent (kv_c / k_pe are 2D, so KH = 1),
+    and both q_out and the KV cache are FP8
+    (the base assumes q_out keeps the BF16 input dtype).
+
+    Approximation: only the T written KV slots are counted, not the full paged
+    cache tensor at Input Dims[4]; cos/sin/positions are small / cache-resident;
+    the per-tensor FP8 quant flops are omitted.
+    """
+
+    @staticmethod
+    def get_param_details(event):
+        dims = event["args"]["Input Dims"]
+        types = event["args"]["Input type"]
+        T, QH, D_lora = tuple(dims[0])
+        D_pe = dims[1][2]
+        KH = 1  # MLA single latent KV head (kv_c / k_pe are 2D [T, D])
+        dtype_in = types[0]
+        dtype_kv = types[4] if len(types) > 4 and types[4] else dtype_in
+        dtype_out = types[5] if len(types) > 5 and types[5] else dtype_in
+        return {
+            "T": T,
+            "QH": QH,
+            "KH": KH,
+            "D_lora": D_lora,
+            "D_pe": D_pe,
+            "dtype_in": dtype_in,
+            "dtype_kv": dtype_kv,
+            "dtype_out": dtype_out,
+        }
+
+    def bytes(self):
+        p = self.param_details
+        if self.bpe_in is None:
+            return None
+        bpe_out = name2bpe(p["dtype_out"]) or self.bpe_in
+        bpe_kv = self.bpe_kv if self.bpe_kv is not None else self.bpe_in
+        T, QH, KH, D_lora, D_pe = (p["T"], p["QH"], p["KH"], p["D_lora"], p["D_pe"])
+        read_q = (T * QH * D_lora + T * QH * D_pe) * self.bpe_in
+        read_k = (T * KH * D_lora + T * KH * D_pe) * self.bpe_in
+        write_q = T * QH * (D_lora + D_pe) * bpe_out
+        write_kv = T * KH * (D_lora + D_pe) * bpe_kv
+        return read_q + read_k + write_q + write_kv
 
 
 class sglang_quant_dynamic_mxfp4_quant(fused_flatten_mxfp4_quant):

--- a/TraceLens/PerfModel/extensions/perf_model_extensions.py
+++ b/TraceLens/PerfModel/extensions/perf_model_extensions.py
@@ -375,6 +375,38 @@ class gemm_a16w16_atomic_(GEMM):
         )
 
 
+class gemm_a16w16(gemm_a16w16_atomic_):
+    """
+    Performance model for AITER's gemm_a16w16 kernel.
+
+    Computes: Y[M, N] = X[M, K] @ W[N, K].T. Both X and W are BF16/FP16.
+
+    Reference implementation:
+        aiter/aiter/ops/triton/gemm/basic/gemm_a16w16.py
+
+    Identical roofline to gemm_a16w16_atomic_; only the output dtype handling
+    differs. The traced arg layout is (x, w, bias, dtype, ...), so Input type[3]
+    is the output ``dtype`` scalar (recorded as ``Scalar``) rather than a tensor.
+    The output dtype therefore follows the input (BF16, per the aiter default),
+    not Input type[3] as in the atomic_ variant (where index 3 is the output
+    tensor ``y``). flops/bytes/compute-precision are inherited.
+    """
+
+    @staticmethod
+    def get_param_details(event):
+        dims = event["args"]["Input Dims"]
+        types = event["args"]["Input type"]
+        bias = len(dims) > 2 and len(dims[2]) > 0
+        return {
+            "B": 1,
+            "M": dims[0][0],
+            "N": dims[1][0],
+            "K": dims[0][1],
+            "bias": bias,
+            "dtype_A_B": (types[0], types[1], types[0]),
+        }
+
+
 class GroupQuant(BinaryElementwise):
     """
     Performance model for group quantization.
@@ -956,6 +988,7 @@ class sglang_store_cache:
     def get_compute_precision(self):
         dtype = self.param_details.get("dtype")
         return torch_dtype_map(dtype) if dtype else None
+
 
 class mixed_sample_outer_exponential:
     """

--- a/TraceLens/PerfModel/extensions/pseudo_ops_perf_utils.py
+++ b/TraceLens/PerfModel/extensions/pseudo_ops_perf_utils.py
@@ -55,10 +55,14 @@ def get_pseudo_op_mappings():
         "sglang_profiler::attention_paged_attention_ragged": attention_perf_model_extensions.aiter_paged_attention_ragged,
         "pseudo_mla_decode_fwd": attention_perf_model_extensions.mla_decode_fwd,
         "pseudo_mla_prefill_fwd": attention_perf_model_extensions.pseudo_mla_prefill_fwd,
+        "aiter::pa_decode_gluon": attention_perf_model_extensions.pa_decode_gluon,
         "sglang_profiler::tilelang_kernel_tilelang_sparse_fwd": attention_perf_model_extensions.mla_tilelang_sparse_fwd,
         ## Misc ops
         "aiter::batched_gemm_a16wfp4_": perf_model_extensions.batched_gemm_a16wfp4,
         "aiter::dynamic_per_token_scaled_quant": perf_model_extensions.per_group_quant,
+        "aiter::dynamic_per_group_scaled_quant": perf_model_extensions.per_group_quant,
+        "aiter::fused_add_rmsnorm_pad_": rmsnorm_perf_model_extensions.vllm_rocm_aiter_triton_add_rmsnorm_pad,
+        "aiter::mixed_sample_outer_exponential": perf_model_extensions.mixed_sample_outer_exponential,
         "sglang_profiler::fp8_utils_gemm_a8w8_blockscale": perf_model_extensions.gemm_a8w8_blockscale,
         "sglang_profiler::gemm_a8w8_blockscale_gemm_a8w8_blockscale": perf_model_extensions.gemm_a8w8_blockscale,
         "vllm::rocm_aiter_triton_gemm_a8w8_blockscale": perf_model_extensions.gemm_a8w8_blockscale,
@@ -139,4 +143,6 @@ def get_pseudo_op_category_only_mappings():
         # with negligible FLOPs; we only classify them.
         "aiter::mxfp4_moe_sort_hip": "MoE_aux",
         "aiter::fused_dynamic_mxfp4_quant_moe_sort_hip": "MoE_aux",
+        "aiter::unified_attention_with_output_base->_fused_qk_rope_reshape_and_cache_kernel (Synthetic Op)": "FusedRoPE",
+        "hipModuleLaunchKernel->kv_indices_generate_kernel (Synthetic Op)": "InferenceAttention",
     }

--- a/TraceLens/PerfModel/extensions/pseudo_ops_perf_utils.py
+++ b/TraceLens/PerfModel/extensions/pseudo_ops_perf_utils.py
@@ -78,6 +78,8 @@ def get_pseudo_op_mappings():
         "vllm::_rocm_aiter_preshuffled_per_token_w8a8_gemm": perf_model_extensions.gemm_a8w8_blockscale,
         "vllm::rocm_unquantized_gemm": perf_model_extensions.vllm_rocm_unquantized_gemm,
         "aiter::gemm_a16w16": perf_model_extensions.gemm_a16w16,
+        "aiter::fused_dynamic_mx_quant_moe_sort_hip": perf_model_extensions.fused_dynamic_mx_quant_moe_sort_hip,
+        "aiter::fused_qk_rope_concat_and_cache_mla": perf_model_extensions.fused_qk_rope_concat_and_cache_mla,
         "aiter::gemm_a16w16_atomic_": perf_model_extensions.gemm_a16w16_atomic_,
         "aiter::_gemm_a16w16_asm": perf_model_extensions.gemm_a16w16_atomic_,
         "sglang_profiler::gemm_kernels_flydsl_hgemm": perf_model_extensions.gemm_a16w16_atomic_,
@@ -107,6 +109,7 @@ def get_pseudo_op_mappings():
         "vllm::rocm_aiter_rmsnorm_with_add_fp8_group_quant": rmsnorm_perf_model_extensions.vllm_rocm_aiter_rmsnorm_with_add_fp8_group_quant,
         "vllm::rocm_aiter_triton_add_rmsnorm_pad": rmsnorm_perf_model_extensions.vllm_rocm_aiter_triton_add_rmsnorm_pad,
         "sglang_profiler::fused_mxfp4_quant_fused_rms_mxfp4_quant": rmsnorm_perf_model_extensions.fused_rms_mxfp4_quant,
+        "aiter::_fuse_rmsnorm_fp4_quant": rmsnorm_perf_model_extensions.fused_rms_mxfp4_quant,
         ## Collective ops
         "aiter::fused_allreduce_rmsnorm": custom_collectives_perf_model_extensions.aiter_fused_allreduce_rmsnorm,
         "aiter::fused_allreduce_rmsnorm_": custom_collectives_perf_model_extensions.aiter_fused_allreduce_rmsnorm_,
@@ -150,4 +153,5 @@ def get_pseudo_op_category_only_mappings():
         "aiter::fused_dynamic_mxfp4_quant_moe_sort_hip": "MoE_aux",
         "aiter::unified_attention_with_output_base->_fused_qk_rope_reshape_and_cache_kernel (Synthetic Op)": "FusedRoPE",
         "hipModuleLaunchKernel->kv_indices_generate_kernel (Synthetic Op)": "InferenceAttention",
+        "aiter::get_mla_metadata_v1": "InferenceAttention",
     }

--- a/TraceLens/PerfModel/extensions/pseudo_ops_perf_utils.py
+++ b/TraceLens/PerfModel/extensions/pseudo_ops_perf_utils.py
@@ -77,6 +77,7 @@ def get_pseudo_op_mappings():
         "aiter::gemm_a8w8_bpreshuffle": perf_model_extensions.gemm_a8w8_blockscale,
         "vllm::_rocm_aiter_preshuffled_per_token_w8a8_gemm": perf_model_extensions.gemm_a8w8_blockscale,
         "vllm::rocm_unquantized_gemm": perf_model_extensions.vllm_rocm_unquantized_gemm,
+        "aiter::gemm_a16w16": perf_model_extensions.gemm_a16w16,
         "aiter::gemm_a16w16_atomic_": perf_model_extensions.gemm_a16w16_atomic_,
         "aiter::_gemm_a16w16_asm": perf_model_extensions.gemm_a16w16_atomic_,
         "sglang_profiler::gemm_kernels_flydsl_hgemm": perf_model_extensions.gemm_a16w16_atomic_,
@@ -108,6 +109,7 @@ def get_pseudo_op_mappings():
         "sglang_profiler::fused_mxfp4_quant_fused_rms_mxfp4_quant": rmsnorm_perf_model_extensions.fused_rms_mxfp4_quant,
         ## Collective ops
         "aiter::fused_allreduce_rmsnorm": custom_collectives_perf_model_extensions.aiter_fused_allreduce_rmsnorm,
+        "aiter::fused_allreduce_rmsnorm_": custom_collectives_perf_model_extensions.aiter_fused_allreduce_rmsnorm_,
         "_C_custom_ar::all_reduce": custom_collectives_perf_model_extensions.custom_ar_all_reduce,
         "aiter::reduce_scatter": custom_collectives_perf_model_extensions.aiter_reduce_scatter,
         "aiter::all_gather_reg": custom_collectives_perf_model_extensions.aiter_all_gather_reg,

--- a/TraceLens/Reporting/generate_perf_report_pytorch_inference.py
+++ b/TraceLens/Reporting/generate_perf_report_pytorch_inference.py
@@ -610,6 +610,7 @@ def generate_perf_report_pytorch(
             "sglang_profiler::tilelang_kernel_tilelang_sparse_fwd",
             "sglang_profiler::attention_paged_attention_ragged",
             "aiter::mha_batch_prefill",
+            "aiter::pa_decode_gluon",
         ]
     )
 


### PR DESCRIPTION
This pull request introduces several new performance model classes and extends support for additional ATOM/aiter/vLLM pseudo-ops in the TraceLens performance modeling codebase. The main changes include new classes for sliding-window decode attention, new collective and GEMM op models, an exponential-noise sampler model, and updates to pseudo-op mappings and category assignments.

**New and updated performance models:**

* Added `pa_decode_gluon` class for sliding-window decode attention, supporting the `aiter::pa_decode_gluon` kernel with proper handling of sliding window limits and FP8 KV cache. [[1]](diffhunk://#diff-11bbfa67e2e4b8f4659996548738b078a104b114c0644e4d3935ffd46b61a345R513-R577) [[2]](diffhunk://#diff-9b10af80cc8b96cbbddd8ac221c1f69ee7c428aef4c3b9675d4be086fc6ee2cfR58-R65) [[3]](diffhunk://#diff-65fef6c8c5821e4b6daa3b8c82338b8e7585fd7b1f77695330694539a0d9325eR613)
* Added `aiter_fused_allreduce_rmsnorm_` class to model the high-level Python op `aiter::fused_allreduce_rmsnorm_`, with updated argument layout handling. [[1]](diffhunk://#diff-bec4fe3fd36d6029cc9269812e58de6601dfe32785b31eb676e677acf83398c9R83-R113) [[2]](diffhunk://#diff-e03d1c0a173269db65bf1bfc351afb58495b3f719c6eac8d35a0664ac43d7e9eR53) [[3]](diffhunk://#diff-e03d1c0a173269db65bf1bfc351afb58495b3f719c6eac8d35a0664ac43d7e9eR100) [[4]](diffhunk://#diff-9b10af80cc8b96cbbddd8ac221c1f69ee7c428aef4c3b9675d4be086fc6ee2cfR112)
* Added `gemm_a16w16` class for the `aiter::gemm_a16w16` kernel, distinguishing it from the atomic variant by output dtype handling. [[1]](diffhunk://#diff-72be722051ad4c0218d52e1b465917a833aae6d12690879134155cddb58ab6f0R378-R409) [[2]](diffhunk://#diff-9b10af80cc8b96cbbddd8ac221c1f69ee7c428aef4c3b9675d4be086fc6ee2cfR80)
* Added `mixed_sample_outer_exponential` class for the `aiter::mixed_sample_outer_exponential` exponential-noise sampling kernel. [[1]](diffhunk://#diff-72be722051ad4c0218d52e1b465917a833aae6d12690879134155cddb58ab6f0R993-R1042) [[2]](diffhunk://#diff-9b10af80cc8b96cbbddd8ac221c1f69ee7c428aef4c3b9675d4be086fc6ee2cfR58-R65)

**Enhancements to attention performance modeling:**

* Introduced `_cap_gen_kv` helper to cap generation KV aggregates for sliding window attention, improving accuracy for models with limited attention windows. This is now used in both `flops` and `bytes` calculations. [[1]](diffhunk://#diff-11bbfa67e2e4b8f4659996548738b078a104b114c0644e4d3935ffd46b61a345R286-R301) [[2]](diffhunk://#diff-11bbfa67e2e4b8f4659996548738b078a104b114c0644e4d3935ffd46b61a345L299-R315) [[3]](diffhunk://#diff-11bbfa67e2e4b8f4659996548738b078a104b114c0644e4d3935ffd46b61a345L319-R335)

**Improvements to pseudo-op mapping and categorization:**

* Updated pseudo-op mappings to include new ops (`aiter::dynamic_per_group_scaled_quant`, `aiter::fused_add_rmsnorm_pad_`, `aiter::fused_allreduce_rmsnorm_`, etc.), and added new category assignments for synthetic and MoE auxiliary ops. [[1]](diffhunk://#diff-9b10af80cc8b96cbbddd8ac221c1f69ee7c428aef4c3b9675d4be086fc6ee2cfR58-R65) [[2]](diffhunk://#diff-9b10af80cc8b96cbbddd8ac221c1f69ee7c428aef4c3b9675d4be086fc6ee2cfR80) [[3]](diffhunk://#diff-9b10af80cc8b96cbbddd8ac221c1f69ee7c428aef4c3b9675d4be086fc6ee2cfR112) [[4]](diffhunk://#diff-9b10af80cc8b96cbbddd8ac221c1f69ee7c428aef4c3b9675d4be086fc6ee2cfR150-R152)

**Other fixes:**

* Corrected compute precision selection for elementwise ops to use the input activation dtype (index 0) instead of index 1.

These changes significantly improve the coverage and accuracy of performance modeling for new and existing ATOM/aiter/vLLM kernels.
<!--
Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.

See LICENSE for license information.
-->
