### PR TITLE
Generic trace splitting support

### DIFF
--- a/TraceLens/TraceUtils/split_inference_trace_annotation.py
+++ b/TraceLens/TraceUtils/split_inference_trace_annotation.py
@@ -302,13 +302,13 @@ def _detect_iteration_roots_from_tree(
     ``roots`` may be a single event dict or a list of event dicts — all are
     seeded into the BFS at depth 0 so they are explored level-by-level together.
 
-    Pattern detection uses only GPU-path children (dur > 1us) to avoid noise
-    from utility calls. Block boundaries are expanded to the full unfiltered
-    child list to include CPU-only events (e.g. scheduler.step) that follow
-    the GPU work within each iteration.
+    Pattern detection uses all children (not just GPU-path ones) so that
+    leading CPU-only events (e.g. ``next`` in the OWL pipeline) are included
+    as part of the iteration anchor. A minimum child count guards against false
+    positives from short utility-function child lists.
 
     Returns a list of synthetic root events, one per detected iteration, where
-    each event's ``dur`` spans the full block from first to last child.
+    each event's ``dur`` spans from the first to the last child of the block.
     """
     from collections import deque
 
@@ -322,18 +322,12 @@ def _detect_iteration_roots_from_tree(
         if not children:
             continue
 
-        # Use GPU-path children (dur > 1us) for pattern detection to avoid noise
-        # from utility calls. Skip nodes with no qualifying children — recurse
-        # only into GPU-bearing subtrees.
-        gpu_children = [
-            c for c in children
-            if c.get("gpu_events") and c.get("dur", 0) > 1
-        ]
-        if not gpu_children:
+        # Only recurse into GPU-bearing subtrees.
+        if not any(c.get("gpu_events") for c in children):
             continue
 
         p, _, start = _find_repeating_period(
-            [c.get("name", "") for c in gpu_children]
+            [c.get("name", "") for c in children]
         )
         if p is None:
             for child in children:
@@ -342,39 +336,34 @@ def _detect_iteration_roots_from_tree(
             continue
 
         print(f"Generic fallback: repeating pattern found under '{current.get('name')}' at depth {depth}")
+        print(f"Generic fallback: period={p}")
 
-        # Map detection indices back to the full child list so each block spans
-        # the complete iteration including CPU-only tail events.
-        first_full_idx = children.index(gpu_children[start])
-        if start + p < len(gpu_children):
-            next_iter_ts = gpu_children[start + p]["ts"]
-            last_full_idx = next(
-                (i - 1 for i, c in enumerate(children) if c["ts"] >= next_iter_ts),
-                len(children) - 1,
-            )
-        else:
-            last_full_idx = len(children) - 1
-        full_block_size = last_full_idx - first_full_idx + 1
-        full_pattern = [
-            c.get("name", "")
-            for c in children[first_full_idx : first_full_idx + full_block_size]
+        # Anchor each iteration between the Nth occurrence of the first and last
+        # events in the detected pattern. Using all-children anchors means
+        # CPU-only leading/trailing events are included naturally.
+        first_anchor_name = children[start]["name"]
+        last_anchor_name = children[start + p - 1]["name"]
+
+        first_anchors = [
+            i for i, c in enumerate(children)
+            if i >= start and c.get("name") == first_anchor_name
         ]
-        print(f"Generic fallback: GPU-path period={p}, full block size={full_block_size}")
+        last_anchors = [
+            i for i, c in enumerate(children)
+            if i >= start and c.get("name") == last_anchor_name
+        ]
 
-        # Group into iteration blocks and synthesize a root event for each.
         iteration_roots = []
-        remaining = children[first_full_idx:]
-        names = [c.get("name", "") for c in remaining]
-        i = 0
-        while i + full_block_size <= len(names):
-            if names[i : i + full_block_size] != full_pattern:
+        for n in range(min(len(first_anchors), len(last_anchors))):
+            block_start = first_anchors[n]
+            block_end = last_anchors[n]
+            if block_end < block_start:
                 break
-            block = remaining[i : i + full_block_size]
+            block = children[block_start : block_end + 1]
             first, last = block[0], block[-1]
             root_event = dict(first)
             root_event["dur"] = (last["ts"] + last.get("dur", 0)) - first["ts"]
             iteration_roots.append(root_event)
-            i += full_block_size
 
         print(f"Generic fallback: identified {len(iteration_roots)} iterations.")
         return iteration_roots if iteration_roots else None
@@ -726,7 +715,22 @@ def extract_and_save(
                 f"_bs{phase_details['avg_bs']}_conc{phase_details['avg_conc']}"
             )
         elif is_annotation and len(root) == 1:
-            name_append = root[0]["name"].replace("(", "_").replace(")", "")
+            root_name = root[0]["name"]
+            is_known_annotation = any(
+                pat.match(root_name)
+                for pat in ANNOTATION_PATTERN + ANNOTATION_PATTERN_BACKUP
+            )
+            if is_known_annotation:
+                name_append = (
+                    root_name
+                    .replace("/", "_")
+                    .replace("(", "_")
+                    .replace(")", "")
+                    .replace(":", "")
+                    .replace(" ", "_")
+                )
+            else:
+                name_append = ""
         else:
             if len(batch_list) == len(iter_details):
                 name_append = f"batch{int(sum(batch_list)/len(batch_list))}_gpu{prefix}"
@@ -738,8 +742,9 @@ def extract_and_save(
                 output_dir, f"{output_label}_{name_append}_{base_name}.json.gz"
             )
         else:
+            suffix = f"_{name_append}" if name_append else ""
             out_path = os.path.join(
-                output_dir, f"{base_name}_{prefix}_{idx}_{name_append}.json.gz"
+                output_dir, f"{base_name}_{prefix}_{idx}{suffix}.json.gz"
             )
         with gzip.open(out_path, "wb") as f:
             f.write(json.dumps(iter_trace).encode("utf-8"))

--- a/TraceLens/TraceUtils/split_inference_trace_annotation.py
+++ b/TraceLens/TraceUtils/split_inference_trace_annotation.py
@@ -293,9 +293,7 @@ def _find_repeating_period(
     return None, None, None
 
 
-def _detect_iteration_roots_from_tree(
-    tree: TraceToTree, roots
-) -> Optional[List[dict]]:
+def _detect_iteration_roots_from_tree(tree: TraceToTree, roots) -> Optional[List[dict]]:
     """BFS down the tree from one or more root nodes to find and return synthetic
     iteration-root events.
 
@@ -326,16 +324,16 @@ def _detect_iteration_roots_from_tree(
         if not any(c.get("gpu_events") for c in children):
             continue
 
-        p, _, start = _find_repeating_period(
-            [c.get("name", "") for c in children]
-        )
+        p, _, start = _find_repeating_period([c.get("name", "") for c in children])
         if p is None:
             for child in children:
                 if child.get("gpu_events"):
                     queue.append((child, depth + 1))
             continue
 
-        print(f"Generic fallback: repeating pattern found under '{current.get('name')}' at depth {depth}")
+        print(
+            f"Generic fallback: repeating pattern found under '{current.get('name')}' at depth {depth}"
+        )
         print(f"Generic fallback: period={p}")
 
         # Anchor each iteration between the Nth occurrence of the first and last
@@ -345,11 +343,13 @@ def _detect_iteration_roots_from_tree(
         last_anchor_name = children[start + p - 1]["name"]
 
         first_anchors = [
-            i for i, c in enumerate(children)
+            i
+            for i, c in enumerate(children)
             if i >= start and c.get("name") == first_anchor_name
         ]
         last_anchors = [
-            i for i, c in enumerate(children)
+            i
+            for i, c in enumerate(children)
             if i >= start and c.get("name") == last_anchor_name
         ]
 
@@ -591,7 +591,9 @@ def get_iter_details_from_name(name: str, prefix: str = "annotation_iteration") 
     # vLLM execute_..._context_..._generation_... annotations: strip parens and the
     # sq/sk shape letters to a flat token list, then pick counts by index.
     try:
-        parts = re.sub(r"[sqk]+", "_", name.replace("(", "_").replace(")", "_")).split("_")
+        parts = re.sub(r"[sqk]+", "_", name.replace("(", "_").replace(")", "_")).split(
+            "_"
+        )
         if len(parts) < 10:
             idx = (2, 3, 6, 7)
         elif len(parts) < 12:
@@ -722,8 +724,7 @@ def extract_and_save(
             )
             if is_known_annotation:
                 name_append = (
-                    root_name
-                    .replace("/", "_")
+                    root_name.replace("/", "_")
                     .replace("(", "_")
                     .replace(")", "")
                     .replace(":", "")

--- a/TraceLens/TraceUtils/split_inference_trace_annotation.py
+++ b/TraceLens/TraceUtils/split_inference_trace_annotation.py
@@ -179,6 +179,7 @@ from dataclasses import dataclass, field
 import csv
 from statistics import mean
 from TraceLens.util import DataLoader
+from TraceLens.Trace2Tree.trace_to_tree import TraceToTree
 import pandas as pd
 
 # Try to use faster JSON parser (orjson is 2-10x faster than json)
@@ -243,8 +244,8 @@ ANNOTATION_PATTERN_BACKUP = [
 def find_iteration_roots(events: List[dict]) -> Optional[List[dict]]:
     """Return iteration-root events.
 
-    Tries the primary annotation pattern first and only falls back to the
-    backup patterns when the primary matches nothing.
+    Tries the primary annotation pattern first, then backup patterns, then
+    falls back to generic call-tree traversal via Trace2Tree.
     """
     roots = find_events_by_pattern(
         events, ANNOTATION_PATTERN, "execution steps (iteration)", cat="user_annotation"
@@ -257,6 +258,166 @@ def find_iteration_roots(events: List[dict]) -> Optional[List[dict]]:
             "execution steps (iteration, backup)",
             cat="user_annotation",
         )
+    if roots is None:
+        print("No annotation patterns found; trying generic call-tree traversal...")
+        roots = find_iteration_roots_generic(events)
+    return roots
+
+
+def _find_repeating_period(
+    names: List[str], min_repeats: int = 3
+) -> Tuple[Optional[int], Optional[List[str]], Optional[int]]:
+    """Find the shortest repeating name sequence anywhere in ``names``.
+
+    Slides a start offset forward to skip any non-repeating prefix (setup
+    events before the loop body). Returns ``(period, pattern, start_offset)``
+    where ``start_offset`` is the index in ``names`` where the first block
+    begins. Returns ``(None, None, None)`` if no qualifying period is found.
+
+    Requires at least ``min_repeats`` consecutive repetitions covering more
+    than half of the suffix starting at ``start_offset``.
+    """
+    n = len(names)
+    for start in range(n):
+        suffix = names[start:]
+        m = len(suffix)
+        for p in range(1, m // 2 + 1):
+            pattern = suffix[:p]
+            count = 0
+            i = 0
+            while i + p <= m and suffix[i : i + p] == pattern:
+                count += 1
+                i += p
+            if count >= min_repeats and count * p > m * 0.5:
+                return p, pattern, start
+    return None, None, None
+
+
+def _detect_iteration_roots_from_tree(
+    tree: TraceToTree, roots
+) -> Optional[List[dict]]:
+    """BFS down the tree from one or more root nodes to find and return synthetic
+    iteration-root events.
+
+    ``roots`` may be a single event dict or a list of event dicts — all are
+    seeded into the BFS at depth 0 so they are explored level-by-level together.
+
+    Pattern detection uses only GPU-path children (dur > 1us) to avoid noise
+    from utility calls. Block boundaries are expanded to the full unfiltered
+    child list to include CPU-only events (e.g. scheduler.step) that follow
+    the GPU work within each iteration.
+
+    Returns a list of synthetic root events, one per detected iteration, where
+    each event's ``dur`` spans the full block from first to last child.
+    """
+    from collections import deque
+
+    if isinstance(roots, dict):
+        roots = [roots]
+
+    queue = deque((node, 0) for node in roots)
+    while queue:
+        current, depth = queue.popleft()
+        children = tree.get_children_events(current)
+        if not children:
+            continue
+
+        # Use GPU-path children (dur > 1us) for pattern detection to avoid noise
+        # from utility calls. Skip nodes with no qualifying children — recurse
+        # only into GPU-bearing subtrees.
+        gpu_children = [
+            c for c in children
+            if c.get("gpu_events") and c.get("dur", 0) > 1
+        ]
+        if not gpu_children:
+            continue
+
+        p, _, start = _find_repeating_period(
+            [c.get("name", "") for c in gpu_children]
+        )
+        if p is None:
+            for child in children:
+                if child.get("gpu_events"):
+                    queue.append((child, depth + 1))
+            continue
+
+        print(f"Generic fallback: repeating pattern found under '{current.get('name')}' at depth {depth}")
+
+        # Map detection indices back to the full child list so each block spans
+        # the complete iteration including CPU-only tail events.
+        first_full_idx = children.index(gpu_children[start])
+        if start + p < len(gpu_children):
+            next_iter_ts = gpu_children[start + p]["ts"]
+            last_full_idx = next(
+                (i - 1 for i, c in enumerate(children) if c["ts"] >= next_iter_ts),
+                len(children) - 1,
+            )
+        else:
+            last_full_idx = len(children) - 1
+        full_block_size = last_full_idx - first_full_idx + 1
+        full_pattern = [
+            c.get("name", "")
+            for c in children[first_full_idx : first_full_idx + full_block_size]
+        ]
+        print(f"Generic fallback: GPU-path period={p}, full block size={full_block_size}")
+
+        # Group into iteration blocks and synthesize a root event for each.
+        iteration_roots = []
+        remaining = children[first_full_idx:]
+        names = [c.get("name", "") for c in remaining]
+        i = 0
+        while i + full_block_size <= len(names):
+            if names[i : i + full_block_size] != full_pattern:
+                break
+            block = remaining[i : i + full_block_size]
+            first, last = block[0], block[-1]
+            root_event = dict(first)
+            root_event["dur"] = (last["ts"] + last.get("dur", 0)) - first["ts"]
+            iteration_roots.append(root_event)
+            i += full_block_size
+
+        print(f"Generic fallback: identified {len(iteration_roots)} iterations.")
+        return iteration_roots if iteration_roots else None
+
+    return None
+
+
+def find_iteration_roots_generic(events: List[dict]) -> Optional[List[dict]]:
+    """Fallback: detect iteration roots by finding a repeating child pattern in
+    the call tree, using Trace2Tree for parent/child relationships.
+
+    Works for any workload (diffusion, training, etc.) where the iteration loop
+    body is a repeating sequence of top-level calls under a common parent.
+    """
+    try:
+        tree = TraceToTree(events, prune_nongpu_paths=False)
+        tree.build_tree(add_python_func=True)
+    except Exception as e:
+        print(f"Generic fallback: Trace2Tree build failed ({e}), skipping.")
+        return None
+
+    # Walk every cpu_root_node upward through python_function parents until
+    # reaching a parentless node — these are the true per-thread entry points.
+    seen_roots: set = set()
+    trace_roots = []
+    for uid in tree.cpu_root_nodes:
+        e = tree.get_UID2event(uid)
+        while True:
+            parent = tree.get_parent_event(e)
+            if parent is None:
+                break
+            e = parent
+        if id(e) not in seen_roots:
+            seen_roots.add(id(e))
+            trace_roots.append(e)
+
+    if not trace_roots:
+        print("Generic fallback: no root nodes found.")
+        return None
+
+    roots = _detect_iteration_roots_from_tree(tree, trace_roots)
+    if roots is None:
+        print("Generic fallback: no repeating child pattern found.")
     return roots
 
 
@@ -427,26 +588,45 @@ def get_iter_details_from_name(name: str, prefix: str = "annotation_iteration") 
         }
 
     if "annotation_iteration" not in prefix:
-        return {"batch_size": 0}
+        # Generic workload (e.g. diffusion): treat every iteration as one
+        # decode-equivalent step so steady-state detection sees a flat line.
+        return {
+            "batch_size": 1,
+            "num_requests": 1,
+            "context_requests": 0,
+            "context_sum": 0,
+            "generation_requests": 1,
+            "generation_sum": 1,
+        }
 
     # vLLM execute_..._context_..._generation_... annotations: strip parens and the
     # sq/sk shape letters to a flat token list, then pick counts by index.
-    parts = re.sub(r"[sqk]+", "_", name.replace("(", "_").replace(")", "_")).split("_")
-    if len(parts) < 10:
-        idx = (2, 3, 6, 7)
-    elif len(parts) < 12:
-        idx = (2, 3, 7, 8)
-    else:
-        idx = (3, 5, 11, 13)
-    ctx_req, ctx_sum, gen_req, gen_sum = (int(parts[i]) for i in idx)
-    return {
-        "batch_size": ctx_sum + gen_sum,
-        "num_requests": ctx_req + gen_req,
-        "context_requests": ctx_req,
-        "context_sum": ctx_sum,
-        "generation_requests": gen_req,
-        "generation_sum": gen_sum,
-    }
+    try:
+        parts = re.sub(r"[sqk]+", "_", name.replace("(", "_").replace(")", "_")).split("_")
+        if len(parts) < 10:
+            idx = (2, 3, 6, 7)
+        elif len(parts) < 12:
+            idx = (2, 3, 7, 8)
+        else:
+            idx = (3, 5, 11, 13)
+        ctx_req, ctx_sum, gen_req, gen_sum = (int(parts[i]) for i in idx)
+        return {
+            "batch_size": ctx_sum + gen_sum,
+            "num_requests": ctx_req + gen_req,
+            "context_requests": ctx_req,
+            "context_sum": ctx_sum,
+            "generation_requests": gen_req,
+            "generation_sum": gen_sum,
+        }
+    except (ValueError, IndexError):
+        return {
+            "batch_size": 1,
+            "num_requests": 1,
+            "context_requests": 0,
+            "context_sum": 0,
+            "generation_requests": 1,
+            "generation_sum": 1,
+        }
 
 
 def find_phase_from_window(iter_details: List[dict]) -> dict:
@@ -738,7 +918,7 @@ def identify_steady_state_regions(
     if len(regions) == 0:
         delta = min(n, max(8, num_steps - n))
         start = max(0, delta // 2)
-        end = min(n, n - delta // 2)
+        end = max(start + 1, min(n, n - delta // 2))
         regions = [(start, end)]
         print(
             "Warning: no steady state region found; discarding initial/final iterations "


### PR DESCRIPTION
## Motivation

This PR adds support for splitting non-vLLM nor SGLang traces. `split_inference_trace_annotation.py` previously only supported traces from vLLM and SGLang. These frameworks annotate each execution step with a structured name (e.g. `execute_4_context_3(sq128sk256...)_generation_2(...)`) that the tool parses to identify iteration boundaries, extract per-step traces, and detect steady-state regions.

Traces from other workloads carry none of these annotations and trace splitting fails.

The goal of this change is to make the splitting and steady-state extraction pipeline work for any workload that has a repeating loop structure in its call tree, without requiring framework-specific annotation support.

## Summary

For vLLM/SGLang traces, iteration boundaries are identified by matching structured annotation names (e.g. `execute_4_context_3(...)_generation_2(...)`) injected by the framework at runtime. Each annotation event spans exactly one execution step; its `ts` and `ts + dur` define the window.

## Implementation

The tool splits a large trace into per-iteration traces by finding events that mark the start and end of each iteration, then extracting all CPU and GPU events that fall within each iteration's time window. For generic traces (this PR), iteration boundaries are identified by building a call tree with Trace2Tree and finding the shallowest node whose children form a repeating sequence. Each repeating block becomes a synthetic root event spanning from the first to the last child of that block. Once iteration roots are found — regardless of how they were detected — the same downstream pipeline of identifying the steady state windows and extracting the iterations occurs.

### Entry point: `find_iteration_roots`

The existing function tries annotation patterns in priority order. This PR adds a third tier that fires only when both the primary (vLLM 1211/1213 pattern) and backup (SGLang `step[...]` pattern) return nothing:

```
primary annotation patterns
    → backup annotation patterns
        → generic call-tree fallback (new)
```

### Finding the repeating pattern: `_detect_iteration_roots_from_tree`

The goal is to find the highest event in the call stack that has a list of children that appear in a repeating pattern. From the root, a BFS search occurs. At each event, the list of children is checked to see if it contains a meaningful pattern. The first such list of children forms the iterations.

Nodes with no GPU-bearing children are skipped entirely.

**Period detection: `_find_repeating_period`.** The full child name list is passed to this function, which finds the shortest name sequence that repeats consecutively: the iteration pattern.

It works by sliding a `start` offset forward from 0. At each `start`, it takes the sub-list `names[start:]` and tries candidate period lengths `p = 1, 2, 3, ...`. For each `p`, it treats `names[start : start + p]` as the candidate pattern and counts how many times that exact block appears back-to-back starting at `start`. A period is accepted when:

- It repeats at least 3 consecutive times (guards against coincidental repetitions in short utility call lists), and
- The repeating portion covers more than 50% of `names[start:]` (guards against a short pattern that only matches a small prefix).

The `start` offset exists to skip setup events that appear before the loop body.

For trace at `tests/traces/h100/Wan-AI_Wan2.1-T2V-1.3B-Diffusers__1016009.json.gz`, the GPU-path children of `__call__` (after skipping the setup prefix) look like:

```
to, expand, WanTransformer, do_classifier_free_guidance, WanTransformer, sub, mul, add, scheduler.step, len, tqdm::update, interrupt, __setattr__,   ← iter 0
to, expand, WanTransformer, do_classifier_free_guidance, WanTransformer, sub, mul, add, scheduler.step, len, tqdm::update, interrupt, __setattr__,   ← iter 1
...
```

The function finds `p=13` with that full 13-event sequence repeating, and returns `(13, pattern, start_offset)`.

**Iteration grouping.** Once the period and pattern are found, each iteration is bounded by the Nth occurrence of the first event in the pattern (`to`) and the Nth occurrence of the last event in the pattern (`__setattr__`).

**Synthetic root events.** Each block is converted to a synthetic root event by copying the first event in the block and overwriting its `dur` to span from `block[0].ts` to `block[-1].ts + block[-1].dur`. This is the format `extract_iteration` expects: a single event whose time window covers the full iteration.

## Testing

Validated against:

- `tests/traces/h100/Wan-AI_Wan2.1-T2V-1.3B-Diffusers__1016009.json.gz`:
Trace:
<img width="1295" height="472" alt="image" src="https://github.com/user-attachments/assets/e8d57a50-9f1d-4b92-8d5a-d11abb12f0fd" />

After splitting:
<img width="1422" height="362" alt="image" src="https://github.com/user-attachments/assets/70f0e45d-e50d-456d-b738-1871549ef5d4" />


- `tests/traces/mi300/google_owlv2-large-patch14-ensemble__1016001.json.gz`:
Trace:
<img width="1296" height="427" alt="image" src="https://github.com/user-attachments/assets/6e9fdd27-8e91-4a66-9626-415ae5facb94" />

After splitting:
<img width="1419" height="555" alt="image" src="https://github.com/user-attachments/assets/cef81a6a-a3b1-43d4-9b13-b55e36039d5c" />

- All 7 existing unit tests in `tests/test_split_inference_trace_annotation.py` continue to pass. The new fallback is only triggered when both annotation pattern tiers return nothing, so existing vLLM/SGLang behaviour is unchanged.
