### PR TITLE
Revert Python Changes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.10'
         cache: 'pip'
 
     - name: Install dependencies

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.10'
 
       - name: Install dependencies
         run: |

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,7 +15,7 @@ sphinx:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.10"
 
 python:
   install:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ See LICENSE for license information.
 [![Tests](https://github.com/AMD-AGI/TraceLens/actions/workflows/regression-tests.yml/badge.svg)](https://github.com/AMD-AGI/TraceLens/actions/workflows/regression-tests.yml)
 [![Lint](https://github.com/AMD-AGI/TraceLens/actions/workflows/lint.yml/badge.svg)](https://github.com/AMD-AGI/TraceLens/actions/workflows/lint.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
-[![Python](https://img.shields.io/badge/python-3.11%2B-blue)](setup.py)
+[![Python](https://img.shields.io/badge/python-3.6%2B-blue)](setup.py)
 
 TraceLens is a Python library for **automated performance analysis of training and inference workloads** from trace files. It reads profiler traces (PyTorch, JAX, rocprofv3) and shows you where GPU time actually goes: which kernels are slow, whether they are compute or memory bound, and where communication or idle gaps are costing you, so you can find and fix bottlenecks without hand-reading traces.
 

--- a/TraceLens/TreePerf/jax_analyses.py
+++ b/TraceLens/TreePerf/jax_analyses.py
@@ -10,7 +10,14 @@ import re
 import string
 from itertools import chain
 
-from enum import StrEnum
+try:
+    from enum import StrEnum
+except ImportError:
+    try:
+        from backports.strenum import StrEnum
+    # fallback for Python 3.10
+    except ImportError:
+        from strenum import StrEnum
 
 from .gpu_event_analyser import GPUEventAnalyser, JaxGPUEventAnalyser
 from ..PerfModel import perf_model

--- a/TraceLens/util.py
+++ b/TraceLens/util.py
@@ -15,7 +15,14 @@ import sys
 import tempfile
 from collections import defaultdict
 
-from enum import StrEnum
+try:
+    from enum import StrEnum
+except ImportError:
+    try:
+        from backports.strenum import StrEnum
+    # fallback for Python 3.10
+    except ImportError:
+        from strenum import StrEnum
 from typing import List, Dict, Callable, Iterable, Tuple, Optional
 
 logger = logging.getLogger(__name__)

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,8 @@ setup(
     install_requires=[
         "pandas",
         "tqdm",
+        'backports.strenum;python_version<"3.11"',
+        'StrEnum;python_version<"3.11"',
         "openpyxl",
         "office365-rest-python-client",
         "msal",
@@ -68,11 +70,10 @@ setup(
     url="https://github.com/AMD-AGI/TraceLens",
     classifiers=[
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.11",
         # 'License :: OSI Approved :: MIT License',
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.11",
+    python_requires=">=3.6",
     entry_points={
         "console_scripts": [
             "TraceLens_generate_perf_report_jax = TraceLens.Reporting.generate_perf_report_jax:main",


### PR DESCRIPTION
Older SGlang ROCm containers still requires python 3.10. Reverting Python version changes for now.