### PR TITLE
fix(jax): parse integer HLO lines and resolve collective aliases

### DIFF
--- a/TraceLens/Trace2Tree/trace_to_tree.py
+++ b/TraceLens/Trace2Tree/trace_to_tree.py
@@ -336,6 +336,8 @@ class JaxTraceToTree(BaseTraceToTree):
 
         self.linking_key_to_uid_map = defaultdict(list)
         self.hlo_ops = defaultdict(list)
+        self.hlo_op_aliases = {}
+        self._warned_missing_hlo_ops = set()
         self.metadata = dict
 
     def default_categorizer(self):
@@ -437,6 +439,9 @@ class JaxTraceToTree(BaseTraceToTree):
 
         self._categorize_gpu_kernel_ops()
 
+    # Kernel-name FA labels are authoritative; do not replace with TE via hlo_op.
+    _FA_KERNEL_NAME_CATEGORIES = frozenset({"FA BWD", "FA FWD", "FA V3"})
+
     def _categorize_gpu_kernel_ops(self) -> None:
         """
         Categorizes GPU kernel operations in the event list based on their names and HLO operation types.
@@ -446,6 +451,9 @@ class JaxTraceToTree(BaseTraceToTree):
         category by matching the event's name and, if available, its 'hlo_op' argument against
         predefined category filters in `TraceEventUtils.JaxOpKeys.ClassCategories`. If no category is
         matched, assigns a default 'Uncategorized/XLA' category.
+
+        When the kernel name matches an FA category (FA FWD / FA BWD / FA V3), that label is kept
+        even if ``hlo_op`` would match TE (e.g. ``te_fused_attn_forward_ffi`` inside Transformer Engine).
 
         Modifies:
             Each relevant event in `self.events` by adding or updating the 'gpu_kernel_op_cat' key.
@@ -457,21 +465,27 @@ class JaxTraceToTree(BaseTraceToTree):
             if event.get("cat") != "kernel":
                 continue
             name = event.get("name", "")
-            gpu_kernel_op_cat_not_found = True
+            name_category = None
 
             for (
                 category,
                 filters,
             ) in TraceEventUtils.JaxOpKeys.ClassCategories.items():
                 if any(f in name for f in filters):
-                    event["gpu_kernel_op_cat"] = category
-                    gpu_kernel_op_cat_not_found = False
+                    name_category = category
                     break
+
+            gpu_kernel_op_cat_not_found = name_category is None
+            if name_category is not None:
+                event["gpu_kernel_op_cat"] = name_category
 
             args = event.get("args")
             if args and "hlo_op" in args:
                 hlo_op = args.get("hlo_op")
-                if hlo_op:
+                if (
+                    hlo_op
+                    and name_category not in self._FA_KERNEL_NAME_CATEGORIES
+                ):
                     for (
                         category,
                         filters,
@@ -532,6 +546,40 @@ class JaxTraceToTree(BaseTraceToTree):
                                 pb_file_name, hlo_module
                             )
                         )
+        self._build_hlo_op_alias_maps()
+
+    def _build_hlo_op_alias_maps(self) -> None:
+        """Build per-module aliases for runtime vs HLO-dump collective names."""
+        trace_ops_by_module = defaultdict(set)
+        for event in self.events:
+            args = event.get("args") or {}
+            hlo_module = args.get("hlo_module")
+            hlo_op = args.get("hlo_op")
+            if hlo_module and hlo_op:
+                trace_ops_by_module[hlo_module].add(
+                    JaxProfileProcessor._normalize_hlo_op_key(hlo_op)
+                )
+
+        self.hlo_op_aliases = {}
+        for hlo_module, trace_ops in trace_ops_by_module.items():
+            module_ops = self.hlo_ops.get(hlo_module)
+            if not module_ops:
+                continue
+            self.hlo_op_aliases[hlo_module] = (
+                JaxProfileProcessor.build_collective_hlo_aliases(
+                    module_ops, trace_ops
+                )
+            )
+
+    def _lookup_hlo_metadata(self, hlo_module: str, hlo_op: str) -> Optional[dict]:
+        module_ops = self.hlo_ops.get(hlo_module, {})
+        aliases = self.hlo_op_aliases.get(hlo_module, {})
+        resolved_key = JaxProfileProcessor.resolve_hlo_op_key(
+            hlo_op, module_ops, aliases
+        )
+        if resolved_key is None:
+            return None
+        return module_ops.get(resolved_key)
 
     def _create_linking_key_to_uid_map(self) -> None:
         """
