### PR TITLE
HL: Set idle threshold as percent

### DIFF
--- a/TraceLens/PerfModel/benchmarking/microbench_utils.py
+++ b/TraceLens/PerfModel/benchmarking/microbench_utils.py
@@ -39,7 +39,7 @@ def resolve_physical_device(logical: int) -> Tuple[int, str]:
     return logical, "identity"
 
 
-def _int_metric(value: Any, default: int = 0) -> int:
+def _int_metric(value: Any, *, default: int = 0) -> int:
     """Coerce an amdsmi metric to int; treat ``N/A`` and non-numeric as *default*."""
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         return default
@@ -51,7 +51,7 @@ def _check_amd_gpu_idle(
     dev_tag: str,
     *,
     util_threshold: int,
-    mem_threshold_mib: int,
+    mem_threshold_pct: float,
 ) -> Tuple[bool, str]:
     import amdsmi
 
@@ -70,7 +70,9 @@ def _check_amd_gpu_idle(
         util = _int_metric(activity.get("gfx_activity"))
 
         vram = amdsmi.amdsmi_get_gpu_vram_usage(device)
-        mem_mib = _int_metric(vram.get("vram_used"))
+        mem_used_mib = _int_metric(vram.get("vram_used"))
+        mem_total_mib = _int_metric(vram.get("vram_total"))
+        mem_pct = 100.0 * mem_used_mib / mem_total_mib if mem_total_mib > 0 else None
 
         other_pids: list[int] = []
         for proc in amdsmi.amdsmi_get_gpu_process_list(device):
@@ -80,18 +82,26 @@ def _check_amd_gpu_idle(
             if pid is not None and int(pid) != os.getpid():
                 other_pids.append(int(pid))
 
-        if util > util_threshold or mem_mib > mem_threshold_mib or other_pids:
+        mem_busy = mem_pct is not None and mem_pct > mem_threshold_pct
+        mem_str = (
+            f"{mem_pct:.1f}% of {mem_total_mib}MiB"
+            if mem_pct is not None
+            else "total unknown"
+        )
+        if util > util_threshold or mem_busy or other_pids:
             return False, (
-                f"amdsmi {dev_tag}: util={util}% mem={mem_mib}MiB "
-                f"other_pids={other_pids}"
+                f"amdsmi {dev_tag}: util={util}% mem={mem_used_mib}MiB "
+                f"({mem_str}) other_pids={other_pids}"
             )
-        return True, f"amdsmi {dev_tag}: idle (util={util}% mem={mem_mib}MiB)"
+        return True, (
+            f"amdsmi {dev_tag}: idle (util={util}% mem={mem_used_mib}MiB {mem_str})"
+        )
     finally:
         amdsmi.amdsmi_shut_down()
 
 
 def check_gpu_idle(
-    device: int, *, util_threshold: int = 5, mem_threshold_mib: int = 256
+    device: int, *, util_threshold: int = 5, mem_threshold_pct: float = 10.0
 ) -> Tuple[bool, str]:
     """Pre-flight idle check via amdsmi or nvidia-smi. Returns (is_idle, msg).
     Skipped (returns True) if neither library/tool is available."""
@@ -109,7 +119,7 @@ def check_gpu_idle(
                 phys,
                 dev_tag,
                 util_threshold=util_threshold,
-                mem_threshold_mib=mem_threshold_mib,
+                mem_threshold_pct=mem_threshold_pct,
             )
         except Exception as e:
             return True, f"amdsmi check skipped ({e})"
@@ -119,7 +129,7 @@ def check_gpu_idle(
             r = subprocess.run(
                 [
                     "nvidia-smi",
-                    "--query-gpu=utilization.gpu,memory.used",
+                    "--query-gpu=utilization.gpu,memory.used,memory.total",
                     "--format=csv,noheader,nounits",
                     "-i",
                     str(phys),
@@ -130,7 +140,13 @@ def check_gpu_idle(
             )
             parts = [p.strip() for p in (r.stdout or "").split(",")]
             util = int(parts[0]) if parts and parts[0].isdigit() else 0
-            mem_mib = int(parts[1]) if len(parts) > 1 and parts[1].isdigit() else 0
+            mem_used_mib = int(parts[1]) if len(parts) > 1 and parts[1].isdigit() else 0
+            mem_total_mib = (
+                int(parts[2]) if len(parts) > 2 and parts[2].isdigit() else 0
+            )
+            mem_pct = (
+                100.0 * mem_used_mib / mem_total_mib if mem_total_mib > 0 else None
+            )
             r2 = subprocess.run(
                 [
                     "nvidia-smi",
@@ -148,12 +164,20 @@ def check_gpu_idle(
                 for p in (r2.stdout or "").splitlines()
                 if p.strip() and p.strip() != str(os.getpid())
             ]
-            if util > util_threshold or mem_mib > mem_threshold_mib or other_pids:
+            mem_busy = mem_pct is not None and mem_pct > mem_threshold_pct
+            mem_str = (
+                f"{mem_pct:.1f}% of {mem_total_mib}MiB"
+                if mem_pct is not None
+                else "total unknown"
+            )
+            if util > util_threshold or mem_busy or other_pids:
                 return False, (
-                    f"nvidia-smi {dev_tag}: util={util}% mem={mem_mib}MiB "
-                    f"other_pids={other_pids}"
+                    f"nvidia-smi {dev_tag}: util={util}% mem={mem_used_mib}MiB "
+                    f"({mem_str}) other_pids={other_pids}"
                 )
-            return True, f"nvidia-smi {dev_tag}: idle (util={util}% mem={mem_mib}MiB)"
+            return True, (
+                f"nvidia-smi {dev_tag}: idle (util={util}% mem={mem_used_mib}MiB {mem_str})"
+            )
         except Exception as e:
             return True, f"nvidia-smi check skipped ({e})"
 


### PR DESCRIPTION
Previously if the GPU had VRAM usage of over 256 MB, it was flagged as not being idle. This caused issues on large systems with lots of memory where 256 MB of VRAM is very little.
Now, if the GPU's VRAM is over 10% occupied, it is flagged as not being idle.

The new python API calls to rocm-smi and nvidia-smi have been verified and tested on MI300 and B300.