### PR TITLE
Add unit tests for TraceLens.Reporting

### DIFF
--- a/tests/test_compare_traces_jax_llama.py
+++ b/tests/test_compare_traces_jax_llama.py
@@ -1,0 +1,317 @@
+###############################################################################
+# Copyright (c) 2025 - 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Unit tests for TraceLens.Reporting.compare_traces_jax_llama."""
+
+import gzip
+import json
+
+import pytest
+
+from TraceLens.Reporting.compare_traces_jax_llama import (
+    Event,
+    Stats,
+    Summary,
+    classify_stage_base,
+    compute_stage_table,
+    emit_report,
+    extract_block,
+    extract_gpu_events,
+    fmt_ms,
+    fmt_us,
+    get_path,
+    infer_params,
+    is_loop_multiply_fusion,
+    mk_stats,
+    parse_range,
+    percentile,
+    pid_map,
+    summarize_one,
+    token_start_times,
+    top_stats_by_key,
+)
+
+
+def test_parse_range_valid():
+    assert parse_range("0:3") == (0, 3)
+    assert parse_range(" 1 : 8 ") == (1, 8)
+
+
+def test_parse_range_invalid():
+    with pytest.raises(ValueError, match="Bad range"):
+        parse_range("bad")
+    with pytest.raises(ValueError, match="end < start"):
+        parse_range("5:2")
+
+
+def test_percentile_and_mk_stats():
+    assert percentile([], 50) == 0.0
+    assert percentile([1.0, 2.0, 3.0, 4.0], 50) == 2.5
+    assert percentile([1.0, 2.0, 3.0], 0) == 1.0
+    assert percentile([1.0, 2.0, 3.0], 100) == 3.0
+
+    empty = mk_stats([])
+    assert empty == Stats(0, 0.0, 0.0, 0.0, 0.0)
+    stats = mk_stats([10.0, 20.0, 30.0])
+    assert stats.count == 3
+    assert stats.total_us == 60.0
+    assert stats.avg_us == 20.0
+
+
+def test_fmt_helpers():
+    assert fmt_us(1234.567) == "1,234.57"
+    assert fmt_ms(5000.0) == "5.00"
+
+
+def test_classify_stage_base_and_fusion():
+    norm = Event(1, 1, 0, 10, "ln", {"name": "/Transformer/block_0/norm_attn/x"})
+    assert classify_stage_base(norm) == "norm_attn"
+
+    q_add = Event(1, 1, 0, 5, "k", {"name": "/Transformer/block_0/attn/q/add"})
+    assert classify_stage_base(q_add) == "q_add"
+
+    post_gsu = Event(1, 1, 0, 5, "PostGSU4_kernel", {})
+    assert classify_stage_base(post_gsu) == "post_gsu"
+
+    fusion = Event(
+        1,
+        1,
+        0,
+        5,
+        "loop_multiply_fusion",
+        {"hlo_op": "loop_multiply_fusion"},
+    )
+    assert is_loop_multiply_fusion(fusion)
+
+
+def test_extract_block_and_infer_params():
+    assert extract_block("/Transformer/block_12/norm_attn/") == 12
+    assert extract_block("no block here") is None
+
+    evs = [
+        Event(
+            1,
+            1,
+            0,
+            10,
+            "ln_fwd_tuned_kernel<Kernel_traits<float, 4096u,",
+            {},
+        ),
+        Event(1, 1, 0, 5, "flash_fprop_hd128", {}),
+        Event(1, 1, 0, 5, "PostGSU2_kernel", {}),
+    ]
+    d_model, head_dim, gsu = infer_params(evs)
+    assert d_model == 4096
+    assert head_dim == 128
+    assert gsu == 2
+
+
+def _make_synthetic_trace_events(pid=1, tid=10, hint="te_layernorm_forward"):
+    events = [
+        {
+            "ph": "M",
+            "name": "process_name",
+            "pid": pid,
+            "args": {"name": "/device:GPU:0"},
+        },
+    ]
+    base_ts = 1000.0
+    for token_idx in range(2):
+        token_start = base_ts + token_idx * 5000.0
+        for block in range(2):
+            layer_start = token_start + block * 500.0
+            path_prefix = f"/Transformer/block_{block}"
+            stage_specs = [
+                (f"{path_prefix}/norm_attn/{hint}", "ln_fwd_tuned_kernel", 20.0),
+                (f"{path_prefix}/attn/q/add", "add_kernel", 5.0),
+                (f"{path_prefix}/attn/q/dot_general", "gemm_kernel", 30.0),
+                (f"{path_prefix}/attn/out/dot_general", "out_gemm", 25.0),
+                (f"{path_prefix}/norm_mlp/te_layernorm", "ln_mlp", 15.0),
+                (f"{path_prefix}/mlp/in/dot_general", "mlp_in", 40.0),
+                (f"{path_prefix}/mlp/out/dot_general", "mlp_out", 35.0),
+            ]
+            ts = layer_start
+            for path, name, dur in stage_specs:
+                events.append(
+                    {
+                        "ph": "X",
+                        "pid": pid,
+                        "tid": tid,
+                        "ts": ts,
+                        "dur": dur,
+                        "name": name,
+                        "args": {"name": path},
+                    }
+                )
+                ts += dur
+            events.append(
+                {
+                    "ph": "X",
+                    "pid": pid,
+                    "tid": tid,
+                    "ts": ts,
+                    "dur": 10.0,
+                    "name": "loop_multiply_fusion",
+                    "args": {
+                        "name": "/Transformer/swiglu",
+                        "hlo_op": "loop_multiply_fusion",
+                    },
+                }
+            )
+    return events
+
+
+def _write_gz_trace(tmp_path, hint="te_layernorm_forward"):
+    path = tmp_path / "trace.json.gz"
+    payload = {"traceEvents": _make_synthetic_trace_events(hint=hint)}
+    with gzip.open(path, "wt", encoding="utf-8") as f:
+        json.dump(payload, f)
+    return path
+
+
+def test_pid_map_and_extract_gpu_events(tmp_path):
+    path = _write_gz_trace(tmp_path)
+    with gzip.open(path, "rt", encoding="utf-8") as f:
+        trace = json.load(f)
+    mp = pid_map(trace)
+    assert "/device:GPU:0" in mp.values()
+    events = extract_gpu_events(trace, gpu_index=0)
+    assert len(events) > 0
+    assert all(isinstance(e, Event) for e in events)
+
+
+def test_token_start_times_and_compute_stage_table(tmp_path):
+    path = _write_gz_trace(tmp_path)
+    with gzip.open(path, "rt", encoding="utf-8") as f:
+        trace = json.load(f)
+    gpu_events = extract_gpu_events(trace, gpu_index=0)
+    stream = sorted(gpu_events, key=lambda e: e.ts)
+    starts = token_start_times(stream, block0_norm_hint="te_layernorm_forward")
+    assert len(starts) == 2
+
+    stage_avg, stage_share, per_layer, per_token, notes = compute_stage_table(
+        stream=stream,
+        token_starts=starts,
+        token_range=(0, 1),
+        layer_range=(0, 1),
+    )
+    assert per_layer > 0
+    assert "norm_attn" in stage_avg
+    assert abs(sum(stage_share.values()) - 1.0) < 1e-6
+    assert isinstance(notes, list)
+
+
+def test_top_stats_by_key():
+    events = [
+        Event(1, 1, 0, 10, "kernel_a", {}),
+        Event(1, 1, 0, 20, "kernel_a", {}),
+        Event(1, 1, 0, 5, "kernel_b", {}),
+    ]
+    top = top_stats_by_key(events, key_fn=lambda e: e.name, top_n=2)
+    assert top[0][0] == "kernel_a"
+    assert top[0][1].total_us == 30.0
+
+
+def test_emit_report_from_summaries():
+    stage_avg = {
+        s: float(i)
+        for i, s in enumerate(
+            [
+                "norm_attn",
+                "q_add",
+                "q_gemm",
+                "k_add",
+                "k_gemm",
+                "v_add",
+                "v_gemm",
+                "attn_core",
+                "out_gemm",
+                "norm_mlp",
+                "mlp_in_gemm",
+                "swiglu_elementwise",
+                "mlp_out_gemm",
+                "post_gsu",
+                "other",
+            ]
+        )
+    }
+    stage_share = {k: v / sum(stage_avg.values()) for k, v in stage_avg.items()}
+    base = Summary(
+        label="ROCm",
+        d_model=4096,
+        head_dim=128,
+        gsu=2,
+        gpu_index=0,
+        main_tid=10,
+        token_range=(0, 1),
+        layer_range=(0, 1),
+        per_layer_us=100.0,
+        per_token_us=200.0,
+        stage_avg_us=stage_avg,
+        stage_share=stage_share,
+        top_kernels=[("k1", mk_stats([10.0]))],
+        top_ops=[("/path/op", mk_stats([5.0]))],
+        notes=["note"],
+    )
+    cuda = Summary(
+        label="CUDA",
+        d_model=4096,
+        head_dim=128,
+        gsu=0,
+        gpu_index=0,
+        main_tid=10,
+        token_range=(0, 1),
+        layer_range=(0, 1),
+        per_layer_us=80.0,
+        per_token_us=160.0,
+        stage_avg_us={k: v * 0.8 for k, v in stage_avg.items()},
+        stage_share=stage_share,
+        top_kernels=[("k2", mk_stats([8.0]))],
+        top_ops=[("/path/op2", mk_stats([4.0]))],
+        notes=[],
+    )
+    report = emit_report(base, cuda)
+    assert "Trace Comparison" in report
+    assert "norm_attn" in report
+    assert "ROCm" in report and "CUDA" in report
+
+
+def test_summarize_one_integration(tmp_path):
+    rocm_path = _write_gz_trace(tmp_path, hint="te_layernorm_forward")
+    cuda_dir = tmp_path / "cuda"
+    cuda_dir.mkdir()
+    cuda_path = _write_gz_trace(cuda_dir, hint="te_norm_forward_ffi")
+
+    rocm = summarize_one(
+        "ROCm",
+        str(rocm_path),
+        gpu_index=0,
+        tokens=(0, 1),
+        layers=(0, 1),
+        block0_norm_hint="te_layernorm_forward",
+        top_kernels_n=3,
+        top_ops_n=3,
+    )
+    cuda = summarize_one(
+        "CUDA",
+        str(cuda_path),
+        gpu_index=0,
+        tokens=(0, 1),
+        layers=(0, 1),
+        block0_norm_hint="te_norm_forward_ffi",
+        top_kernels_n=3,
+        top_ops_n=3,
+    )
+    assert rocm.per_layer_us > 0
+    assert cuda.per_layer_us > 0
+    assert len(rocm.top_kernels) > 0
+    assert len(cuda.top_ops) > 0
+
+
+def test_get_path():
+    ev = Event(1, 1, 0, 1, "k", {"name": "/some/path"})
+    assert get_path(ev) == "/some/path"
+    assert get_path(Event(1, 1, 0, 1, "k", {})) == ""