@@ -589,17 +637,22 @@ class JaxTraceToTree(BaseTraceToTree):
                                 if "hlo_op" in GPU_event.get("args").keys():
                                     hlo_op = "%" + GPU_event.get("args").get("hlo_op")
                                     hlo_module = GPU_event.get("args").get("hlo_module")
-                                    if (hlo_module in self.hlo_ops.keys()) and (
-                                        hlo_op in self.hlo_ops.get(hlo_module).keys()
-                                    ):
-                                        GPU_event["metadata"] = self.hlo_ops.get(
-                                            hlo_module
-                                        ).get(hlo_op)
+                                    metadata = self._lookup_hlo_metadata(
+                                        hlo_module, hlo_op
+                                    )
+                                    if metadata is not None:
+                                        GPU_event["metadata"] = metadata
                                     else:
-                                        logger.warning(f"Missing hlo_op: {hlo_op}")
-                                        logger.warning(
-                                            f"in hlo_module: {GPU_event['args']['hlo_module']}"
-                                        )
+                                        warn_key = (hlo_module, hlo_op)
+                                        if warn_key not in self._warned_missing_hlo_ops:
+                                            self._warned_missing_hlo_ops.add(warn_key)
+                                            logger.warning(
+                                                f"Missing hlo_op: {hlo_op}"
+                                            )
+                                            logger.warning(
+                                                "in hlo_module: "
+                                                f"{GPU_event['args']['hlo_module']}"
+                                            )
 
 
 class TraceToTree(BaseTraceToTree):

--- a/TraceLens/util.py
+++ b/TraceLens/util.py
@@ -88,6 +88,43 @@ class DataLoader:
 class JaxProfileProcessor:
     gemm_columns = ["Batch", "M", "N", "K", "Beta", "Type"]
 
+    # Substrings used to detect parseable HLO graph-viewer text lines.
+    # The legacy list only covered float types; integer/bool lines were skipped and
+    # later showed up as "Missing hlo_op" when the profiler trace referenced them.
+    _HLO_LINE_ELEMENT_TYPE_HINTS_LEGACY = [
+        "get-tuple-element",
+        "bf16",
+        "f8",
+        "f16",
+        "f32",
+        "f64",
+    ]
+    _HLO_LINE_ELEMENT_TYPE_HINTS = _HLO_LINE_ELEMENT_TYPE_HINTS_LEGACY + [
+        "s32",
+        "s64",
+        "u32",
+        "u64",
+        "pred",
+    ]
+
+    @staticmethod
+    def _should_parse_hlo_graph_line(line: str) -> bool:
+        """Return True if a graph-viewer text line should be parsed into hlo_ops."""
+        line_processed = line.strip()
+        if not line_processed or line_processed.startswith("HloModule "):
+            return False
+        if line_processed.startswith("ROOT"):
+            return False
+        if (
+            "metadata" in line_processed
+            and not re.search(r"\)$", line_processed)
+        ):
+            return True
+        return any(
+            hint in line_processed
+            for hint in JaxProfileProcessor._HLO_LINE_ELEMENT_TYPE_HINTS
+        )
+
     @staticmethod
     def process_xla_file(xla_file_name):
         hlo_ops = {}
@@ -172,22 +209,84 @@ class JaxProfileProcessor:
     @staticmethod
     def process_line(hlo_ops: dict, line: str):
         line_processed = line.strip()
