### PR TITLE
Propagate standalone table cols to comparative

### DIFF
--- a/TraceLens/Agent/Analysis/utils/templates/analysis_template.md
+++ b/TraceLens/Agent/Analysis/utils/templates/analysis_template.md
@@ -367,7 +367,7 @@ communication/compute overlap). These affect the GPU pipeline as a whole.
 **Resolution:**
 **Impact estimate:**
 
-<!-- === COMPARATIVE Compute Kernel Data table === Use this schema for comparative mode ONLY. Use these 8 exact columns (Kernel Name/Path are omitted in comparative mode) -->
+<!-- === COMPARATIVE Compute Kernel Data table === Use this schema for comparative mode ONLY. Use these 10 exact columns (must match sub_agent_spec.md § Operations Table Schema) -->
 <!-- Trace 1 ms = operations[i].time_ms. Trace 2 ms = operations[i].t2_time_ms.
      Count T1/T2 = operations[i].count / operations[i].count_trace2 when present.
      Difference (ms) = operations[i].difference_ms (negative ⇒ Trace 1 slower), or —. -->
@@ -378,9 +378,9 @@ communication/compute overlap). These affect the GPU pipeline as a whole.
 **Identification:** [1-2 sentences - How this opportunity was surfaced relative to the target trace. Must end with (source: <artifact> → <keys>).]
 **Data:** [1 sentence summary of table]
 
-| Operation | Args (T1) | Trace 1 Time (ms) | Trace 2 Time (ms) | Count (T1/T2) | Difference (ms) | FLOPS/Byte (T1) | Bound (T1) |
-|-----------|-----------|-------------------|-------------------|---------------|-----------------|-----------------|------------|
-| ...       | ...       | ...               | ...               | .../...       | ...             | ...             | ...        |
+| Operation | Args (T1) | Kernel Path | Kernel Name | Trace 1 Time (ms) | Trace 2 Time (ms) | Count (T1/T2) | Difference (ms) | FLOPS/Byte (T1) | Bound (T1) |
+|-----------|-----------|-------------|-------------|-------------------|-------------------|---------------|-----------------|-----------------|------------|
+| ...       | ...       | ...         | ...         | ...               | ...               | .../...       | ...             | ...             | ...        |
 
 **Reasoning for Slowdown:** [2-3 sentences - Why Trace 1 is slower than Trace 2 for these operations as the traces show. No micro-architecture speculation.]
 **Resolution:** [1-2 sentences - Why the suggested optimization helps close the gap — not merely restating what to do.]

--- a/TraceLens/Agent/Analysis/utils/templates/sub_agent_spec.md
+++ b/TraceLens/Agent/Analysis/utils/templates/sub_agent_spec.md
@@ -178,13 +178,15 @@ inside `## Detailed Analysis` blocks.
 ### Comparative (`comparison_scope` = `comparative`)
 
 ```markdown
-| Operation | Args (T1) | Trace 1 Time (ms) | Trace 2 Time (ms) | Count (T1/T2) | Difference (ms) | FLOPS/Byte (T1) | Bound (T1) |
-|-----------|-----------|-------------------|-------------------|---------------|-----------------|-----------------|------------|
+| Operation | Args (T1) | Kernel Path | Kernel Name | Trace 1 Time (ms) | Trace 2 Time (ms) | Count (T1/T2) | Difference (ms) | FLOPS/Byte (T1) | Bound (T1) |
+|-----------|-----------|-------------|-------------|-------------------|-------------------|---------------|-----------------|-----------------|------------|
 ```
 
 **Column mappings** (all sourced from `metrics['operations']`; do **not** re-join the CSV):
 - **Operation**: `operations[i].name`. Bare op name only.
 - **Args (T1)**: `operations[i].args`. Pre-rendered shape/dtype string, already joined with `<br>` — paste verbatim. `—` when absent.
