### PR TITLE
Experimental multi stream support for graph capture and graph replay trace merge merge

### DIFF
--- a/TraceLens/Reporting/generate_perf_report_pytorch_inference_multistream.py
+++ b/TraceLens/Reporting/generate_perf_report_pytorch_inference_multistream.py
@@ -1,0 +1,1390 @@
+###############################################################################
+# Copyright (c) 2025 - 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+import argparse
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import warnings
+from typing import Dict, Optional, Tuple
+
+from tqdm import tqdm
+
+import numpy as np
+import pandas as pd
+import collections
+import gzip
+import re
+import zipfile
+
+from TraceLens import NcclAnalyser, TraceToTree, TraceDiff, TreePerfAnalyzer
+from TraceLens.PerfModel.torch_op_mapping import build_sheet_category_to_op_names
+from TraceLens.Reporting.generate_perf_report_pytorch import _find_entry_point
+from TraceLens.Reporting.reporting_utils import (
+    add_gpu_arch_cli_args,
+    request_install,
+    resolve_gpu_arch,
+)
+from TraceLens.util import TraceEventUtils
+from TraceLens.Trace2Tree.trace_capture_merge_experimental_multistram import (
+    merge_capture_trace_into_graph,
+)
+
+import TraceLens
+
+
+def perf_report_sanity_check(
+    events,
+    df_gpu_timeline,
+    df_kernel_launchers,
+    df_unified_perf,
+    include_nccl=False,
+):
+    """
+    Sanity checks on the performance report DataFrames.
+
+    1) Total kernel time accounted by df_kernel_launchers and df_unified_perf
+       should each be >= the computation_time reported in df_gpu_timeline.
+    2) Total GPU events in tree events should equal the number of kernels
+       accounted by df_kernel_launchers and df_unified_perf.
+    """
+    use_time = "busy_time" if include_nccl else "computation_time"
+
+    computation_time_us = (
+        df_gpu_timeline.loc[df_gpu_timeline["type"] == use_time, "time ms"].values[0]
+        * 1e3
+    )
+
+    # --- Check 1: kernel time coverage ---
+    kl_time_col = (
+        "total_direct_kernel_time_sum"
+        if "total_direct_kernel_time_sum" in df_kernel_launchers.columns
+        else "total_direct_kernel_time"
+    )
+    up_time_col = (
+        "Kernel Time (µs)_sum"
+        if "Kernel Time (µs)_sum" in df_unified_perf.columns
+        else "Kernel Time (µs)"
+    )
+
+    kl_total_us = df_kernel_launchers[kl_time_col].sum()
+    up_total_us = df_unified_perf[up_time_col].sum()
+
+    print(f"\n{'='*60}")
+    print("Perf Report Sanity Check")
+    print(f"{'='*60}")
+    print(f"  {use_time} (gpu_timeline):     {computation_time_us:.2f} µs")
+    print(f"  Kernel time (kernel_launchers):       {kl_total_us:.2f} µs")
+    print(f"  Kernel time (unified_perf):           {up_total_us:.2f} µs")
+
+    kl_pass = kl_total_us >= computation_time_us
+    up_pass = up_total_us >= computation_time_us
+    print(f"  kernel_launchers >= computation_time: {'PASS' if kl_pass else 'FAIL'}")
+    print(f"  unified_perf     >= computation_time: {'PASS' if up_pass else 'FAIL'}")
+
+    # --- Check 2: per-kernel-name count verification ---
+    # Build {kernel_name: count} from tree events (ground truth)
+    tree_kernel_counts = dict(
+        collections.Counter(
+            e["name"]
+            for e in events
+            if e.get("cat") in {"kernel", "gpu_memcpy", "gpu_memset"}
+            and (
+                not TraceEventUtils.is_communication_string(e.get("name", ""))
+                or include_nccl
+            )
+        )
+    )
+
+    def _extract_kernel_counts(df, label):
+        """Extract {kernel_name: count} from a DataFrame's kernel_details column."""
+        if "kernel_details_summary" in df.columns:
+            col = "kernel_details_summary"
+        elif "kernel_details" in df.columns:
+            col = "kernel_details"
+        else:
+            print(f"  WARNING: no kernel_details column in {label}")
+            return {}
+        counts = collections.Counter()
+        for kd in df[col]:
+            if isinstance(kd, list):
+                for d in kd:
+                    counts[d["name"]] += d.get("count", 1)
+        return dict(counts)
+
+    def _print_per_kernel_check(tree_counts, df_counts, label):
+        """Compare per-kernel counts and print mismatches."""
+        df_total = sum(df_counts.values())
+        tree_total = sum(tree_counts.values())
+        total_pass = tree_total == df_total
+        print(f"\n  --- {label} ---")
+        print(f"  Total GPU events in tree:  {tree_total}")
+        print(f"  Kernels accounted:         {df_total}")
+        print(f"  Total count match:         {'PASS' if total_pass else 'FAIL'}")
+
+        all_names = sorted(set(tree_counts) | set(df_counts))
+        mismatches = []
+        for name in all_names:
+            t = tree_counts.get(name, 0)
+            d = df_counts.get(name, 0)
+            if t != d:
+                mismatches.append((name, t, d))
+
+        if mismatches:
+            print(f"  Per-kernel mismatches ({len(mismatches)}):")
+            for name, t, d in mismatches:
+                trunc = name[:80] + "..." if len(name) > 80 else name
+                print(f"    {trunc}")
+                print(f"      tree={t}  {label}={d}  diff={t - d}")
+        else:
+            print(f"  Per-kernel detail check:   PASS (all match)")
+
+        return df_total, total_pass, mismatches
+
+    # Build {kernel_name: count} from each source
+    kl_kernel_counts = _extract_kernel_counts(df_kernel_launchers, "kernel_launchers")
+    up_kernel_counts = _extract_kernel_counts(df_unified_perf, "unified_perf")
+
+    total_gpu_events = sum(tree_kernel_counts.values())
+
+    kl_kernel_count, kl_count_pass, kl_mismatches = _print_per_kernel_check(
+        tree_kernel_counts, kl_kernel_counts, "kernel_launchers"
+    )
+    up_kernel_count, up_count_pass, up_mismatches = _print_per_kernel_check(
+        tree_kernel_counts, up_kernel_counts, "unified_perf"
+    )
+
+    print(f"{'='*60}\n")
+
+    return {
+        "computation_time_us": computation_time_us,
+        "kl_total_us": kl_total_us,
+        "up_total_us": up_total_us,
+        "kl_time_pass": kl_pass,
+        "up_time_pass": up_pass,
+        "total_gpu_events": total_gpu_events,
+        "kl_kernel_count": kl_kernel_count,
+        "up_kernel_count": up_kernel_count,
+        "kl_count_pass": kl_count_pass,
+        "up_count_pass": up_count_pass,
+        "tree_kernel_counts": dict(tree_kernel_counts),
+        "kl_kernel_counts": dict(kl_kernel_counts),
+        "up_kernel_counts": dict(up_kernel_counts),
+        "kl_mismatches": kl_mismatches,
+        "up_mismatches": up_mismatches,
+    }
+
+
+def classify_graph_capture_trace(input_folder: str):
+    """
+    Return {file, batch_size, mode} for a single graph-capture trace file.
+    Supports .json, .json.gz, and .zip (containing a .json).
+    """
+    execution_details_path = os.path.join(input_folder, "execution_details.json")
+    if os.path.isfile(execution_details_path):
+        print(
+            f"Execution details already exist at {execution_details_path}. Skipping classification."
+        )
+        return
+    ## vLLM specific dummy run pattern
+    dummy_run_pattern = re.compile(
+        r"vllm/v1/worker/gpu_model_runner\.py\(\d+\): _dummy_run"
+    )
+    ## SGLang specific dummy run pattern
+    ##dummy_run_pattern = re.compile(r"/sgl-workspace/sglang/python/sglang/srt/model_executor/cuda_graph_runner.py\(\d+\): _capture_graph")
+    annotation_pattern = re.compile(r"capture_(\d+)_(.*)")
+
+    def load_trace(path: str) -> dict:
+        if path.endswith(".zip"):
+            with zipfile.ZipFile(path, "r") as zf:
+                json_files = [f for f in zf.namelist() if f.endswith(".json")]
+                if not json_files:
+                    raise ValueError(f"No .json file found inside {path}")
+                with zf.open(json_files[0]) as f:
+                    return json.load(f)
+        if path.endswith(".json.gz"):
+            with gzip.open(path, "rt") as f:
+                return json.load(f)
+        with open(path, "r") as f:
+            return json.load(f)
+
+    def find_dummy_run_roots(events):
+        roots = [e for e in events if dummy_run_pattern.match(e.get("name", ""))]
+        roots.sort(key=lambda x: x.get("ts", 0))
+        return roots
+
+    def find_annotation_roots(events):
+        roots = [
+            e
+            for e in events
+            if e.get("cat") == "user_annotation"
+            and annotation_pattern.match(e.get("name", ""))
+        ]
+        roots.sort(key=lambda x: x.get("ts", 0))
+        return roots
+
+    def parse_annotation(name: str):
+        m = annotation_pattern.match(name)
+        if not m:
+            raise ValueError(f"Annotation name does not match expected pattern: {name}")
+        return int(m.group(1)), m.group(2)
+
+    def count_stream_begin_captures(events):
+        return sum(
+            1
+            for e in events
+            if "StreamBeginCapture" in e.get("name", "")
+            and e.get("cat") == "cuda_runtime"
+        )
+
+    def infer_batch_size_from_cpu_ops(events):
+        first_dims = []
+        for e in events:
+            if e.get("cat") != "cpu_op":
+                continue
+            input_dims = e.get("args", {}).get("Input Dims")
+            if not input_dims:
+                continue
+            for dim_list in input_dims:
+                if isinstance(dim_list, list) and dim_list:
+                    if isinstance(dim_list[0], int):
+                        first_dims.append(dim_list[0])
+        if not first_dims:
+            return None
+        return collections.Counter(first_dims).most_common(1)[0][0]
+
+    def infer_mode_from_captures(num_captures: int):
+        return "FULL" if num_captures <= 1 else "PIECEWISE"
+
+    if not os.path.isdir(input_folder):
+        print(f"Error: {input_folder} is not a directory", file=sys.stderr)
+        sys.exit(1)
+
+    trace_files = sorted(
+        os.path.join(input_folder, f)
+        for f in os.listdir(input_folder)
+        if f.endswith(".json") or f.endswith(".json.gz")
+    )
+
+    if not trace_files:
+        print(f"No files starting with 'graph_capture_rank_0' found in {input_folder}")
+        sys.exit(0)
+
+    print(f"Found {len(trace_files)} graph-capture trace file(s) in {input_folder}\n")
+
+    results = []
+    for filepath in trace_files:
+        trace_json = load_trace(filepath)
+        events = trace_json.get("traceEvents", [])
+        dummy_roots = find_dummy_run_roots(events)
+        annotation_roots = find_annotation_roots(events)
+        basename = os.path.basename(filepath)
+
+        if annotation_roots and len(annotation_roots) == len(dummy_roots):
+            batch_size, mode = parse_annotation(annotation_roots[0]["name"])
+            print(
+                f"batch_size: {batch_size}, mode: {mode} parsed from annotation, num_captures: {count_stream_begin_captures(events)}"
+            )
+            results.append({"file": basename, "batch_size": batch_size, "mode": mode})
+            continue
+
+        num_captures = count_stream_begin_captures(events)
+        mode = infer_mode_from_captures(num_captures)
+        batch_size = infer_batch_size_from_cpu_ops(events)
+        print(
+            f"batch_size: {batch_size}, mode: {mode} inferred, num_captures: {num_captures}"
+        )
+
+        results.append({"file": basename, "batch_size": batch_size, "mode": mode})
+    with open(f"{input_folder}/execution_details.json", "w") as f:
+        json.dump(results, f, indent=2)
+    print(f"\nResults written to {input_folder}/execution_details.json")
+    return
+
+
+def get_dfs_short_kernels(
+    perf_analyzer, short_kernel_threshold_us=10, histogram_bins=100, topk=None
+):
+    """
+    TODO: move this to the TreePerfAnalyzer class
+    Analyze short kernel events from the performance data and return two DataFrames:
+    a histogram of short kernel durations and a summary of top short kernels.
+
+    Args:
+        perf_analyzer (TreePerfAnalyzer): The performance analyzer object containing kernel data.
+        short_kernel_threshold_us (int, optional): Threshold in microseconds to classify a kernel as "short". Defaults to 10.
+        histogram_bins (int, optional): Number of bins for the histogram of short kernel durations. Defaults to 100.
+        topk (int, optional): Number of top short kernels to include in the summary. If None, include all. Defaults to None.
+
+    Returns:
+        tuple: A tuple containing:
+            - pd.DataFrame: Histogram of short kernel durations with columns ['bin_start', 'bin_end', 'count'].
+            - pd.DataFrame: Summary of top short kernels with detailed statistics and percentage contribution to total time.
+    """
+    df_kernels = perf_analyzer.get_df_kernels()
+    df_filtered = df_kernels[
+        df_kernels["Kernel duration (µs)"] < short_kernel_threshold_us
+    ]
+
+    # 1. get histogram of these short kernels
+    if df_filtered.empty:
+        df_hist = pd.DataFrame(columns=["bin_start", "bin_end", "count"])
+    else:
+        vals = df_filtered["Kernel duration (µs)"].values
+        counts, bin_edges = np.histogram(vals, bins=histogram_bins)
+        df_hist = pd.DataFrame(
+            {"bin_start": bin_edges[:-1], "bin_end": bin_edges[1:], "count": counts}
+        )
+
+    # 2. get df short kernels topk by total time
+    agg_dict = {
+        "Kernel duration (µs)": ["sum", "count", "mean"],
+    }
+    # For GPU-only traces, only group by Kernel name (CPU-related columns don't exist)
+    # For regular traces, group by all available columns
+    if perf_analyzer.gpu_only:
+        groupby_cols = ["Kernel name"]
+    else:
+        groupby_cols = [
+            "Parent cpu_op",
+            "Input dims",
+            "Input strides",
+            "Concrete Inputs",
+            "Kernel name",
+        ]
+
+    # If dataframe is empty, return empty dataframe
+    if df_filtered.empty:
+        df_grouped = pd.DataFrame()
+    else:
+        df_grouped = df_filtered.groupby(
+            groupby_cols,
+            sort=False,
+        ).agg(agg_dict)
+
+    # Handle empty dataframe case
+    if df_grouped.empty:
+        return df_hist, df_grouped
+
+    # Flatten multi-level column names
+    df_grouped.columns = ["_".join(col).strip() for col in df_grouped.columns]
+
+    # Rename columns for clarity
+    df_grouped.rename(
+        columns={
+            "Kernel duration (µs)_sum": "Short Kernel duration (µs) sum",
+            "Kernel duration (µs)_count": "Short Kernel count",
+            "Kernel duration (µs)_mean": "Short Kernel duration (µs) mean",
+        },
+        inplace=True,
+    )
+
+    # Add percentage contribution to total time
+    df_grouped["Short Kernel duration (µs) percent of total time"] = (
+        df_grouped["Short Kernel duration (µs) sum"]
+        / (perf_analyzer.total_time_ms * 1e3)
+        * 100
+    )
+
+    # Sort: primary by total short-kernel time (desc), then all other columns for stable order
+    _sum_col = "Short Kernel duration (µs) sum"
+    _sort_cols = [_sum_col] + [c for c in df_grouped.columns if c != _sum_col]
+    _ascending = [False] + [True] * (len(_sort_cols) - 1)
+    df_grouped.sort_values(by=_sort_cols, ascending=_ascending, inplace=True)
+    df_grouped.reset_index(inplace=True)
+    if topk is not None:
+        df_grouped = df_grouped.head(topk)
+    return df_hist, df_grouped
+
+
+def apply_extension(perf_analyzer, extension_path):
+    extension_path = os.path.abspath(extension_path)
+    extension_name = os.path.splitext(os.path.basename(extension_path))[0]
+
+    from TraceLens.PerfModel.torch_op_mapping import (
+        OP_CATEGORY_REGISTRY,
+        register_op_categories,
+        register_perf_model_categories,
+    )
+
+    spec = importlib.util.spec_from_file_location(extension_name, extension_path)
+    extension = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(extension)
+
+    if hasattr(extension, "tree_postprocess_extension"):
+        print(f"Applying tree postprocess extension from {extension_path}")
+        tree_postprocess_extension = getattr(extension, "tree_postprocess_extension")
+        tree_postprocess_extension(perf_analyzer.tree)
+        perf_analyzer.tree.label_non_gpu_paths()
+
+    if hasattr(extension, "perf_model_extension"):
+        print(f"Applying perf model extension from {extension_path}")
+        perf_model_extension = getattr(extension, "perf_model_extension")
+        if not isinstance(perf_model_extension, dict):
+            raise ValueError(
+                f"Expected perf_model_extension to be a dict, got {type(perf_model_extension)}"
+            )
+        perf_analyzer.op_to_perf_model_class_map.update(perf_model_extension)
+        register_perf_model_categories(
+            perf_model_extension,
+            OP_CATEGORY_REGISTRY,
+        )
+    if hasattr(extension, "op_category_extension"):
+        print(f"Applying op category extension from {extension_path}")
+        op_category_extension = getattr(extension, "op_category_extension")
+        if not isinstance(op_category_extension, dict):
+            raise ValueError(
+                f"Expected op_category_extension to be a dict, got {type(op_category_extension)}"
+            )
+        register_op_categories(
+            op_category_extension,
+            OP_CATEGORY_REGISTRY,
+        )
+    if hasattr(extension, "dict_cat2names_extension"):
+        warnings.warn(
+            "dict_cat2names_extension is deprecated and ignored. Use "
+            "perf_model_extension for modeled ops or op_category_extension for "
+            "category-only ops."
+        )
+
+
+def trunc_kernel_details(row, kernel_detail_col, trunc_length=64):
+    """
+    Truncates the kernel details in a row to a specified length for readability.
+    """
+    if kernel_detail_col not in row or not row[kernel_detail_col]:
+        return None  # No kernel details available
+
+    truncated_details = []
+    for detail in row[kernel_detail_col]:
+        truncated_name = (
+            detail["name"][:trunc_length] + "..."
+            if len(detail["name"]) > trunc_length
+            else detail["name"]
+        )
+        truncated_details.append(
+            {
+                "name": truncated_name,
+                "stream": detail.get("stream", None),
+                "mean_duration_us": round(detail.get("mean_duration_us", 0), 2),
+            }
+        )
+
+    return truncated_details if truncated_details else None
+
+
+def add_truncated_kernel_details(
+    df: pd.DataFrame,
+    source_col: str = "kernel_details",
+    new_col_name: str = None,
+    trunc_length: int = 64,
+) -> pd.DataFrame:
+    """
+    Applies the truncation logic to a DataFrame column and inserts the new
+    truncated column immediately after the source column for easy comparison.
+
+    Args:
+        df (pd.DataFrame): The DataFrame to process.
+        source_col (str): The name of the column containing the full kernel details.
+        new_col_name (str): The name for the new truncated column.
+        trunc_length (int): The character length to truncate kernel names to.
+
+    Returns:
+        pd.DataFrame: A new DataFrame with the added truncated column.
+    """
+    # First, ensure the source column exists. If not, do nothing.
+    if source_col not in df.columns:
+        warnings.warn(
+            f"Source column '{source_col}' not found in DataFrame. Skipping truncation.",
+            UserWarning,
+        )
+        return df
+    if new_col_name is None:
+        new_col_name = f"trunc_{source_col}"
+    # 1. Create the new column's data. It will be added to the end for now.
+    df[new_col_name] = df.apply(
+        lambda row: trunc_kernel_details(row, source_col, trunc_length=trunc_length),
+        axis=1,
+    )
+
+    # 2. Reorder the columns to place the new column next to its source.
+    cols = df.columns.tolist()
+    # Pop the new column from the end of the list
+    new_col = cols.pop(cols.index(new_col_name))
+    # Find the position of our source column and insert the new one after it
+    source_col_idx = cols.index(source_col)
+    cols.insert(source_col_idx + 1, new_col)
+
+    # Return a new DataFrame with the desired column order
+    return df[cols]
+
+
+def generate_perf_report_pytorch(
+    profile_json_path: str,
+    augmented_tree: TraceToTree = None,
+    output_xlsx_path: Optional[str] = None,
+    output_csvs_dir: Optional[str] = None,
+    # include unlinked kernels in gpu timeline
+    include_unlinked_kernels: bool = False,
+    enable_pseudo_ops: bool = False,  # pseudo-op generation
+    # threshold in microseconds for micro idle time
+    micro_idle_thresh_us: int = None,
+    # collective analysis
+    collective_analysis: bool = True,
+    # overlapping kernel details (optional extra sheets)
+    include_overlap_info: bool = False,
+    # kernel summary sheet
+    kernel_summary: bool = False,
+    # short kernel study options
+    short_kernel_study: bool = False,
+    short_kernel_threshold_us: int = 10,
+    short_kernel_histogram_bins: int = 100,
+    topk_short_kernels: Optional[int] = None,  # include all below thresh by default
+    topk_ops: Optional[int] = None,
+    topk_roofline_ops: Optional[int] = None,
+    comparison_json_path: Optional[str] = None,
+    extension_file: Optional[str] = None,
+    # for gemm simulator / Origami (Origami requires --enable_origami when arch is set)
+    python_path: Optional[str] = None,
+    gpu_arch_json_path: Optional[str] = None,
+    gpu_arch_platform: Optional[str] = None,
+    gpu_arch: Optional[dict] = None,
+    enable_origami: bool = False,
+    group_by_parent_module: bool = False,
+    group_by_num_kernels: bool = False,
+    include_call_stack: bool = False,
+) -> Dict[str, pd.DataFrame]:
+    gpu_arch_json = resolve_gpu_arch(
+        gpu_arch_json_path=gpu_arch_json_path,
+        gpu_arch_platform=gpu_arch_platform,
+        gpu_arch=gpu_arch,
+    )
+    add_python_func = (
+        True if (group_by_parent_module or include_call_stack is True) else False
+    )
+    if augmented_tree is not None:
+        perf_analyzer = TreePerfAnalyzer(
+            tree=augmented_tree,
+            arch=gpu_arch_json,
+            python_path=python_path,
+            include_unlinked_kernels=include_unlinked_kernels,
+            add_python_func=add_python_func,
+            enable_pseudo_ops=enable_pseudo_ops,
+            rebuild_tree=False,
+        )
+    else:
+        perf_analyzer = TreePerfAnalyzer.from_file(
+            profile_filepath=profile_json_path,
+            arch=gpu_arch_json,
+            python_path=python_path,
+            include_unlinked_kernels=include_unlinked_kernels,
+            add_python_func=add_python_func,
+            enable_pseudo_ops=enable_pseudo_ops,
+        )
+
+        graph_launch_events = [
+            event
+            for event in perf_analyzer.tree.events
+            if "graphlaunch" in event.get("name", "").lower()
+        ]
+        if len(graph_launch_events) > 0:
+            warnings.warn(
+                f"There are hipgraph launches (Count: {len(graph_launch_events)}) in this trace, but a graph capture folder not provided, the analysis might be limited",
+                UserWarning,
+            )
+
+    ## Apply annotation for vLLM eager and replay phase
+    perf_analyzer.tree.apply_annotation(
+        name_filters=[
+            "vllm::unified_attention_with_output",
+            "aiter::mha_varlen_fwd",
+            "pseudo_mla_decode_fwd",
+            "pseudo_mla_prefill_fwd",
+            "vllm::gdn_attention_core",
+            "aiter::fmha_v3_varlen_fwd",
+            "sglang_profiler::tilelang_kernel_tilelang_sparse_fwd",
+            "sglang_profiler::attention_paged_attention_ragged",
+            "aiter::mha_batch_prefill",
+            "aiter::pa_decode_gluon",
+        ]
+    )
+
+    if extension_file:
+        apply_extension(perf_analyzer, extension_file)
+
+    # Detect GPU-only trace early and inform user
+    if perf_analyzer.gpu_only:
+        print(
+            "Detected GPU-only trace. Skipping CPU-dependent analysis and generating only GPU timeline and kernel summary."
+        )
+    agg_metrics = ["mean", "median", "std", "min", "max"]
+
+    # Generate base DataFrames
+    df_gpu_timeline = perf_analyzer.get_df_gpu_timeline(
+        micro_idle_thresh_us=micro_idle_thresh_us
+    )
+
+    # TODO: move this to the TreePerfAnalyzer class
+    total_time_row = df_gpu_timeline[df_gpu_timeline["type"] == "total_time"]
+    total_time_ms = total_time_row["time ms"].values[0]
+    perf_analyzer.total_time_ms = total_time_ms
+
+    # Initialize empty DataFrames for GPU-only traces to avoid NameError
+    df_kernel_launchers_summary = pd.DataFrame()
+    df_kernel_launchers_summary_by_category = pd.DataFrame()
+    df_kernel_launchers_unique_args = pd.DataFrame()
+    perf_metrics_dfs = {}
+    df_hist = pd.DataFrame()
+    df_short_kernels = pd.DataFrame()
+
+    # Only process CPU-dependent analysis for non-GPU-only traces
+    if not perf_analyzer.gpu_only:
+        df_kernel_launchers = perf_analyzer.get_df_kernel_launchers(
+            include_kernel_details=True,
+            include_call_stack=group_by_parent_module,
+        )
+        df_kernel_launchers_summary = (
+            perf_analyzer.get_df_kernel_launchers_summary_module(df_kernel_launchers)
+        )
+        df_kernel_launchers_summary_by_category = (
+            perf_analyzer.get_df_kernel_launchers_summary_by_category_module(
+                df_kernel_launchers
+            )
+        )
+        df_kernel_launchers_unique_args = (
+            perf_analyzer.get_df_kernel_launchers_unique_args(
+                df_kernel_launchers,
+                agg_metrics=agg_metrics,
+                include_pct=True,
+                group_by_parent_module=group_by_parent_module,
+                group_by_num_kernels=group_by_num_kernels,
+            )
+        )
+        df_kernel_launchers_unique_args = add_truncated_kernel_details(
+            df_kernel_launchers_unique_args,
+            source_col="kernel_details_summary",
+            new_col_name="trunc_kernel_details",
+        )
+        df_kernel_launchers_unique_args_overlapping_kernels = pd.DataFrame()
+        if include_overlap_info:
+            df_kernel_launchers_unique_args_overlapping_kernels = (
+                perf_analyzer.get_df_kernel_launchers_unique_args(
+                    df_kernel_launchers,
+                    agg_metrics=agg_metrics,
+                    include_pct=True,
+                    group_by_parent_module=group_by_parent_module,
+                    group_by_num_kernels=group_by_num_kernels,
+                    include_overlapping_kernels=True,
+                )
+            )
+            df_kernel_launchers_unique_args_overlapping_kernels = (
+                add_truncated_kernel_details(
+                    df_kernel_launchers_unique_args_overlapping_kernels,
+                    source_col="kernel_details_summary",
+                    new_col_name="trunc_kernel_details",
+                )
+            )
+            df_kernel_launchers_unique_args_overlapping_kernels = (
+                add_truncated_kernel_details(
+                    df_kernel_launchers_unique_args_overlapping_kernels,
+                    source_col="overlapping_kernels_details_summary",
+                    new_col_name="trunc_overlapping_kernels_details",
+                )
+            )
+        # Dictionary to hold the op-specific DataFrames
+        perf_metrics_dfs = {}
+        sheet_category_to_op_names = build_sheet_category_to_op_names(
+            perf_analyzer.op_to_perf_model_class_map
+        )
+        for sheet_category, op_names in sheet_category_to_op_names.items():
+            # Filter events belonging to the current legacy sheet category
+            op_events = [
+                event
+                for event in perf_analyzer.tree.events
+                if event["name"] in op_names
+            ]
+            if len(op_events) == 0:
+                continue
+            # Skip categories with no events
+            if sheet_category in ["GEMM", "UnaryElementwise", "BinaryElementwise"]:
+                # For GEMM: create a single table that covers both fwd and bwd.
+                df_ops_raw = perf_analyzer.build_df_perf_metrics(
+                    op_events, bwd=False, include_kernel_details=True, include_args=True
+                )
+                df_ops = perf_analyzer.summarize_df_perf_metrics(
+                    df_ops_raw,
+                    agg_metrics,
+                    group_by_num_kernels=group_by_num_kernels,
+                )
+                df_ops = add_truncated_kernel_details(
+                    df_ops,
+                    source_col="kernel_details__summarize_kernel_stats",
+                    new_col_name="trunc_kernel_details",
+                )
+                if not df_ops.empty:
+                    perf_metrics_dfs[sheet_category] = df_ops
+                if include_overlap_info:
+                    df_ops_overlapping_kernels = (
+                        perf_analyzer.summarize_df_perf_metrics(
+                            df_ops_raw,
+                            agg_metrics,
+                            group_by_num_kernels=group_by_num_kernels,
+                            include_overlapping_kernels=True,
+                        )
+                    )
+                    df_ops_overlapping_kernels = add_truncated_kernel_details(
+                        df_ops_overlapping_kernels,
+                        source_col="kernel_details__summarize_kernel_stats",
+                        new_col_name="trunc_kernel_details",
+                    )
+                    df_ops_overlapping_kernels = add_truncated_kernel_details(
+                        df_ops_overlapping_kernels,
+                        source_col="overlapping_kernels_details__summarize_kernel_stats",
+                        new_col_name="trunc_overlapping_kernels_details",
+                    )
+                    if not df_ops_overlapping_kernels.empty:
+                        perf_metrics_dfs[f"{sheet_category}_kl_overlap"] = (
+                            df_ops_overlapping_kernels
+                        )
+            else:
+                # For FLASH_ATTN and CONV: create separate tables for forward and backward passes.
+                df_ops_fwd_raw = perf_analyzer.build_df_perf_metrics(
+                    op_events, bwd=False, include_kernel_details=True, include_args=True
+                )
+                df_ops_fwd = perf_analyzer.summarize_df_perf_metrics(
+                    df_ops_fwd_raw,
+                    agg_metrics,
+                    group_by_num_kernels=group_by_num_kernels,
+                )
+                df_ops_fwd = add_truncated_kernel_details(
+                    df_ops_fwd,
+                    source_col="kernel_details__summarize_kernel_stats",
+                    new_col_name="trunc_kernel_details",
+                )
+                # For now, flash_attention_varlen_backward and aten::convolution_backward are processed with bwd=True,
+                # so we need a workaround to extract them from the fwd df and append them to the bwd df.
+                filtered_df_bwd_ops = None
+                if not df_ops_fwd.empty:
+                    # Filter out backward operations that were incorrectly included in forward
+                    bwd_op_names = [
+                        "flash_attn::_flash_attn_varlen_backward",
+                        "aten::convolution_backward",
+                    ]
+                    filtered_df_bwd_ops = df_ops_fwd[
+                        df_ops_fwd["name"].isin(bwd_op_names)
+                    ]
+                    df_ops_fwd = df_ops_fwd[~df_ops_fwd["name"].isin(bwd_op_names)]
+                    df_ops_fwd = df_ops_fwd[
+                        df_ops_fwd["name"] != "flash_attn::_flash_attn_varlen_backward"
+                    ]
+
+                op_events = []
+                if len(op_events) > 0:
+                    df_ops_bwd_raw = perf_analyzer.build_df_perf_metrics(
+                        op_events,
+                        bwd=True,
+                        include_kernel_details=True,
+                        include_args=True,
+                    )
+                    df_ops_bwd = perf_analyzer.summarize_df_perf_metrics(
+                        df_ops_bwd_raw,
+                        agg_metrics,
+                        group_by_num_kernels=group_by_num_kernels,
+                    )
+                    df_ops_bwd = add_truncated_kernel_details(
+                        df_ops_bwd,
+                        source_col="kernel_details__summarize_kernel_stats",
+                        new_col_name="trunc_kernel_details",
+                    )
+                    if filtered_df_bwd_ops is not None:
+                        df_ops_bwd = pd.concat([df_ops_bwd, filtered_df_bwd_ops])
+                    if not df_ops_bwd.empty:
+                        perf_metrics_dfs[f"{sheet_category}_bwd"] = df_ops_bwd
+                if not df_ops_fwd.empty:
+                    perf_metrics_dfs[f"{sheet_category}_fwd"] = df_ops_fwd
+
+                if include_overlap_info:
+                    df_ops_fwd_overlapping_kernels = (
+                        perf_analyzer.summarize_df_perf_metrics(
+                            df_ops_fwd_raw,
+                            agg_metrics,
+                            group_by_num_kernels=group_by_num_kernels,
+                            include_overlapping_kernels=True,
+                        )
+                    )
+                    df_ops_fwd_overlapping_kernels = add_truncated_kernel_details(
+                        df_ops_fwd_overlapping_kernels,
+                        source_col="kernel_details__summarize_kernel_stats",
+                        new_col_name="trunc_kernel_details",
+                    )
+                    df_ops_fwd_overlapping_kernels = add_truncated_kernel_details(
+                        df_ops_fwd_overlapping_kernels,
+                        source_col="overlapping_kernels_details__summarize_kernel_stats",
+                        new_col_name="trunc_overlapping_kernels_details",
+                    )
+                    filtered_df_bwd_ops_overlapping_kernels = None
+                    if not df_ops_fwd_overlapping_kernels.empty:
+                        bwd_op_names = [
+                            "flash_attn::_flash_attn_varlen_backward",
+                            "aten::convolution_backward",
+                        ]
+                        filtered_df_bwd_ops_overlapping_kernels = (
+                            df_ops_fwd_overlapping_kernels[
+                                df_ops_fwd_overlapping_kernels["name"].isin(
+                                    bwd_op_names
+                                )
+                            ]
+                        )
+                        df_ops_fwd_overlapping_kernels = df_ops_fwd_overlapping_kernels[
+                            ~df_ops_fwd_overlapping_kernels["name"].isin(bwd_op_names)
+                        ]
+                        df_ops_fwd_overlapping_kernels = df_ops_fwd_overlapping_kernels[
+                            df_ops_fwd_overlapping_kernels["name"]
+                            != "flash_attn::_flash_attn_varlen_backward"
+                        ]
+
+                    df_ops_bwd_overlapping_kernels = pd.DataFrame()
+                    if df_ops_bwd_raw is not None:
+                        df_ops_bwd_overlapping_kernels = (
+                            perf_analyzer.summarize_df_perf_metrics(
+                                df_ops_bwd_raw,
+                                agg_metrics,
+                                group_by_num_kernels=group_by_num_kernels,
+                                include_overlapping_kernels=True,
+                            )
+                        )
+                        df_ops_bwd_overlapping_kernels = add_truncated_kernel_details(
+                            df_ops_bwd_overlapping_kernels,
+                            source_col="kernel_details__summarize_kernel_stats",
+                            new_col_name="trunc_kernel_details",
+                        )
+                        df_ops_bwd_overlapping_kernels = add_truncated_kernel_details(
+                            df_ops_bwd_overlapping_kernels,
+                            source_col="overlapping_kernels_details__summarize_kernel_stats",
+                            new_col_name="trunc_overlapping_kernels_details",
+                        )
+                        if filtered_df_bwd_ops_overlapping_kernels is not None:
+                            df_ops_bwd_overlapping_kernels = pd.concat(
+                                [
+                                    df_ops_bwd_overlapping_kernels,
+                                    filtered_df_bwd_ops_overlapping_kernels,
+                                ]
+                            )
+                    if not df_ops_bwd_overlapping_kernels.empty:
+                        perf_metrics_dfs[f"{sheet_category}_bwd_kl_overlap"] = (
+                            df_ops_bwd_overlapping_kernels
+                        )
+                    if not df_ops_fwd_overlapping_kernels.empty:
+                        perf_metrics_dfs[f"{sheet_category}_fwd_kl_overlap"] = (
+                            df_ops_fwd_overlapping_kernels
+                        )
+
+    # Short kernel study (works for both GPU-only and regular traces)
+    if short_kernel_study:
+        df_hist, df_short_kernels = get_dfs_short_kernels(
+            perf_analyzer,
+            short_kernel_threshold_us=short_kernel_threshold_us,
+            histogram_bins=short_kernel_histogram_bins,
+            topk=topk_short_kernels,
+        )
+
+    # Build dict_name2df - only include sheets that have data
+    dict_name2df = {"gpu_timeline": df_gpu_timeline}
+    df_unified_perf: pd.DataFrame = pd.DataFrame()
+
+    # Add CPU-dependent sheets only if not GPU-only
+    if not perf_analyzer.gpu_only:
+        if not df_kernel_launchers_summary_by_category.empty:
+            dict_name2df["ops_summary_by_category"] = (
+                df_kernel_launchers_summary_by_category
+            )
+        if not df_kernel_launchers_summary.empty:
+            dict_name2df["ops_summary"] = df_kernel_launchers_summary
+        if not df_kernel_launchers_unique_args.empty:
+            dict_name2df["ops_unique_args"] = df_kernel_launchers_unique_args
+        if (
+            include_overlap_info
+            and not df_kernel_launchers_unique_args_overlapping_kernels.empty
+        ):
+            dict_name2df["ops_unique_args_kl_overlap"] = (
+                df_kernel_launchers_unique_args_overlapping_kernels
+            )
+
+        # Add unified perf metrics table (ops with perf models + leaf ops with GPU kernels)
+        df_unified_perf = perf_analyzer.build_df_unified_perf_table(
+            include_nccl=collective_analysis
+        )
+
+        # Run TraceDiff when a comparison trace is provided. diff_stats_df is generated
+        _tracediff_diff_stats: Optional[pd.DataFrame] = None
+        if comparison_json_path and not df_unified_perf.empty:
+            perf_analyzer2 = TreePerfAnalyzer.from_file(
+                profile_filepath=comparison_json_path,
+                python_path=perf_analyzer.python_path,
+                include_unlinked_kernels=perf_analyzer.include_unlinked_kernels,
+                enable_pseudo_ops=enable_pseudo_ops,
+                add_python_func=perf_analyzer.add_python_func,
+            )
+            perf_analyzer2.tree.apply_annotation(
+                name_filters=["vllm::unified_attention_with_output"]
+            )
+            td = TraceDiff(perf_analyzer.tree, perf_analyzer2.tree)
+            td.generate_tracediff_report()
+            _tracediff_diff_stats = td.diff_stats_df
+
+        if not df_unified_perf.empty:
+            df_unified_perf_summary = perf_analyzer.summarize_df_unified_perf_table(
+                df_unified_perf,
+                agg_metrics=agg_metrics,
+                include_pct=True,
+                group_by_num_kernels=group_by_num_kernels,
+                include_call_stack=include_call_stack,
+                tree=perf_analyzer.tree,
+            )
+            if not df_unified_perf_summary.empty:
+                df_unified_perf_summary = add_truncated_kernel_details(
+                    df_unified_perf_summary,
+                    source_col="kernel_details_summary",
+                    new_col_name="trunc_kernel_details",
+                )
+                if "call_stack_full" in df_unified_perf_summary.columns:
+                    cs_col = df_unified_perf_summary.columns.get_loc("call_stack_full")
+                    ep_results = df_unified_perf_summary.apply(
+                        lambda row: _find_entry_point(
+                            row["call_stack_full"], row["name"]
+                        ),
+                        axis=1,
+                    )
+                    df_unified_perf_summary.insert(
+                        cs_col,
+                        "entry_point",
+                        ep_results.apply(lambda x: x["entry_point"]),
+                    )
+                    if os.environ.get("TRACELENS_DEBUG"):
+                        df_unified_perf_summary.insert(
+                            cs_col + 1,
+                            "num_wrappers",
+                            ep_results.apply(lambda x: x["num_wrappers"]),
+                        )
+                        df_unified_perf_summary.insert(
+                            cs_col + 2,
+                            "traversal",
+                            ep_results.apply(lambda x: x["traversal"]),
+                        )
+                        df_unified_perf_summary.insert(
+                            cs_col + 3,
+                            "wrappers",
+                            ep_results.apply(lambda x: x["wrappers"]),
+                        )
+                dict_name2df["unified_perf_summary"] = df_unified_perf_summary
+
+            if _tracediff_diff_stats is not None and not _tracediff_diff_stats.empty:
+                from TraceLens.Reporting.tracediff_comparison_extension import (
+                    enrich_perf_report_dict_inplace,
+                )
+
+                dict_name2df = enrich_perf_report_dict_inplace(
+                    dict_name2df,
+                    _tracediff_diff_stats,
+                    df_unified_perf=df_unified_perf,
+                )
+                dict_name2df["diff_stats"] = _tracediff_diff_stats
+
+            if include_overlap_info:
+                df_unified_perf_summary_overlapping_kernels = (
+                    perf_analyzer.summarize_df_unified_perf_table(
+                        df_unified_perf,
+                        agg_metrics=agg_metrics,
+                        include_pct=True,
+                        group_by_num_kernels=group_by_num_kernels,
+                        include_overlapping_kernels=True,
+                    )
+                )
+                if not df_unified_perf_summary_overlapping_kernels.empty:
+                    df_unified_perf_summary_overlapping_kernels = (
+                        add_truncated_kernel_details(
+                            df_unified_perf_summary_overlapping_kernels,
+                            source_col="kernel_details_summary",
+                            new_col_name="trunc_kernel_details",
+                        )
+                    )
+                    df_unified_perf_summary_overlapping_kernels = (
+                        add_truncated_kernel_details(
+                            df_unified_perf_summary_overlapping_kernels,
+                            source_col="overlapping_kernels_details_summary",
+                            new_col_name="trunc_overlapping_kernels_details",
+                        )
+                    )
+                if not df_unified_perf_summary_overlapping_kernels.empty:
+                    dict_name2df["unified_perf_summary_kl_overlap"] = (
+                        df_unified_perf_summary_overlapping_kernels
+                    )
+
+        # update this dict with the perf_metrics_dfs
+        dict_name2df.update(perf_metrics_dfs)
+        perf_report_sanity_check(
+            perf_analyzer.tree.events,
+            df_gpu_timeline,
+            df_kernel_launchers,
+            df_unified_perf,
+            include_nccl=collective_analysis,
+        )
+
+    # Kernel summary: aggregate per-kernel durations and counts
+    if kernel_summary:
+        try:
+            df_kernels = perf_analyzer.get_df_kernels(launcher_detail=True)
+        except Exception as e:
+            df_kernels = pd.DataFrame()
+        if not df_kernels.empty and "Kernel duration (µs)" in df_kernels.columns:
+            # Fallback: If Parent cpu_op is missing, fill it from Launcher (for display purposes)
+            if (
+                "Parent cpu_op" in df_kernels.columns
+                and "Launcher" in df_kernels.columns
+            ):
+                mask_missing_parent = df_kernels["Parent cpu_op"].isna()
+                if mask_missing_parent.any():
+                    df_kernels.loc[mask_missing_parent, "Parent cpu_op"] = (
+                        df_kernels.loc[mask_missing_parent, "Launcher"]
+                    )
+
+            # Fallback categorization for graph/runtime launched kernels with no cpu_op
+            # Note: Basic 'Parent op category' is added by get_kernel_details() in tree_perf.py
+            # This adds categorization for kernels that don't have a parent cpu_op
+            if "Parent op category" not in df_kernels.columns:
+                df_kernels["Parent op category"] = np.nan
+
+            if "Launcher" in df_kernels.columns:
+                mask_missing_cat = df_kernels["Parent op category"].isna()
+                if mask_missing_cat.any():
+
+                    def _launcher_category(name):
+                        s = str(name).lower()
+                        if "cudagraph" in s or "graphlaunch" in s:
+                            return "graph"
+                        return "runtime" if s and s != "nan" else np.nan
+
+                    df_kernels.loc[mask_missing_cat, "Parent op category"] = (
+                        df_kernels.loc[mask_missing_cat, "Launcher"].apply(
+                            _launcher_category
+                        )
+                    )
+
+            # Group by category/cpu_op along with kernel identifiers when available
+            group_cols = []
+            for col in [
+                "Parent op category",
+                "Parent cpu_op",
+                "Kernel name",
+                "Kernel stream",
+            ]:
+                if col in df_kernels.columns:
+                    group_cols.append(col)
+            if not group_cols:
+                group_cols = (
+                    ["Kernel name"] if "Kernel name" in df_kernels.columns else []
+                )
+
+            agg_dict = {"Kernel duration (µs)": ["sum", "count", "mean", "min", "max"]}
+            df_kernel_summary = df_kernels.groupby(group_cols, dropna=False).agg(
+                agg_dict
+            )
+            df_kernel_summary.columns = [
+                "_".join(col).strip() for col in df_kernel_summary.columns.values
+            ]
+            df_kernel_summary.reset_index(inplace=True)
+
+            # Percent columns:
+            # 1) Percent of kernels time: sums to ~100% across rows
+            total_kernels_us = df_kernels["Kernel duration (µs)"].sum()
+            if total_kernels_us > 0:
+                df_kernel_summary["Percent of kernels time (%)"] = (
+                    df_kernel_summary["Kernel duration (µs)_sum"] / total_kernels_us
+                ) * 100
+            else:
+                df_kernel_summary["Percent of kernels time (%)"] = np.nan
+            # 2) Percent of total time (GPU timeline baseline; includes idle/non-kernel)
+            total_us = (
+                perf_analyzer.total_time_ms * 1e3
+                if hasattr(perf_analyzer, "total_time_ms")
+                else None
+            )
+            if total_us:
+                df_kernel_summary["Percent of total time (%)"] = (
+                    df_kernel_summary["Kernel duration (µs)_sum"] / total_us
+                ) * 100
+            else:
+                df_kernel_summary["Percent of total time (%)"] = np.nan
+
+            df_kernel_summary.sort_values(
+                by="Kernel duration (µs)_sum", ascending=False, inplace=True
+            )
+            df_kernel_summary.reset_index(drop=True, inplace=True)
+            dict_name2df["kernel_summary"] = df_kernel_summary
+
+    if short_kernel_study:
+        dict_name2df["short_kernel_histogram"] = df_hist
+        dict_name2df["short_kernels_summary"] = df_short_kernels
+
+    # Skip collective analysis for GPU-only traces (no CPU ops means no collectives)
+    if collective_analysis and not perf_analyzer.gpu_only:
+        nccl_analyser = NcclAnalyser([profile_json_path], None)
+        df_nccl_summary = nccl_analyser.build_df_summary_long()
+        if not df_nccl_summary.empty:
+            dict_name2df["coll_analysis"] = df_nccl_summary
+
+    # Get additional DataFrames from extension if available
+    if extension_file:
+        extension_path = os.path.abspath(extension_file)
+        extension_name = os.path.splitext(os.path.basename(extension_path))[0]
+        spec = importlib.util.spec_from_file_location(extension_name, extension_path)
+        extension = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(extension)
+
+        if hasattr(extension, "get_additional_dataframes_extension"):
+            print(f"Getting additional DataFrames from extension: {extension_path}")
+            get_additional_dfs = getattr(
+                extension, "get_additional_dataframes_extension"
+            )
+            additional_dfs = get_additional_dfs(perf_analyzer.tree)
+            if additional_dfs:
+                dict_name2df.update(additional_dfs)
+                print(f"Added {len(additional_dfs)} additional sheets from extension")
+
+    # Write CSVs and/or Excel (independent options)
+    if output_csvs_dir:
+        # Ensure the output directory exists
+        os.makedirs(output_csvs_dir, exist_ok=True)
+        for sheet_name, df in dict_name2df.items():
+            csv_path = os.path.join(output_csvs_dir, f"{sheet_name}.csv")
+            df.to_csv(csv_path, index=False)
+            print(f"DataFrame '{sheet_name}' written to {csv_path}")
+    else:
+        if output_xlsx_path is None:
+            # split input path at 'json' and take the first part and append '.xlsx'
+            base_path = profile_json_path.rsplit(".json", 1)[0]
+            output_xlsx_path = base_path + "_perf_report.xlsx"
+        try:
+            import openpyxl
+        except (ImportError, ModuleNotFoundError) as e:
+            print(f"Error importing openpyxl: {e}")
+            request_install("openpyxl")
+
+        with pd.ExcelWriter(output_xlsx_path, engine="openpyxl") as writer:
+            for sheet_name, df in dict_name2df.items():
+                df.to_excel(writer, sheet_name=sheet_name, index=False)
+            print(f"DataFrames successfully written to {output_xlsx_path}")
+
+    return dict_name2df
+
+
+def main():
+
+    parser = argparse.ArgumentParser(
+        description="Process a JSON trace profile and generate performance report tables."
+    )
+    parser.add_argument(
+        "--profile_json_path",
+        type=str,
+        required=True,
+        help="Path to the profile.json or .json.gz file",
+    )
+    parser.add_argument(
+        "--output_xlsx_path",
+        type=str,
+        default=None,
+        help="Path to the output Excel file",
+    )
+    parser.add_argument(
+        "--output_csvs_dir",
+        type=str,
+        default=None,
+        help="Directory to save output CSV files",
+    )
+
+    # Optional arguments
+    parser.add_argument(
+        "--include_unlinked_kernels",
+        action="store_true",
+        help="Include unlinked kernels in the GPU timeline analysis.",
+    )
+    parser.add_argument(
+        "--micro_idle_thresh_us",
+        type=int,
+        default=None,
+        help="Threshold in microseconds to classify idle interval as micro idle in GPU timeline analysis. "
+        "Default is None and all idle times are included in one category.",
+    )
+    parser.add_argument(
+        "--disable_coll_analysis",
+        action="store_false",
+        dest="collective_analysis",
+        default=False,
+        help="Disable collective analysis section in the report. Enabled by default.",
+    )
+    parser.add_argument(
+        "--enable_kernel_summary",
+        action="store_true",
+        dest="kernel_summary",
+        default=False,
+        help="Enable kernel summary sheet in the report. Disabled by default.",
+    )
+
+    parser.add_argument(
+        "--group_by_parent_module",
+        action="store_true",
+        dest="group_by_parent_module",
+        default=False,
+        help="Group kernel launcher summaries by parent module in addition to operation name.",
+    )
+    parser.add_argument(
+        "--short_kernel_study",
+        action="store_true",
+        help="Include short kernel study in the report.",
+    )
+    parser.add_argument(
+        "--short_kernel_threshold_us",
+        type=int,
+        default=10,
+        help='Threshold in microseconds to classify a kernel as "short". Defaults to 10 us.',
+    )
+    parser.add_argument(
+        "--short_kernel_histogram_bins",
+        type=int,
+        default=100,
+        help="Number of bins for the short-kernel histogram.",
+    )
+    parser.add_argument(
+        "--topk_short_kernels",
+        type=int,
+        default=None,
+        help="Rows to keep in the short-kernel table.",
+    )
+    parser.add_argument(
+        "--enable_pseudo_ops",
+        action="store_true",
+        default=False,
+        help="Enable automatic pseudo-op augmentation to tree to isolate specific kernels (e.g., FusedMoE).",
+    )
+    parser.add_argument(
+        "--topk_ops",
+        type=int,
+        default=None,
+        help="Rows to keep in the unique-args launcher table.",
+    )
+    parser.add_argument(
+        "--topk_roofline_ops",
+        type=int,
+        default=None,
+        help="Rows to keep in the roofline table.",
+    )
+
+    parser.add_argument(
+        "--comparison_json_path",
+        type=str,
+        default=None,
+        help=(
+            "Path to a second trace to compare against the primary trace. "
+            "Runs TraceDiff and adds speedup, delta, and LCA columns to "
+            "unified_perf_summary, plus a diff_stats sheet."
+        ),
+    )
+
+    parser.add_argument(
+        "--extension_file",
+        type=str,
+        default=None,
+        help="Path to the extension file containing custom extensions for TraceTree and PerfModel.",
+    )
+
+    parser.add_argument(
+        "--python_path",
+        type=str,
+        default=None,
+        help="Path to the python executable for gemm simulator",
+    )
+    add_gpu_arch_cli_args(parser)
+    parser.add_argument(
+        "--enable-origami",
+        action="store_true",
+        default=False,
+        help="Use Origami for simulated GEMM/SDPA times when a GPU arch JSON is provided",
+    )
+
+    parser.add_argument(
+        "--capture_folder",
+        type=str,
+        required=False,
+        help="Path to the capture trace folder",
+    )
+    parser.add_argument(
+        "--group_by_num_kernels",
+        action="store_true",
+        default=False,
+        help="Group by number of kernels in summary tables.",
+    )
+    parser.add_argument(
+        "--include_call_stack",
+        action="store_true",
+        default=False,
+        help="Include callstack in the report.",
+    )
+    parser.add_argument(
+        "--include_overlap_info",
+        action="store_true",
+        default=False,
+        help="Include overlap info in the report. Disabled by default. "
+        "Adds ops_unique_args_kl_overlap, unified_perf_summary_kl_overlap, and "
+        "per-category *_kl_overlap / *_fwd_kl_overlap / *_bwd_kl_overlap sheets when data exists.",
+    )
+
+    args = parser.parse_args()
+    if args.capture_folder and args.comparison_json_path:
+        parser.error(
+            "--capture_folder and --comparison_json_path cannot be used together. "
+            "The TraceDiff comparison extension does not support graph capture traces."
+        )
+    if args.capture_folder:
+        classify_graph_capture_trace(args.capture_folder)
+        metadata_json_path = os.path.join(args.capture_folder, "execution_details.json")
+        graph_tree = merge_capture_trace_into_graph(
+            args.capture_folder, metadata_json_path, args.profile_json_path
+        )
+    else:
+        graph_tree = None
+    generate_perf_report_pytorch(
+        profile_json_path=args.profile_json_path,
+        augmented_tree=graph_tree,
+        output_xlsx_path=args.output_xlsx_path,
+        output_csvs_dir=args.output_csvs_dir,
+        include_unlinked_kernels=args.include_unlinked_kernels,
+        enable_pseudo_ops=args.enable_pseudo_ops,
+        micro_idle_thresh_us=args.micro_idle_thresh_us,
+        collective_analysis=args.collective_analysis,
+        include_overlap_info=args.include_overlap_info,
+        kernel_summary=args.kernel_summary,
+        short_kernel_study=args.short_kernel_study,
+        short_kernel_threshold_us=args.short_kernel_threshold_us,
+        short_kernel_histogram_bins=args.short_kernel_histogram_bins,
+        topk_short_kernels=args.topk_short_kernels,
+        topk_ops=args.topk_ops,
+        topk_roofline_ops=args.topk_roofline_ops,
+        comparison_json_path=args.comparison_json_path,
+        extension_file=args.extension_file,
+        python_path=args.python_path,
+        gpu_arch_json_path=args.gpu_arch_json_path,
+        gpu_arch_platform=args.gpu_arch_platform,
+        enable_origami=args.enable_origami,
+        group_by_parent_module=args.group_by_parent_module,
+        group_by_num_kernels=args.group_by_num_kernels,
+        include_call_stack=args.include_call_stack,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/TraceLens/Trace2Tree/trace_capture_merge_experimental.py
+++ b/TraceLens/Trace2Tree/trace_capture_merge_experimental.py
@@ -17,7 +17,7 @@ model suitable for performance analysis.
 
 import sys
 import time
-from collections import OrderedDict
+from collections import OrderedDict, deque
 from typing import Any, Dict, List, Optional, Tuple
 import json
 import os
@@ -58,7 +58,71 @@ def get_subtree_events(tree, event, cat_filter=None, name_filter=None):
     return list_events, list_filtered_events
 
 
+def _normalize_kernel_name(event):
+    """Cross-trace match key for a launch/kernel event.
+
+    Capture launches store the kernel name under ``args.kernel``; graph kernels
+    store it in ``name``. Memory ops are named differently per trace
+    (``hipMemsetAsync``/``hipMemcpyAsync`` vs ``Memset (Device)``/``Memcpy ...``),
+    so collapse them to stable tokens.
+    """
+    name = event.get("args", {}).get("kernel", event.get("name", ""))
+    if "Memset" in name:
+        return "MEMSET"
+    if "Memcpy" in name:
+        return "MEMCPY"
+    return name
+
+
+def build_stream_pairs(graph_filtered_events, capture_filtered_events):
+    """Pair graph kernels with capture launches across GPU streams.
+
+    Capture launches are in CPU enqueue (program) order; graph kernels are in
+    GPU execution order, which interleaves streams differently. Within a stream
+    both orders agree, so group graph kernels into per-stream FIFO queues and
+    walk capture launches in program order, consuming the matching stream head.
+    On a name tie across streams, prefer the stream whose queue matches the
+    longest contiguous run of upcoming capture launches.
+
+    Returns ``(pairs, ok)`` with ``pairs`` as ``(g_event, c_event)`` in capture
+    program order; ``ok`` is True iff every event on both sides was paired once.
+    Single-stream traces reduce to the original positional pairing.
+    """
+    cap_names = [_normalize_kernel_name(c) for c in capture_filtered_events]
+    g_name = {id(g): _normalize_kernel_name(g) for g in graph_filtered_events}
+
+    streams = OrderedDict()
+    for g in graph_filtered_events:
+        streams.setdefault(g.get("args", {}).get("stream"), deque()).append(g)
+
+    def forward_run_len(stream, start_idx):
+        q = streams[stream]
+        run = 0
+        while (
+            run < len(q)
+            and start_idx + run < len(cap_names)
+            and g_name[id(q[run])] == cap_names[start_idx + run]
+        ):
+            run += 1
+        return run
+
+    pairs = []
+    for idx, c_event in enumerate(capture_filtered_events):
+        cands = [s for s, q in streams.items() if q and g_name[id(q[0])] == cap_names[idx]]
+        if not cands:
+            continue
+        chosen = cands[0] if len(cands) == 1 else max(cands, key=lambda s: forward_run_len(s, idx))
+        pairs.append((streams[chosen].popleft(), c_event))
+
+    ok = (
+        all(not q for q in streams.values())
+        and len(pairs) == len(graph_filtered_events) == len(capture_filtered_events)
+    )
+    return pairs, ok
+
+
 def verify_subtree_events(capture_events, graph_events):
+    """Return 1 if capture/graph subtrees fully pair (stream-aware), else 0."""
     if len(capture_events) != len(graph_events):
         print(
             "Mismatch in number of events: Capture {}, Graph {}".format(
@@ -66,28 +130,14 @@ def verify_subtree_events(capture_events, graph_events):
             )
         )
         return 0
-    else:
-        # print("=========matching ========")
-        for j, i in zip(capture_events, graph_events):
-            if "kernel" not in j.get("args", {}).keys():
-                if "Memcpy" in j["name"] or "Memset" in j["name"]:
-                    continue
-                warnings.warn(
-                    "Kernel name missing in capture event args, "
-                    "alignment has not been verified",
-                    stacklevel=2,
-                )
-                continue
-            if i["name"] != j.get("args", {}).get("kernel", j["name"]):
-                print(
-                    "Mismatch in kernel name: {} vs {}".format(
-                        i["name"], j.get("args", {}).get("kernel", j["name"])
-                    )
-                )
-                return 0
-    # print(
-    #    "Subtree events match successfully with {} events".format(len(capture_events))
-    # )
+    _, ok = build_stream_pairs(graph_events, capture_events)
+    if not ok:
+        print(
+            "Stream-aware pairing failed to align {} capture / {} graph events".format(
+                len(capture_events), len(graph_events)
+            )
+        )
+        return 0
     return 1
 
 
@@ -160,7 +210,12 @@ def append_subtree_to_event(tree, subtree_events, parent_event, cpu_root_nodes):
     return tree
 
 
-def make_connections(graph_tree, graph_filtered_events, capture_filtered_events):
+def make_connections(graph_tree, pairs):
+    """Wire each graph kernel to its paired capture launch and roll gpu_events up.
+
+    *pairs* is ``(g_event, c_event)`` in capture program order, so consecutive
+    ``c_event`` ancestor paths share a suffix (exploited by the chain cache).
+    """
     events_by_uid = graph_tree.events_by_uid
 
     # Accumulate gpu_event UIDs per ancestor, then batch-apply with extend.
@@ -181,7 +236,7 @@ def make_connections(graph_tree, graph_filtered_events, capture_filtered_events)
         {}
     )  # uid → index in ancestor_chain for O(1) merge detection
 