-        if (
-            (
-                "metadata" in line_processed
-                and not (re.search(r"\)$", line_processed))
-                and not (line_processed.startswith("ROOT"))
-            )
-            or any(
-                t in line_processed
-                for t in ["get-tuple-element", "bf16", "f8", "f16", "f32", "f64"]
-            )
-            and not (line_processed.startswith("HloModule "))
-        ):
-            k, v = JaxProfileProcessor.get_dict(hlo_ops, line_processed)
-            hlo_ops[k] = v
-            return True
-        return False
+        if not JaxProfileProcessor._should_parse_hlo_graph_line(line_processed):
+            return False
+        k, v = JaxProfileProcessor.get_dict(hlo_ops, line_processed)
+        hlo_ops[k] = v
+        return True
+
+    # Async collectives in HLO text use *-start/*-done names; runtime traces may
+    # use numbered aliases (e.g. reduce-scatter.12 -> reduce-scatter-start).
+    _ASYNC_COLLECTIVE_FAMILIES = ("all-to-all", "reduce-scatter", "all-gather")
+
+    @staticmethod
+    def _normalize_hlo_op_key(hlo_op: str) -> str:
+        return hlo_op if hlo_op.startswith("%") else f"%{hlo_op}"
+
+    @staticmethod
+    def _collective_start_keys(module_ops: dict, family: str) -> list:
+        start_keys = sorted(
+            k for k in module_ops if k.startswith(f"%{family}-start")
+        )
+        if start_keys:
+            return start_keys
+        return sorted(k for k in module_ops if k.startswith(f"%{family}-done"))
+
+    @classmethod
+    def build_collective_hlo_aliases(cls, module_ops: dict, trace_hlo_ops) -> dict:
+        """Map numbered runtime collective tags to parsed HLO dump keys."""
+        aliases = {}
+        normalized_ops = {cls._normalize_hlo_op_key(op) for op in trace_hlo_ops}
+
+        for family in cls._ASYNC_COLLECTIVE_FAMILIES:
+            numbered = []
+            for op_key in normalized_ops:
+                if op_key in module_ops:
+                    continue
+                bare = op_key.lstrip("%")
+                prefix = f"{family}."
+                if not bare.startswith(prefix):
+                    continue
+                suffix = bare[len(prefix) :]
+                if suffix.isdigit():
+                    numbered.append((int(suffix), op_key))
+
+            if not numbered:
+                continue
+
+            start_keys = cls._collective_start_keys(module_ops, family)
+            if not start_keys:
+                continue
+
+            numbered.sort()
+            if len(start_keys) == 1:
+                for _, op_key in numbered:
+                    aliases[op_key] = start_keys[0]
+            else:
+                for idx, (_, op_key) in enumerate(numbered):
+                    aliases[op_key] = start_keys[min(idx, len(start_keys) - 1)]
+
+        return aliases
+
+    @classmethod
+    def resolve_hlo_op_key(cls, hlo_op: str, module_ops: dict, aliases=None):
+        """Resolve a trace hlo_op to a key present in module_ops."""
+        key = cls._normalize_hlo_op_key(hlo_op)
+        if key in module_ops:
+            return key
+        if aliases and key in aliases and aliases[key] in module_ops:
+            return aliases[key]
+
+        bare = key.lstrip("%")
+        match = re.match(
+            r"^(all-to-all|reduce-scatter|all-gather)\.(\d+)$",
+            bare,
+        )
+        if match:
+            start_keys = cls._collective_start_keys(module_ops, match.group(1))
+            if start_keys:
+                return start_keys[0]
+        return None
 
     @staticmethod
     def get_operands(operands):


### PR DESCRIPTION
## Summary
- Extend HLO graph parsing to include integer and boolean element types (`s32`, `s64`, `u32`, `u64`, `pred`) so trace metadata is not dropped for non-float ops
- Map runtime collective names (e.g. `reduce-scatter.12`) to HLO dump keys (`reduce-scatter-start`) when linking GPU events to HLO metadata
- Deduplicate missing-`hlo_op` warnings (log once per module+op)
- Preserve FA FWD / FA BWD / FA V3 kernel categories when `hlo_op` would incorrectly classify them as TE

## Motivation
On JAX profiles (e.g. `tw052.xplane.pb`), the legacy HLO parser only matched float element types, causing thousands of `Missing hlo_op` warnings and missing `op_gemm` / `op_te` xlsx sheets. Async collectives also use different names in traces vs HLO dumps.

## Test plan
- [ ] Run `TraceLens_generate_perf_report_jax --profile tw052.xplane.pb --output_xlsx_path tw052_perf_report.xlsx`
- [ ] Confirm `op_gemm` and `op_te` sheets are present in the output xlsx
- [ ] Confirm FA FWD / FA BWD appear in `kernel_launchers_summary_by_category`
- [ ] Confirm `Missing hlo_op` warning count is low (single digits vs thousands before fix)


Made with [Cursor](https://cursor.com)