--- a/tests/test_jax_analysis_report.py
+++ b/tests/test_jax_analysis_report.py
@@ -6,14 +6,17 @@
 
 """Unit tests for TraceLens.Reporting.generate_perf_report_jax_analysis."""
 
+import importlib
 from unittest import mock
 
 import pandas as pd
 
-from TraceLens.Reporting.generate_perf_report_jax_analysis import (
-    calculate_gpu_event_statistics,
-    generate_perf_report_jax_analysis,
+_JAX_ANALYSIS_MOD = importlib.import_module(
+    "TraceLens.Reporting.generate_perf_report_jax_analysis"
 )
+calculate_gpu_event_statistics = _JAX_ANALYSIS_MOD.calculate_gpu_event_statistics
+generate_perf_report_jax_analysis = _JAX_ANALYSIS_MOD.generate_perf_report_jax_analysis
+JaxAnalyses = _JAX_ANALYSIS_MOD.JaxAnalyses
 
 
 def _sample_averages_df():
@@ -51,8 +54,9 @@ def _mock_side_inputs():
 
 def test_calculate_gpu_event_statistics_adds_overlapped_comm():
     categorized, xla_events = _mock_side_inputs()
-    with mock.patch(
-        "TraceLens.Reporting.generate_perf_report_jax_analysis.JaxAnalyses.summarize_gpu_events",
+    with mock.patch.object(
+        JaxAnalyses,
+        "summarize_gpu_events",
         return_value=(_sample_averages_df(), categorized, xla_events),
     ):
         averages, categorized_out, xla_grouped = calculate_gpu_event_statistics(
@@ -69,14 +73,17 @@ def test_generate_perf_report_jax_analysis_writes_csvs(tmp_path):
     gemms = pd.DataFrame({"time ms": [1.0], "percent": [1.0]}, index=["gemm1"])
     gemms_detailed = pd.DataFrame({"name": ["gemm1"], "tflops": [1.0]})
 
-    with mock.patch(
-        "TraceLens.Reporting.generate_perf_report_jax_analysis.JaxAnalyses.summarize_gpu_events",
+    with mock.patch.object(
+        JaxAnalyses,
+        "summarize_gpu_events",
         return_value=(_sample_averages_df(), categorized, xla_events),
-    ), mock.patch(
-        "TraceLens.Reporting.generate_perf_report_jax_analysis.JaxAnalyses.summarize_gpu_gemm_events_from_pb",
+    ), mock.patch.object(
+        JaxAnalyses,
+        "summarize_gpu_gemm_events_from_pb",
         return_value=gemms,
-    ), mock.patch(
-        "TraceLens.Reporting.generate_perf_report_jax_analysis.JaxAnalyses.gemm_performance_from_pb",
+    ), mock.patch.object(
+        JaxAnalyses,
+        "gemm_performance_from_pb",
         return_value=gemms_detailed,
     ):
         generate_perf_report_jax_analysis(

--- a/tests/test_jax_analysis_report.py
+++ b/tests/test_jax_analysis_report.py
@@ -1,0 +1,97 @@
+###############################################################################
+# Copyright (c) 2025 - 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Unit tests for TraceLens.Reporting.generate_perf_report_jax_analysis."""
+
+from unittest import mock
+
+import pandas as pd
+
+from TraceLens.Reporting.generate_perf_report_jax_analysis import (
+    calculate_gpu_event_statistics,
+    generate_perf_report_jax_analysis,
+)
+
+
+def _sample_averages_df():
+    """Nine-row averages frame matching JaxAnalyses.summarize_gpu_events layout."""
+    return pd.DataFrame(
+        {
+            "type": [
+                "total_time",
+                "computation_time",
+                "total_comm_time",
+                "exposed_comm_time",
+                "memcpy_time",
+                "idle_time",
+                "other",
+                "overlap",
+                "misc",
+            ],
+            "time ms": [100.0, 80.0, 20.0, 5.0, 1.0, 2.0, 3.0, 4.0, 5.0],
+            "percent": [100.0] * 9,
+        }
+    )
+
+
+def _mock_side_inputs():
+    categorized = pd.DataFrame(
+        {"time ms": [10.0], "percent": [10.0]},
+        index=["gemm"],
+    )
+    xla_events = pd.DataFrame(
+        {"time ms": [5.0], "percent": [5.0]},
+        index=["dot_general_123"],
+    )
+    return categorized, xla_events
+
+
+def test_calculate_gpu_event_statistics_adds_overlapped_comm():
+    categorized, xla_events = _mock_side_inputs()
+    with mock.patch(
+        "TraceLens.Reporting.generate_perf_report_jax_analysis.JaxAnalyses.summarize_gpu_events",
+        return_value=(_sample_averages_df(), categorized, xla_events),
+    ):
+        averages, categorized_out, xla_grouped = calculate_gpu_event_statistics(
+            "/fake/profile.xplane.pb"
+        )
+
+    assert not categorized_out.empty
+    assert "short_name_grouped" in xla_grouped.columns
+    assert len(averages) == 9
+
+
+def test_generate_perf_report_jax_analysis_writes_csvs(tmp_path):
+    categorized, xla_events = _mock_side_inputs()
+    gemms = pd.DataFrame({"time ms": [1.0], "percent": [1.0]}, index=["gemm1"])
+    gemms_detailed = pd.DataFrame({"name": ["gemm1"], "tflops": [1.0]})
+
+    with mock.patch(
+        "TraceLens.Reporting.generate_perf_report_jax_analysis.JaxAnalyses.summarize_gpu_events",
+        return_value=(_sample_averages_df(), categorized, xla_events),
+    ), mock.patch(
+        "TraceLens.Reporting.generate_perf_report_jax_analysis.JaxAnalyses.summarize_gpu_gemm_events_from_pb",
+        return_value=gemms,
+    ), mock.patch(
+        "TraceLens.Reporting.generate_perf_report_jax_analysis.JaxAnalyses.gemm_performance_from_pb",
+        return_value=gemms_detailed,
+    ):
+        generate_perf_report_jax_analysis(
+            profile_xplane_pb_path="/fake/profile.xplane.pb",
+            output_path=str(tmp_path),
+            output_filename="jax_analysis",
+            output_table_formats=[".csv"],
+        )
+
+    expected = [
+        "jax_analysis_gpu_events_averages.csv",
+        "jax_analysis_gpu_events_categorized_mean.csv",
+        "jax_analysis_xla_grouped.csv",
+        "jax_analysis_gemms.csv",
+        "jax_analysis_gemms_detailed.csv",
+    ]
+    for name in expected:
+        assert (tmp_path / name).exists()

--- a/tests/test_multi_rank_collective_report.py
+++ b/tests/test_multi_rank_collective_report.py
@@ -1,0 +1,122 @@
+###############################################################################
+# Copyright (c) 2025 - 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Unit tests for generate_multi_rank_collective_report_pytorch."""
+
+import glob
+import os
+
+import pandas as pd
+import pytest
+
+from TraceLens.Reporting.generate_multi_rank_collective_report_pytorch import (
+    DEFAULT_RANK_REGEX,
+    _resolve_trace_files_glob,
+    find_trace_files,
+    generate_collective_report,
+    infer_world_size,
+)
+
+LLAMA_TRACE_DIR = "tests/traces/mi300/llama_70b_fsdp"
+
+
+def test_find_trace_files(tmp_path):
+    (tmp_path / "rank0_trace.json").write_text("{}")
+    (tmp_path / "rank1_trace.json").write_text("{}")
+    (tmp_path / "other.json").write_text("{}")
+
+    found = find_trace_files(str(tmp_path))
+    assert len(found) == 2
+    assert all("rank" in os.path.basename(p) for p in found)
+
+
+def test_infer_world_size():
+    assert infer_world_size(["a", "b", "c"]) == 3
+
+
+def test_resolve_trace_files_glob(tmp_path):
+    sub = tmp_path / "run"
+    sub.mkdir()
+    (sub / "trace_rank_0.json").write_text("{}")
+    (sub / "trace_rank_1.json").write_text("{}")
+
+    paths = _resolve_trace_files_glob(
+        str(sub / "trace_rank_*.json"),
+        world_size=2,
+        rank_regex=DEFAULT_RANK_REGEX,
+    )
+    assert len(paths) == 2
+
+
+def test_resolve_trace_files_glob_missing_ranks(tmp_path):
+    (tmp_path / "trace_rank_0.json").write_text("{}")
+    with pytest.raises(FileNotFoundError, match="Missing ranks"):
+        _resolve_trace_files_glob(
+            str(tmp_path / "trace_rank_*.json"),
+            world_size=2,
+        )
+
+
+def test_resolve_trace_files_glob_no_matches(tmp_path):
+    with pytest.raises(FileNotFoundError, match="No files matched"):
+        _resolve_trace_files_glob(str(tmp_path / "*.json"), world_size=1)
+
+
+def test_generate_collective_report_requires_world_size():
+    with pytest.raises(ValueError, match="world_size must be provided"):
+        generate_collective_report(trace_dir="/tmp", world_size=None)
+
+
+def test_generate_collective_report_exclusive_inputs():
+    with pytest.raises(ValueError, match="exactly one"):
+        generate_collective_report(
+            trace_dir="/tmp",
+            trace_glob="/tmp/*.json",
+            world_size=1,
+        )
+
+
+def test_generate_collective_report_invalid_gpus_per_node(tmp_path):
+    (tmp_path / "rank0_trace.json").write_text('{"traceEvents": []}')
+    with pytest.raises(ValueError, match="gpus_per_node"):
+        generate_collective_report(
+            trace_dir=str(tmp_path),
+            world_size=1,
+            gpus_per_node=0,
+            strict_world_size_check=False,
+        )
+
+
+def test_generate_collective_report_trace_pattern_missing_file(tmp_path):
+    pattern = str(tmp_path / "trace_rank_*.json")
+    (tmp_path / "trace_rank_0.json").write_text('{"traceEvents": []}')
+
+    with pytest.raises(FileNotFoundError, match="Expected trace file not found"):
+        generate_collective_report(trace_pattern=pattern, world_size=2)
+
+
+def test_generate_collective_report_llama_traces(tmp_path):
+    """Direct API call for coverage of generate_collective_report."""
+    if not os.path.isdir(LLAMA_TRACE_DIR):
+        pytest.skip(f"Trace dir not found: {LLAMA_TRACE_DIR}")
+
+    pattern = os.path.join(LLAMA_TRACE_DIR, "rank*_trace_no_pyfn.json.gz")
+    world_size = len(glob.glob(pattern))
+    if world_size == 0:
+        pytest.skip("No rank traces found")
+
+    out_dir = str(tmp_path / "nccl_csvs")
+    dfs = generate_collective_report(
+        trace_pattern=pattern,
+        world_size=world_size,
+        output_csvs_dir=out_dir,
+        detailed_analysis=False,
+        gpus_per_node=8,
+    )
+    assert isinstance(dfs, dict)
+    assert "nccl_summary_implicit_sync" in dfs
+    assert isinstance(dfs["nccl_summary_implicit_sync"], pd.DataFrame)
+    assert os.path.isfile(os.path.join(out_dir, "nccl_summary_implicit_sync.csv"))

--- a/tests/test_pftrace_utils.py
+++ b/tests/test_pftrace_utils.py
@@ -1,0 +1,87 @@
+###############################################################################
+# Copyright (c) 2025 - 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Unit tests for TraceLens.Reporting.pftrace_utils."""
+
+import json
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from TraceLens.Reporting.pftrace_utils import (
+    acquire_traceconv,
+    ensure_trace_json,
+    run,
+)
+
+
+def test_run_success():
+    run(["python3", "-c", "print('ok')"])
+
+
+def test_run_failure_raises():
+    with pytest.raises(RuntimeError, match="Command failed"):
+        run(["python3", "-c", "import sys; sys.exit(1)"])
+
+
+def test_ensure_trace_json_returns_json_path(tmp_path):
+    trace = tmp_path / "trace.json"
+    trace.write_text(json.dumps({"traceEvents": []}))
+    assert ensure_trace_json(str(trace)) == str(trace.resolve())
+
+
+def test_ensure_trace_json_returns_json_gz_path(tmp_path):
+    trace = tmp_path / "trace.json.gz"
+    trace.write_bytes(b"")
+    result = ensure_trace_json(str(trace))
+    assert result.endswith(".json.gz")
+
+
+def test_ensure_trace_json_unsupported_format(tmp_path):
+    bad = tmp_path / "trace.bin"
+    bad.write_bytes(b"\x00")
+    with pytest.raises(ValueError, match="Unsupported trace format"):
+        ensure_trace_json(str(bad))
+
+
+def test_acquire_traceconv_uses_preferred_path(tmp_path):
+    preferred = tmp_path / "traceconv"
+    preferred.write_text("#!/bin/sh\n")
+    preferred.chmod(0o755)
+    result = acquire_traceconv(preferred, tmp_path / "out")
+    assert result == preferred.resolve()
+
+
+def test_acquire_traceconv_uses_path(tmp_path):
+    with mock.patch("shutil.which", return_value="/usr/bin/traceconv"):
+        result = acquire_traceconv(None, tmp_path)
+    assert result == Path("/usr/bin/traceconv")
+
+
+def test_ensure_trace_json_pftrace_converts(tmp_path):
+    pftrace = tmp_path / "capture.pftrace"
+    pftrace.write_bytes(b"PFTRACE")
+    fake_traceconv = tmp_path / "traceconv"
+    fake_traceconv.write_text("#!/bin/sh\n")
+    fake_traceconv.chmod(0o755)
+
+    def fake_run(cmd, cwd=None):
+        out_json = Path(cmd[3])
+        out_json.write_text(json.dumps({"traceEvents": []}))
+
+    with mock.patch("TraceLens.Reporting.pftrace_utils.run", side_effect=fake_run):
+        result = ensure_trace_json(str(pftrace), traceconv_path=str(fake_traceconv))
+
+    assert result == str(pftrace.with_suffix(".json"))
+    assert Path(result).exists()
+
+
+def test_ensure_trace_json_missing_traceconv_raises(tmp_path):
+    pftrace = tmp_path / "capture.pftrace"
+    pftrace.write_bytes(b"PFTRACE")
+    with pytest.raises(FileNotFoundError, match="traceconv not found"):
+        ensure_trace_json(str(pftrace), traceconv_path=str(tmp_path / "missing"))

--- a/tests/test_reporting_inference_helpers.py
+++ b/tests/test_reporting_inference_helpers.py
@@ -1,0 +1,114 @@
+###############################################################################
+# Copyright (c) 2025 - 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Unit tests for helper functions in generate_perf_report_pytorch_inference."""
+
+import os
+
+import pandas as pd
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from TraceLens.Reporting.generate_perf_report_pytorch_inference import (
+    add_truncated_kernel_details,
+    get_dfs_short_kernels,
+    perf_report_sanity_check,
+    trunc_kernel_details,
+)
+
+
+def _make_sanity_check_inputs():
+    events = [
+        {"name": "kernel_a", "cat": "kernel"},
+        {"name": "kernel_b", "cat": "kernel"},
+    ]
+    df_gpu_timeline = pd.DataFrame({"type": ["computation_time"], "time ms": [0.1]})
+    df_kernel_launchers = pd.DataFrame(
+        {
+            "total_direct_kernel_time_sum": [50.0, 60.0],
+            "kernel_details_summary": [
+                [{"name": "kernel_a", "count": 1}],
+                [{"name": "kernel_b", "count": 1}],
+            ],
+        }
+    )
+    df_unified_perf = pd.DataFrame(
+        {
+            "Kernel Time (µs)_sum": [50.0, 60.0],
+            "kernel_details_summary": [
+                [{"name": "kernel_a", "count": 1}],
+                [{"name": "kernel_b", "count": 1}],
+            ],
+        }
+    )
+    return events, df_gpu_timeline, df_kernel_launchers, df_unified_perf
+
+
+def test_perf_report_sanity_check_pass():
+    events, tl, kl, up = _make_sanity_check_inputs()
+    result = perf_report_sanity_check(events, tl, kl, up)
+    assert result["kl_time_pass"]
+    assert result["up_time_pass"]
+    assert result["kl_count_pass"]
+    assert result["up_count_pass"]
+    assert result["total_gpu_events"] == 2
+
+
+def test_perf_report_sanity_check_count_mismatch():
+    events, tl, kl, up = _make_sanity_check_inputs()
+    kl.loc[0, "kernel_details_summary"] = [{"name": "kernel_a", "count": 2}]
+    result = perf_report_sanity_check(events, tl, kl, up)
+    assert not result["kl_count_pass"]
+    assert len(result["kl_mismatches"]) > 0
+
+
+def test_trunc_kernel_details():
+    row = {
+        "kernel_details": [
+            {"name": "a" * 100, "count": 1},
+            {"name": "short", "count": 2},
+        ]
+    }
+    out = trunc_kernel_details(row, "kernel_details", trunc_length=20)
+    assert len(out[0]["name"]) == 20
+    assert out[1]["name"] == "short"
+
+
+def test_add_truncated_kernel_details():
+    df = pd.DataFrame(
+        {
+            "kernel_details": [
+                [{"name": "x" * 80, "count": 1}],
+            ]
+        }
+    )
+    out = add_truncated_kernel_details(df, trunc_length=10)
+    assert "trunc_kernel_details" in out.columns
+    truncated = out.iloc[0]["trunc_kernel_details"]
+    assert len(truncated[0]["name"]) == 10
+
+
+@pytest.mark.gpu
+def test_get_dfs_short_kernels():
+    if not torch.cuda.is_available():
+        pytest.skip("Requires CUDA/HIP with at least one visible GPU")
+
+    from TraceLens import TreePerfAnalyzer
+
+    trace = os.path.join(
+        "tests",
+        "traces",
+        "mi300",
+        "Falconsai_nsfw_image_detection__1016002.json.gz",
+    )
+    if not os.path.isfile(trace):
+        pytest.skip(f"Trace not found: {trace}")
+
+    analyzer = TreePerfAnalyzer.from_file(trace)
+    df_hist, df_top = get_dfs_short_kernels(analyzer, short_kernel_threshold_us=1000)
+    assert isinstance(df_hist, pd.DataFrame)
+    assert isinstance(df_top, pd.DataFrame)

--- a/tests/test_reporting_utils.py
+++ b/tests/test_reporting_utils.py
@@ -1,0 +1,165 @@
+###############################################################################
+# Copyright (c) 2025 - 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Unit tests for TraceLens.Reporting.reporting_utils helpers."""
+
+import json
+import os
+from unittest import mock
+
+import pandas as pd
+import pytest
+
+from TraceLens.Reporting.reporting_utils import (
+    add_gpu_arch_cli_args,
+    add_node_span_columns,
+    detect_gpus_per_node,
+    export_data_df,
+    request_install,
+    resolve_gpu_arch,
+)
+
+
+def test_export_data_df_csv_and_xlsx(tmp_path):
+    df = pd.DataFrame({"a": [1.23456, 2.0], "b": [3.0, 4.567]})
+    export_data_df(
+        df,
+        tmp_path,
+        "report",
+        output_table_format=[".csv", ".xlsx"],
+        suffix="_stats",
+    )
+    csv_path = tmp_path / "report_stats.csv"
+    xlsx_path = tmp_path / "report_stats.xlsx"
+    assert csv_path.exists()
+    assert xlsx_path.exists()
+    loaded = pd.read_csv(csv_path)
+    assert list(loaded.columns) == ["a", "b"]
+    assert loaded["a"].tolist() == [1.23, 2.0]
+
+
+def test_export_data_df_verbose(tmp_path, capsys):
+    df = pd.DataFrame({"x": [1]})
+    export_data_df(
+        df,
+        tmp_path,
+        "out",
+        output_table_format=[".csv"],
+        suffix="",
+        verbose=1,
+    )
+    captured = capsys.readouterr()
+    assert "Exporting data to" in captured.out
+
+
+def test_request_install_declines_exits():
+    with mock.patch("builtins.input", return_value="n"):
+        with pytest.raises(SystemExit) as exc:
+            request_install("openpyxl")
+        assert exc.value.code == 1
+
+
+def test_request_install_accepts_and_installs():
+    with mock.patch("builtins.input", return_value="y"):
+        with mock.patch("subprocess.check_call") as mock_install:
+            request_install("openpyxl")
+    mock_install.assert_called_once()
+
+
+def test_request_install_failed_install_exits():
+    import subprocess
+
+    with mock.patch("builtins.input", return_value="y"):
+        with mock.patch(
+            "subprocess.check_call",
+            side_effect=subprocess.CalledProcessError(1, "pip"),
+        ):
+            with pytest.raises(SystemExit) as exc:
+                request_install("openpyxl")
+            assert exc.value.code == 1
+
+
+def test_add_node_span_columns_intra_node():
+    df = pd.DataFrame(
+        {
+            "rank": [0, 1, 2, 3],
+            "Process Group Ranks": ["[0, 1, 2, 3]"] * 4,
+        }
+    )
+    out = add_node_span_columns(df, gpus_per_node=4, world_size=8)
+    assert "node_id" in out.columns
+    assert "node_span" in out.columns
+    assert out["node_id"].tolist() == [0, 0, 0, 0]
+    assert (out["node_span"] == "intra_node").all()
+
+
+def test_add_node_span_columns_inter_node():
+    df = pd.DataFrame(
+        {
+            "rank": [0, 4],
+            "Process Group Ranks": [
+                "[0, 1, 2, 3, 4, 5, 6, 7]",
+                "[0, 1, 2, 3, 4, 5, 6, 7]",
+            ],
+        }
+    )
+    out = add_node_span_columns(df, gpus_per_node=4, world_size=8)
+    assert (out["node_span"] == "inter_node").all()
+    assert out["node_id"].tolist() == [0, 1]
+
+
+def test_add_node_span_columns_pg_ranks_string_formats():
+    df = pd.DataFrame({"Process Group Ranks": ["(0, 1)", "0, 2, 4"]})
+    out = add_node_span_columns(df, gpus_per_node=2, world_size=8)
+    assert set(out["node_span"].unique()) <= {"intra_node", "inter_node", "unknown"}
+
+
+def test_add_node_span_columns_empty_or_missing_columns():
+    empty = pd.DataFrame()
+    assert add_node_span_columns(empty, gpus_per_node=4).empty
+
+    no_cols = pd.DataFrame({"other": [1]})
+    result = add_node_span_columns(no_cols, gpus_per_node=4)
+    assert "node_id" not in result.columns
+
+
+def test_add_node_span_columns_invalid_gpus_per_node():
+    df = pd.DataFrame({"rank": [0]})
+    with pytest.raises(ValueError, match="gpus_per_node"):
+        add_node_span_columns(df, gpus_per_node=0)
+
+
+def test_detect_gpus_per_node_from_trace():
+    trace_path = os.path.join(
+        "tests",
+        "traces",
+        "mi300",
+        "Falconsai_nsfw_image_detection__1016002.json.gz",
+    )
+    if not os.path.isfile(trace_path):
+        pytest.skip(f"Trace not found: {trace_path}")
+    gpus = detect_gpus_per_node(trace_path)
+    assert gpus is not None
+    assert gpus > 0
+
+
+def test_detect_gpus_per_node_invalid_file():
+    assert detect_gpus_per_node("/nonexistent/trace.json") is None
+
+
+def test_add_gpu_arch_cli_args_adds_mutually_exclusive_group():
+    parser = __import__("argparse").ArgumentParser()
+    add_gpu_arch_cli_args(parser)
+    action_dests = {a.dest for a in parser._actions}
+    assert "gpu_arch_json_path" in action_dests
+    assert "gpu_arch_platform" in action_dests
+
+
+def test_resolve_gpu_arch_json_roundtrip(tmp_path):
+    arch = {"name": "test", "num_cus": 64}
+    path = tmp_path / "arch.json"
+    path.write_text(json.dumps(arch))
+    assert resolve_gpu_arch(gpu_arch_json_path=str(path)) == arch


### PR DESCRIPTION
## Summary
- Add targeted unit tests for low-coverage `TraceLens/Reporting/` modules: `compare_traces_jax_llama.py`, `generate_multi_rank_collective_report_pytorch.py`, `reporting_utils.py`, `pftrace_utils.py`, `generate_perf_report_jax_analysis.py`, and inference helpers in `generate_perf_report_pytorch_inference.py`.
- Use CPU-only synthetic fixtures and mocks where possible; reuse existing mi300 traces for collective report and GPU detection tests.
- Extend coverage without duplicating existing end-to-end perf report regression tests.

## Test plan
- [x] `pytest tests/test_reporting_utils.py tests/test_pftrace_utils.py tests/test_compare_traces_jax_llama.py tests/test_multi_rank_collective_report.py tests/test_jax_analysis_report.py tests/test_reporting_inference_helpers.py`
- [x] `black --check` and `ruff F401,F841,RET502,RET503` on changed files
- [ ] CI unit test workflow


Made with [Cursor](https://cursor.com)