### PR TITLE
docs: fix dead docs_original link in Profiling README

### DIFF
--- a/TraceLens/Agent/Profiling/README.md
+++ b/TraceLens/Agent/Profiling/README.md
@@ -149,7 +149,7 @@ The skill parses the `case` blocks of these scripts at runtime to discover curre
 
 ## Trace Splitting and Handoff to Analysis
 
-Step 6 produces split traces in `torch_trace/trace_split/` via `TraceLens.TraceUtils.split_inference_trace_annotation`. The skill then prints (but does **not** run) a `generate_perf_report_pytorch_inference.py` command that the user can launch to feed the split traces into the [TraceLens Agent](../Analysis/README.md). See [`docs_original/Inference_analysis.md`](../../../docs_original/Inference_analysis.md) for splitting heuristics and prefill/decode mix selection.
+Step 6 produces split traces in `torch_trace/trace_split/` via `TraceLens.TraceUtils.split_inference_trace_annotation`. The skill then prints (but does **not** run) a `generate_perf_report_pytorch_inference.py` command that the user can launch to feed the split traces into the [TraceLens Agent](../Analysis/README.md). See [Generate a PyTorch inference performance report](../../../docs/how-to/generate-perf-report-pytorch-inference.md) for splitting heuristics and prefill/decode mix selection.
 
 ## Bug Reporting
 


### PR DESCRIPTION
## Summary

#824 retired the `docs_original/` directory as part of the docs migration. #823 (branched before #824 and merged just after it) reintroduced a link to `docs_original/Inference_analysis.md`, which no longer exists on `main` — leaving a dead link in `TraceLens/Agent/Profiling/README.md`.

This repoints that reference to the migrated how-to page and restores the descriptive link text.

- `docs_original/Inference_analysis.md` (deleted) -> `docs/how-to/generate-perf-report-pytorch-inference.md`

## Test plan

- [ ] Link resolves to the migrated inference how-to page