+- **Kernel Path**: `operations[i].launcher_path`. Relative Python path that launched the kernel. **Copy the value exactly as-is — do NOT truncate, shorten, or extract just the function name.** `—` when absent.
+- **Kernel Name**: `operations[i].kernel_name_trunc`. Truncated GPU kernel name(s). For multi-kernel ops, formatted as `Kernel 1: <name><br>Kernel 2: <name>`. **Copy the value exactly as-is.** `—` when absent.
 - **Trace 1 Time (ms)**: `operations[i].time_ms`
 - **Trace 2 Time (ms)**: `operations[i].t2_time_ms`. `—` when absent.
 - **Count (T1/T2)**: T1 = `operations[i].count`; T2 = `operations[i].count_trace2`. Format `T1 / T2` (use `—` for missing T2).

--- a/TraceLens/Agent/Analysis/utils/validation_utils.py
+++ b/TraceLens/Agent/Analysis/utils/validation_utils.py
@@ -42,7 +42,8 @@ _NOT_QUANTIFIABLE_SENTINEL = re.compile(
     r"not quantifiable from trace data", re.IGNORECASE
 )
 # Header matcher for the report-wide Args verbatim check (Level 3).
-_TABLE_HEADER_RE = re.compile(r"^\|.*\|\s*Args\s*\|.*\|\s*$", re.MULTILINE)
+# Matches both standalone ("Args") and comparative ("Args (T1)") column headers.
+_TABLE_HEADER_RE = re.compile(r"^\|.*\|\s*Args(?: \(T1\))?\s*\|.*\|\s*$", re.MULTILINE)
 # Mandatory columns of the compute-tier **Data:** Operations Table, in spec
 # order (sub_agent_spec.md § Operations Table Schema). Agents may append
 # extra columns at the end but must not drop or reorder these.
@@ -63,6 +64,8 @@ _COMPUTE_DATA_REQUIRED_COLS_STANDALONE = (
 _COMPUTE_DATA_REQUIRED_COLS_COMPARATIVE = (
     "Operation",
     "Args (T1)",
+    "Kernel Path",
+    "Kernel Name",
     "Trace 1 Time (ms)",
     "Trace 2 Time (ms)",
     "Count (T1/T2)",
@@ -253,9 +256,11 @@ def _scan_args_cells(content):
         if not _TABLE_HEADER_RE.match(header_line):
             continue
         cols = [c.strip() for c in header_line.strip("|").split("|")]
-        try:
+        if "Args (T1)" in cols:
+            args_col = cols.index("Args (T1)")
+        elif "Args" in cols:
             args_col = cols.index("Args")
-        except ValueError:
+        else:
             continue
         # Skip the separator row (|---|...|).
         for row_idx in range(header_idx + 2, len(lines)):
@@ -393,12 +398,16 @@ def _validate_compute_data_tables(content, findings_path, comparison_scope=None)
                 f"(sub_agent_spec.md § Operations Table Schema)"
             )
             continue
-        args_idx = _COMPUTE_DATA_REQUIRED_COLS_STANDALONE.index("Args")
-        kp_idx = _COMPUTE_DATA_REQUIRED_COLS_STANDALONE.index("Kernel Path")
-        kn_idx = _COMPUTE_DATA_REQUIRED_COLS_STANDALONE.index("Kernel Name")
+        active_cols = (
+            _COMPUTE_DATA_REQUIRED_COLS_COMPARATIVE
+            if is_comparative
+            else _COMPUTE_DATA_REQUIRED_COLS_STANDALONE
+        )
+        args_col = "Args (T1)" if is_comparative else "Args"
+        args_idx = active_cols.index(args_col)
+        kp_idx = active_cols.index("Kernel Path")
+        kn_idx = active_cols.index("Kernel Name")
         for row_line, cells in row_iter:
-            if is_comparative:
-                continue
             if valid_args and args_idx < len(cells) and cells[args_idx]:
                 if cells[args_idx] not in valid_args:
                     errors.append(


### PR DESCRIPTION
Adds the Kernel Path and Kernel Name columns to comparative tables. Fixes oversight in `validation_utils.py` that wasn't checking for `Args (T1)` column in comparative mode. It was previously only checking for `Args` column when in standalone mode. 