### PR TITLE
Add lychee gate for analysis orchestrator skill

### DIFF
--- a/.github/workflows/skills-checks.yml
+++ b/.github/workflows/skills-checks.yml
@@ -1,0 +1,27 @@
+###############################################################################
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+# Reuse the amd/skills lychee gate on federated TraceLens skills so link rot is
+# caught in this repo before the catalog nightly run.
+# See: https://github.com/amd/skills/blob/main/docs/federating-your-repo.md#catch-failures-before-nightly
+
+name: skills-checks
+
+on:
+  pull_request:
+    paths:
+      - "TraceLens/Agent/Analysis/skills/analysis-orchestrator/**"
+      - ".github/workflows/skills-checks.yml"
+  workflow_dispatch:
+
+jobs:
+  analysis-orchestrator-external-references:
+    uses: amd/skills/.github/workflows/external-reference-check.yml@main
+    with:
+      markdown_glob: "./TraceLens/Agent/Analysis/skills/analysis-orchestrator/**/*.md"
+    permissions:
+      contents: read
+      issues: write


### PR DESCRIPTION
## Summary
- Add `.github/workflows/skills-checks.yml` that reuses the canonical [amd/skills external-reference-check](https://github.com/amd/skills/blob/main/.github/workflows/external-reference-check.yml) reusable workflow
- Scope the lychee run to markdown under `TraceLens/Agent/Analysis/skills/analysis-orchestrator/`, matching the skill federated into the amd/skills catalog as `tracelens-analysis-orchestrator`
- Trigger on PRs that touch the orchestrator skill (or this workflow) and on manual dispatch, following [Federate Your Repo — Catch failures before nightly](https://github.com/amd/skills/blob/main/docs/federating-your-repo.md#catch-failures-before-nightly)

## Test plan
- [ ] `skills-checks` workflow runs on this PR (may be informational depending on branch protection)
- [ ] Broken external links in orchestrator markdown surface as a failed check


Made with [Cursor](https://cursor.com)