### PR TITLE
Fix TraceEventUtils.split_by_field bug

### DIFF
--- a/TraceLens/util.py
+++ b/TraceLens/util.py
@@ -667,9 +667,10 @@ class TraceEventUtils:
     def split_by_field(
         events: List[dict], field: str, defaultKey: str = None
     ) -> Dict[str, List]:
-        return dict(
-            itertools.groupby(events, lambda event: event.get(field, defaultKey))
-        )
+        grouped = defaultdict(list)
+        for event in events:
+            grouped[event.get(field, defaultKey)].append(event)
+        return dict(grouped)
 
     # Splits metadata and non-metadata events
     # Merges metadata events into a dictionary hierarchy per process

--- a/TraceLens/util.py
+++ b/TraceLens/util.py
@@ -5,7 +5,6 @@
 ###############################################################################
 
 import contextlib
-import itertools
 import json
 import logging
 import os

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,20 @@
+###############################################################################
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Unit tests for TraceLens.util helpers."""
+
+from TraceLens.util import TraceEventUtils
+
+
+def test_trace_event_utils_split_by_field():
+    k1 = {"cat": "kernel", "i": 1}
+    c1 = {"cat": "cpu_op", "i": 2}
+    k2 = {"cat": "kernel", "i": 3}
+    grouped = TraceEventUtils.split_by_field([k1, c1, k2], "cat")
+    assert {key: list(val) for key, val in grouped.items()} == {
+        "kernel": [k1, k2],
+        "cpu_op": [c1],
+    }


### PR DESCRIPTION
### Summary

`TraceEventUtils.split_by_field` is typed to return `Dict[str, List]` — a mapping from a field value to the list of events sharing that value — but its implementation, `dict(itertools.groupby(...))`, doesn't actually honor that contract.

`itertools.groupby` only merges *adjacent* runs of equal keys, so events sharing a field value that aren't contiguous in the input list are split into separate groups; once wrapped in `dict()`, a later group with the same key silently overwrites an earlier one, dropping events. More fundamentally, building a `dict` from a `groupby` iterator requires fully consuming it before returning anything, and doing so invalidates every group's shared cursor along the way — so every value in the resulting dict is already an exhausted iterator that yields nothing when read.

There are currently no callers of this method anywhere in the codebase, so the bug is dormant, but it's a public `staticmethod` on a shared utility class and worth fixing before something starts relying on it.

For example, given non-adjacent events sharing a key:

```python
events = [
    {"cat": "kernel", "i": 1},
    {"cat": "cpu_op", "i": 2},
    {"cat": "kernel", "i": 3},   # "kernel" reappears after "cpu_op"
]
```

**Old implementation** (`dict(itertools.groupby(...))`) returns:

```python
{'kernel': <itertools._grouper object>, 'cpu_op': <itertools._grouper object>}
```

Reading those values back out yields nothing — both come back empty (`[]`) because `dict()` fully consumes `groupby` before returning, invalidating every group's iterator along the way. Even if that weren't the case, the two non-adjacent `"kernel"` events would land in separate groups (`groupby` doesn't merge them), so the second would silently overwrite the first in the dict.

**New implementation** returns:

```python
{
    'kernel': [{'cat': 'kernel', 'i': 1}, {'cat': 'kernel', 'i': 3}],
    'cpu_op': [{'cat': 'cpu_op', 'i': 2}],
}
```

Every event is preserved and correctly bucketed by its `cat` value, regardless of position in the input.

### Implementation

- `TraceLens/util.py`: Replaced the `dict(itertools.groupby(...))` one-liner in `split_by_field` with an eager loop that buckets events into a `defaultdict(list)` keyed by the field value, then converts to a plain `dict`. This preserves every event regardless of input order and returns real lists instead of exhausted iterators.

### Tests

- Added `tests/test_util.py::test_trace_event_utils_split_by_field`, which passes interleaved (non-adjacent) events sharing the same field value and asserts the returned dict contains the full, correct event lists for each key. This test fails against the old implementation and passes against the fix.