-    for g_event, c_event in zip(graph_filtered_events, capture_filtered_events):
+    for g_event, c_event in pairs:
         g_uid = g_event[UID]
 
         graph_tree.events[c_event[UID]]["children"] = [g_uid]
@@ -548,11 +603,12 @@ def merge_capture_trace_into_graph(
                 graph_tree, g_root, cat_filter=["kernel", "gpu_memset", "gpu_memcpy"]
             )
 
-            verify_success = verify_subtree_events(
-                capture_filtered_events, graph_filtered_events
+            # Compute the stream-aware pairing once; reuse it as the gate and
+            # for make_connections.
+            pairs, ok = build_stream_pairs(
+                graph_filtered_events, capture_filtered_events
             )
-
-            if verify_success == 0:
+            if not ok:
                 print(
                     "Warning: subtree events verification failed for capture root {} and graph root {}".format(
                         c_root["name"], g_root["name"]
@@ -577,8 +633,6 @@ def merge_capture_trace_into_graph(
                 graph_tree, capture_events, g_root, cpu_root_nodes
             )
 
-            graph_tree = make_connections(
-                graph_tree, graph_filtered_events, capture_filtered_events
-            )
+            graph_tree = make_connections(graph_tree, pairs)
     finalize_non_gpu_paths(graph_tree)
     return graph_tree


### PR DESCRIPTION
This pull request significantly improves the accuracy and reliability of pairing kernel launch events between capture and graph traces in multi-stream GPU traces. The main enhancement is the introduction of a stream-aware pairing algorithm that matches events based on both stream and kernel name, replacing the previous positional matching logic. This ensures correct alignment even when event orders differ across streams.

The most important changes are:

**Stream-aware event pairing and verification:**

* Added the `_normalize_kernel_name` function to consistently extract and normalize kernel names across different trace formats, collapsing memory operations to stable tokens for robust matching.
* Introduced the `build_stream_pairs` function to pair graph kernels and capture launches by stream and name, handling multi-stream traces and ensuring each event is paired exactly once.
* Updated `verify_subtree_events` to use the new stream-aware pairing, returning success only if all events are correctly paired.

**Refactoring and integration:**

* Modified `merge_capture_trace_into_graph` to compute event pairs once using `build_stream_pairs`, using the result for both verification and connection, reducing redundant computation and improving clarity. [[1]](diffhunk://#diff-a361820c09001fd17b2d09215e178075fa4e355e907c434103b7f0bd0a40041cL551-R611) [[2]](diffhunk://#diff-a361820c09001fd17b2d09215e178075fa4e355e907c434103b7f0bd0a40041cL580-R636)
* Refactored `make_connections` to accept precomputed event pairs instead of separate event lists, simplifying its interface and leveraging the new pairing logic. [[1]](diffhunk://#diff-a361820c09001fd17b2d09215e178075fa4e355e907c434103b7f0bd0a40041cL163-R218) [[2]](diffhunk://#diff-a361820c09001fd17b2d09215e178075fa4e355e907c434103b7f0bd0a40041cL184-R239)

These changes make the kernel launch pairing process more robust, especially for traces with multiple GPU streams.
<!--
Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.

See LICENSE for license information.
-->

