### PR TITLE
Prioritize TraceLens support links in the 0.1.0 docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,14 +40,14 @@ html_theme_options = {
     "header_link": False,
     "version_list_link": False,
     "nav_secondary_items": {
-        "Hyperloom": "https://rocm.docs.amd.com/projects/hyperloom/en/latest/index.html",
+        "Support": "https://github.com/AMD-AGI/TraceLens/issues/new/choose",
         "GitHub": "https://github.com/AMD-AGI/TraceLens",
         "Community": False,
         "Blogs": "https://rocm.blogs.amd.com/",
         "ROCm Developer Hub": "https://www.amd.com/en/developer/resources/rocm-hub.html",
         "Instinct™ Docs": "https://instinct.docs.amd.com/",
         "Infinity Hub": "https://www.amd.com/en/developer/resources/infinity-hub.html",
-        "Support": "https://github.com/AMD-AGI/TraceLens/issues/new/choose",
+        "Hyperloom": "https://rocm.docs.amd.com/projects/hyperloom/en/latest/index.html",
     },
     "link_main_doc": False,
 }


### PR DESCRIPTION
Backports the documentation header ordering from #844 to the 0.1.0 release branch. Support and project links appear first, while Hyperloom remains available as a related ecosystem link at the end of the menu.

Made with [Cursor](https://cursor.com)