### PR TITLE
docs: clarify OS requirement in compatibility matrix

### DIFF
--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -55,7 +55,7 @@ TraceLens requires the following software.
 | Component | Requirement | Notes |
 |-----------|-------------|-------|
 | Python | 3.6 or later (3.10 recommended) | `python_requires>=3.6`; the 3.10 toolchain is used for documentation and CI builds. |
-| Operating system | Linux (OS-independent core) | Report generation is not OS-specific; ROCm-based trace capture requires Linux. |
+| Operating system | N/A | TraceLens analysis and report generation are pure Python and run on any OS. Capturing ROCm-based traces requires a Linux ROCm environment; TraceLens only reads those traces afterward. |
 | TraceLens package | 0.1.0 | Installed from [github.com/AMD-AGI/TraceLens](https://github.com/AMD-AGI/TraceLens). |
 
 ### Python dependencies


### PR DESCRIPTION
## Summary
- The compatibility matrix listed the Operating system requirement as `Linux (OS-independent core)`, which is self-contradictory: it reads as "Linux is required" while also claiming OS independence.
- Replaced the cell with `N/A` and moved the nuance into the Notes column: TraceLens analysis and report generation are pure Python and run on any OS; capturing ROCm-based traces requires a Linux ROCm environment, and TraceLens only reads those traces afterward.
- Matches the `N/A` convention used elsewhere in the compatibility docs.

## Test plan
- [ ] Docs build renders the compatibility table with the updated Operating system row.
