### PR TITLE
Match memset with buffer fill kernels

### DIFF
--- a/TraceLens/Trace2Tree/trace_capture_merge_experimental.py
+++ b/TraceLens/Trace2Tree/trace_capture_merge_experimental.py
@@ -85,7 +85,8 @@ def _align_capture_to_graph(capture_events, graph_events):
             c_name = _capture_kernel_name(c_event)
             # Memcpy/Memset events carry no kernel arg — match when both sides agree
             if ("Memcpy" in c_event["name"] and "Memcpy" in g_name) or (
-                "Memset" in c_event["name"] and ("Memset" in g_name or "fillBuffer" in g_name)
+                "Memset" in c_event["name"]
+                and ("Memset" in g_name or "fillBuffer" in g_name)
             ):
                 aligned.append(c_event)
                 matched = True

--- a/TraceLens/Trace2Tree/trace_capture_merge_experimental.py
+++ b/TraceLens/Trace2Tree/trace_capture_merge_experimental.py
@@ -85,7 +85,7 @@ def _align_capture_to_graph(capture_events, graph_events):
             c_name = _capture_kernel_name(c_event)
             # Memcpy/Memset events carry no kernel arg — match when both sides agree
             if ("Memcpy" in c_event["name"] and "Memcpy" in g_name) or (
-                "Memset" in c_event["name"] and "Memset" in g_name
+                "Memset" in c_event["name"] and ("Memset" in g_name or "fillBuffer" in g_name)
             ):
                 aligned.append(c_event)
                 matched = True
@@ -146,7 +146,7 @@ def _stream_of(event):
 def _names_match(c_event, g_name):
     """Pair a capture dispatch to a graph kernel by name (Memcpy/Memset carry no kernel arg)."""
     if ("Memcpy" in c_event["name"] and "Memcpy" in g_name) or (
-        "Memset" in c_event["name"] and "Memset" in g_name
+        "Memset" in c_event["name"] and ("Memset" in g_name or "fillBuffer" in g_name)
     ):
         return True
     return _capture_kernel_name(c_event) == g_name


### PR DESCRIPTION
`hipMemsetAsync` is the name of the dispatcher. It can call kernels without `memset` in the name such as buffer copying kernels like `__amd_rocclr_fillBufferAligned`. `hipMemsetAsync` should be matched with these buffer copying kernels. 