### PR TITLE
Expand TraceLens code ownership to Deval and Tharun

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,8 +5,8 @@
 *                            @AMD-AGI/tracelens-code-owners
 # Stricter paths — leads must approve
 
-# TraceLens package changes require Adeem or Gabe review
-/TraceLens/                   @ajassani @gabeweisz
+# TraceLens package changes require Adeem, Gabe, Deval, or Tharun review
+/TraceLens/                   @ajassani @gabeweisz @devalshahamd @tsrikris
 
 # Agent code and evals require area owner review
 /TraceLens/Agent/             @tsrikris


### PR DESCRIPTION
## Summary
- add Deval and Tharun as code owners for top-level TraceLens package changes
- keep Adeem and Gabe as existing package owners

## Test plan
- [x] Verified the CODEOWNERS usernames already exist in repository rules
- [x] Confirmed the change is limited to `.github/CODEOWNERS`