### PR TITLE
Add Codecov test analytics and GPU coverage flags

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -37,13 +37,23 @@ jobs:
       - name: Run unit tests
         run: |
           . .venv/bin/activate
-          python -m pytest tests/ -v --tb=short -n auto --dist loadgroup --cov=./TraceLens --cov-report=xml
+          python -m pytest tests/ -v --tb=short -n auto --dist loadgroup \
+            --cov=./TraceLens --cov-report=xml \
+            --junitxml=junit.xml -o junit_family=legacy
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: coverage.xml
+          if-no-files-found: error
+
+      - name: Upload junit report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: junit-report
+          path: junit.xml
           if-no-files-found: error
 
   codecov:
@@ -59,10 +69,27 @@ jobs:
         with:
           name: coverage-report
 
+      - name: Download junit report
+        uses: actions/download-artifact@v4
+        with:
+          name: junit-report
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
+          flags: unit
+          fail_ci_if_error: true
+          verbose: true
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: junit.xml
+          report_type: test_results
+          flags: unit
           fail_ci_if_error: true
           verbose: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -12,5 +12,19 @@ coverage:
     project: off
     patch: off
 
+comment:
+  show_carryforward_flags: true
+
+flags:
+  unit:
+    paths:
+      - TraceLens/
+    carryforward: false
+  gpu:
+    paths:
+      - TraceLens/EventReplay/
+      - TraceLens/PerfModel/benchmarking/
+    carryforward: true
+
 fixes:
   - "/__w/TraceLens/TraceLens/::"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,13 @@ import pytest
 from pandas.api.types import is_float_dtype
 
 
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "gpu: test requires a CUDA/HIP GPU (skipped in CPU-only CI)",
+    )
+
+
 def pytest_addoption(parser):
     parser.addoption(
         "--update-references",

--- a/tests/test_event_replay.py
+++ b/tests/test_event_replay.py
@@ -238,6 +238,7 @@ def compare_event_replay(perf_analyzer, list_unique_evts, verbose=False):
     return df, list_replay_ir
 
 
+@pytest.mark.gpu
 def test_resnet(full_run_trace_path=None, output_csv_path=None):
     """
     Run and profile a simple ResNet model


### PR DESCRIPTION
## Summary
- Upload JUnit test results to Codecov Test Analytics alongside coverage (flag: `unit`).
- Configure `codecov.yml` with `unit` and `gpu` flags; GPU paths carry forward when GPU CI is absent.
- Register `@pytest.mark.gpu` in `tests/conftest.py` and mark existing GPU integration test `test_resnet`.

Morning test PR branches (#909–#915) were updated to merge this infra; GPU markers were added on:
- #914 `TestMicrobenchGpuBenchmarks`
- #915 `TestEventReplayGpu`

## Test plan
- [x] Lint passes on changed Python files
- [ ] CI uploads `coverage.xml` and `junit.xml` with `flags: unit`
- [ ] Codecov Tests tab shows skipped GPU tests with skip reasons when torch/GPU unavailable


Made with [Cursor](https://cursor.com)