### PR TITLE
Update Python version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.11'
         cache: 'pip'
 
     - name: Install dependencies

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install dependencies
         run: |

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,7 +15,7 @@ sphinx:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.11"
 
 python:
   install:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ See LICENSE for license information.
 [![Tests](https://github.com/AMD-AGI/TraceLens/actions/workflows/regression-tests.yml/badge.svg)](https://github.com/AMD-AGI/TraceLens/actions/workflows/regression-tests.yml)
 [![Lint](https://github.com/AMD-AGI/TraceLens/actions/workflows/lint.yml/badge.svg)](https://github.com/AMD-AGI/TraceLens/actions/workflows/lint.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
-[![Python](https://img.shields.io/badge/python-3.6%2B-blue)](setup.py)
+[![Python](https://img.shields.io/badge/python-3.11%2B-blue)](setup.py)
 
 TraceLens is a Python library for **automated performance analysis of training and inference workloads** from trace files. It reads profiler traces (PyTorch, JAX, rocprofv3) and shows you where GPU time actually goes: which kernels are slow, whether they are compute or memory bound, and where communication or idle gaps are costing you, so you can find and fix bottlenecks without hand-reading traces.
 

--- a/TraceLens/TreePerf/jax_analyses.py
+++ b/TraceLens/TreePerf/jax_analyses.py
@@ -10,14 +10,7 @@ import re
 import string
 from itertools import chain
 
-try:
-    from enum import StrEnum
-except ImportError:
-    try:
-        from backports.strenum import StrEnum
-    # fallback for Python 3.10
-    except ImportError:
-        from strenum import StrEnum
+from enum import StrEnum
 
 from .gpu_event_analyser import GPUEventAnalyser, JaxGPUEventAnalyser
 from ..PerfModel import perf_model

--- a/TraceLens/util.py
+++ b/TraceLens/util.py
@@ -15,14 +15,7 @@ import sys
 import tempfile
 from collections import defaultdict
 
-try:
-    from enum import StrEnum
-except ImportError:
-    try:
-        from backports.strenum import StrEnum
-    # fallback for Python 3.10
-    except ImportError:
-        from strenum import StrEnum
+from enum import StrEnum
 from typing import List, Dict, Callable, Iterable, Tuple, Optional
 
 logger = logging.getLogger(__name__)

--- a/setup.py
+++ b/setup.py
@@ -45,8 +45,6 @@ setup(
     install_requires=[
         "pandas",
         "tqdm",
-        'backports.strenum;python_version<"3.11"',
-        'StrEnum;python_version<"3.11"',
         "openpyxl",
         "office365-rest-python-client",
         "msal",
@@ -71,10 +69,11 @@ setup(
     url="https://github.com/AMD-AGI/TraceLens",
     classifiers=[
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.11",
         # 'License :: OSI Approved :: MIT License',
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.11",
     entry_points={
         "console_scripts": [
             "TraceLens_generate_perf_report_jax = TraceLens.Reporting.generate_perf_report_jax:main",


### PR DESCRIPTION
## Summary

Raises the supported-Python floor from **3.6** (EOL since Dec 2021) to **3.11** and removes the compatibility scaffolding that the old floor required. Because `enum.StrEnum` is in the standard library as of Python 3.11, the two backport dependencies (`backports.strenum`, `StrEnum`) and their try/except import fallbacks are now dead code and have been deleted. CI, Read the Docs, and the README badge are aligned to 3.11 to match. Net: 7 files changed, 8 insertions(+), 23 deletions(-).

## Why

The `python_requires=">=3.6"` floor forced the project to carry `StrEnum` shims for pre-3.11 interpreters — two extra install-time dependencies plus duplicated fallback import blocks in `util.py` and `jax_analyses.py`. Raising the floor to 3.11 lets the code import `StrEnum` straight from the stdlib and drops the shims entirely, with CI and docs already running 3.10 (a one-step bump to 3.11).

## What changed

### Packaging (1 file)

| File | Change |
|---|---|
| `setup.py` | `python_requires` `>=3.6` → `>=3.11`; removed the `backports.strenum` and `StrEnum` conditional (`python_version<"3.11"`) deps; added `Programming Language :: Python :: 3.11` classifier |

### Python (2 files)

| File | Change |
|---|---|
| `TraceLens/util.py` | Collapsed the `StrEnum` try/except backport fallback to a plain `from enum import StrEnum` |
| `TraceLens/TreePerf/jax_analyses.py` | Same `StrEnum` import simplification |

### CI / Docs config (4 files)

| File | Change |
|---|---|
| `.github/workflows/lint.yml` | `python-version` `3.10` → `3.11` |
| `.github/workflows/regression-tests.yml` | `python-version` `3.10` → `3.11` |
| `.readthedocs.yaml` | `tools.python` `3.10` → `3.11` |
| `README.md` | Python badge `3.6+` → `3.11+` |

## Test plan

- [x] `black --check setup.py TraceLens/util.py TraceLens/TreePerf/jax_analyses.py` — clean
- [x] Import smoke test — `TraceLens.util` and `TraceLens.TreePerf.jax_analyses` import; `StrEnum` resolves from stdlib `enum`
- [x] Regression suites pass: `test_subtract_intervals`, `test_graph_mode`, `test_kernel_launchers`, `test_call_stack_perf_report`, `test_perf_report_regression`, `test_compare_perf_reports`, `test_inference_perf_report`, `test_collective_analysis`, `test_all2allv_summary`, `test_detect_recompute`
- [x] Grep check — no remaining `backports.strenum` / `python_version<"3.11"` references, no stale `3.6` / `3.10` version pins in changed configs

## Net diff

```
7 files changed, 8 insertions(+), 23 deletions(-)
```
