### PR TITLE
Defer to TraceLens Core for Roofline Computation

### DIFF
--- a/TraceLens/Agent/Analysis/category_analyses/analysis_utils.py
+++ b/TraceLens/Agent/Analysis/category_analyses/analysis_utils.py
@@ -408,9 +408,12 @@ def calculate_efficiency(
     result["resolved_peak_maf"] = round(peak_maf, 2) if peak_maf else None
     result["resolved_peak_hbm_bw"] = round(peak_hbm_bw, 2) if peak_hbm_bw else None
 
-    if flops_byte:
-        balance_point = peak_maf / peak_hbm_bw
-        result["bound_type"] = "compute" if flops_byte > balance_point else "memory"
+    roofline_bound = row.get("Roofline Bound")
+    if isinstance(roofline_bound, str):
+        if roofline_bound == "COMPUTE_BOUND":
+            result["bound_type"] = "compute"
+        elif roofline_bound == "MEMORY_BOUND":
+            result["bound_type"] = "memory"
 
     if comparison_scope == "comparative":
         comparative_efficiency(result, row)


### PR DESCRIPTION
## Summary

The Analysis Agent re-derived each operation's compute/memory bound classification from `FLOPS/Byte` and a recomputed `balance_point`, duplicating the roofline decision the core perf pipeline already makes and writes to the `Roofline Bound` CSV column. This change makes `calculate_efficiency()` read that authoritative column directly, giving the classification a single owner. Net diff: 1 file, +6/−3.

## Why

The agent's `balance_point = peak_maf / peak_hbm_bw` test is algebraically identical to the core's `compute_time >= memory_time` comparison in `TreePerf/tree_perf.py`, so it was a second copy of the same ridge-point math — with its own peak-resolution path that could silently drift from the core. The core already emits the result as `Roofline Bound` (`COMPUTE_BOUND`/`MEMORY_BOUND`) into every per-category CSV the agent consumes, so the duplication was pure redundancy. Reading the column also fixes an edge case where the agent classified ops against a *fallback* peak that the core deliberately left unclassified (no resolved compute spec).

## What changed

### Python (1 file)

| File | Change |
|---|---|
| `TraceLens/Agent/Analysis/category_analyses/analysis_utils.py` | In `calculate_efficiency()`, replace the `FLOPS/Byte` vs `balance_point` derivation of `bound_type` with a direct read of the `Roofline Bound` column (`COMPUTE_BOUND`→`compute`, `MEMORY_BOUND`→`memory`, empty→`None`). |

The `resolved_peak_maf` / `resolved_peak_hbm_bw` fields and `_resolve_peak_maf()` are retained — they still feed the "X% of Y TFLOPS/TB/s" rendering in `utils/templates/sub_agent_spec.md`. The function signature is unchanged, so no callers are affected. The `efficiency.bound_type` field keeps its name, `compute`/`memory` values, and JSON location, so downstream consumers are unaffected.

## Test plan

- [x] `pytest tests/test_analysis_agent.py` — 35 passed (ROCm dev container; black 26.1.0 clean on the changed file).
- [x] Equivalence check: agent `bound_type` vs core `Roofline Bound` on a default-mode training trace — 233/233 modelled ops matched, zero compute↔memory disagreements.
- [x] End-to-end analysis runs on two traces (one default-mode, one FP4 inference-mode): freshly generated `bound_type` equals the CSV column positionally — 449/449 and 39/39, zero mismatches. Report headers, P-item sets, template markers, and headline metrics all match the prior baseline (only display-precision INFO deltas).

### Rollback

Revert the single hunk in `calculate_efficiency()` to restore the `balance_point` derivation; no data-contract or signature changes to unwind.

## Net diff

```
1 file changed, 6 insertions(+), 3 deletions(-)
```
