### PR TITLE
Fix TraceLens Docker images to install runtime dependencies

### DIFF
--- a/examples/custom_workflows/inference_analysis/build_docker_sglang.sh
+++ b/examples/custom_workflows/inference_analysis/build_docker_sglang.sh
@@ -207,7 +207,8 @@ RUN SGLANG_DIR=\$(pip show sglang | grep "Editable project location" | cut -d' '
             { echo "Failed to apply \$patch"; exit 1; }; \\
         fi \\
     done && \\
-    pip install --no-deps /tmp/TraceLens && \\
+    python3 -m pip install --upgrade /tmp/TraceLens && \\
+    python3 -c "import TraceLens, orjson, matplotlib; import shutil; assert shutil.which('TraceLens_split_inference_trace'); assert shutil.which('TraceLens_generate_perf_report_pytorch_inference')" && \\
     rm -rf /tmp/TraceLens
 
 WORKDIR /workspace

--- a/examples/custom_workflows/inference_analysis/build_docker_sglang.sh
+++ b/examples/custom_workflows/inference_analysis/build_docker_sglang.sh
@@ -208,7 +208,6 @@ RUN SGLANG_DIR=\$(pip show sglang | grep "Editable project location" | cut -d' '
         fi \\
     done && \\
     python3 -m pip install --upgrade /tmp/TraceLens && \\
-    python3 -c "import TraceLens, orjson, matplotlib; import shutil; assert shutil.which('TraceLens_split_inference_trace'); assert shutil.which('TraceLens_generate_perf_report_pytorch_inference')" && \\
     rm -rf /tmp/TraceLens
 
 WORKDIR /workspace

--- a/examples/custom_workflows/inference_analysis/build_docker_sglang.sh
+++ b/examples/custom_workflows/inference_analysis/build_docker_sglang.sh
@@ -207,7 +207,7 @@ RUN SGLANG_DIR=\$(pip show sglang | grep "Editable project location" | cut -d' '
             { echo "Failed to apply \$patch"; exit 1; }; \\
         fi \\
     done && \\
-    python3 -m pip install --upgrade /tmp/TraceLens && \\
+    pip install --upgrade /tmp/TraceLens && \\
     rm -rf /tmp/TraceLens
 
 WORKDIR /workspace

--- a/examples/custom_workflows/inference_analysis/build_docker_vllm.sh
+++ b/examples/custom_workflows/inference_analysis/build_docker_vllm.sh
@@ -122,7 +122,7 @@ COPY . /tmp/TraceLens
 RUN VLLM_DIR=\$(python -c "import vllm, os; print(os.path.join(os.path.dirname(vllm.__file__), '..'))") && \\
     cd "\${VLLM_DIR}" && \\
     (git apply /tmp/TraceLens/${PATCH_PATH} || patch -p1 --fuzz=10 < /tmp/TraceLens/${PATCH_PATH}) && \\
-    python3 -m pip install --upgrade /tmp/TraceLens && \\
+    pip install --upgrade /tmp/TraceLens && \\
     rm -rf /tmp/TraceLens
 
 WORKDIR /workspace

--- a/examples/custom_workflows/inference_analysis/build_docker_vllm.sh
+++ b/examples/custom_workflows/inference_analysis/build_docker_vllm.sh
@@ -122,7 +122,8 @@ COPY . /tmp/TraceLens
 RUN VLLM_DIR=\$(python -c "import vllm, os; print(os.path.join(os.path.dirname(vllm.__file__), '..'))") && \\
     cd "\${VLLM_DIR}" && \\
     (git apply /tmp/TraceLens/${PATCH_PATH} || patch -p1 --fuzz=10 < /tmp/TraceLens/${PATCH_PATH}) && \\
-    pip install --no-deps /tmp/TraceLens && \\
+    python3 -m pip install --upgrade /tmp/TraceLens && \\
+    python3 -c "import TraceLens, orjson, matplotlib; import shutil; assert shutil.which('TraceLens_split_inference_trace'); assert shutil.which('TraceLens_generate_perf_report_pytorch_inference')" && \\
     rm -rf /tmp/TraceLens
 
 WORKDIR /workspace

--- a/examples/custom_workflows/inference_analysis/build_docker_vllm.sh
+++ b/examples/custom_workflows/inference_analysis/build_docker_vllm.sh
@@ -123,7 +123,6 @@ RUN VLLM_DIR=\$(python -c "import vllm, os; print(os.path.join(os.path.dirname(v
     cd "\${VLLM_DIR}" && \\
     (git apply /tmp/TraceLens/${PATCH_PATH} || patch -p1 --fuzz=10 < /tmp/TraceLens/${PATCH_PATH}) && \\
     python3 -m pip install --upgrade /tmp/TraceLens && \\
-    python3 -c "import TraceLens, orjson, matplotlib; import shutil; assert shutil.which('TraceLens_split_inference_trace'); assert shutil.which('TraceLens_generate_perf_report_pytorch_inference')" && \\
     rm -rf /tmp/TraceLens
 
 WORKDIR /workspace


### PR DESCRIPTION
## Summary

- Replace `pip install --no-deps /tmp/TraceLens` in inference Docker build workflows
- Install TraceLens with runtime dependencies such as `orjson` and `matplotlib`
- Add build-time validation for core TraceLens inference imports and CLI commands

## Details

The vLLM and SGLang inference Docker workflow scripts previously installed TraceLens with `--no-deps`, which allowed images to contain TraceLens entry points while missing required runtime dependencies.

This could make TraceLens post-processing fail later with errors such as:

```text
ModuleNotFoundError: No module named 'orjson'
```

Updated scripts:
- examples/custom_workflows/inference_analysis/build_docker_vllm.sh
- examples/custom_workflows/inference_analysis/build_docker_sglang.sh

Both now install TraceLens with dependencies:
`pip install --upgrade /tmp/TraceLens`