### PR TITLE
Prioritize TraceLens support links in the docs header

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,14 +40,14 @@ html_theme_options = {
     "header_link": False,
     "version_list_link": False,
     "nav_secondary_items": {
-        "Hyperloom": "https://rocm.docs.amd.com/projects/hyperloom/en/latest/index.html",
+        "Support": "https://github.com/AMD-AGI/TraceLens/issues/new/choose",
         "GitHub": "https://github.com/AMD-AGI/TraceLens",
         "Community": False,
         "Blogs": "https://rocm.blogs.amd.com/",
         "ROCm Developer Hub": "https://www.amd.com/en/developer/resources/rocm-hub.html",
         "Instinct™ Docs": "https://instinct.docs.amd.com/",
         "Infinity Hub": "https://www.amd.com/en/developer/resources/infinity-hub.html",
-        "Support": "https://github.com/AMD-AGI/TraceLens/issues/new/choose",
+        "Hyperloom": "https://rocm.docs.amd.com/projects/hyperloom/en/latest/index.html",
     },
     "link_main_doc": False,
 }


### PR DESCRIPTION
Reorders the documentation header so TraceLens support and project links appear first. Hyperloom remains available as a related ecosystem link at the end of the menu without implying that TraceLens is a Hyperloom component. This is a navigation-only change.

Made with [Cursor](https://cursor.com)