### PR TITLE
Add pre and post upstreaming support for all vLLM versions

### DIFF
--- a/TraceLens/Agent/Profiling/README.md
+++ b/TraceLens/Agent/Profiling/README.md
@@ -54,7 +54,7 @@ pip install git+https://github.com/AMD-AGI/TraceLens.git
 
 2. **Provide if prompted:**
    - Target node, conda env name, conda install path
-   - Whether the Docker image is already patched, or a vLLM version tag / SGLang GPU type to build a patched image
+   - Whether the Docker image is already patched, or a vLLM version tag / SGLang GPU type to build a patched image (nothing to build on vLLM v0.26.0+)
    - Profiling mode: targeted steady-state window (recommended) vs full benchmark
 
 3. **Results:**
@@ -134,6 +134,8 @@ The **Magpie Benchmark + Profiling** skill coordinates the entire trace-collecti
 | **SGLang** (`framework: sglang`) | `examples/custom_workflows/inference_analysis/build_docker_sglang.sh` (`--sglang-version`, `--gpu-type`) | `benchmark_serving.py` `start_step`/`num_steps` patch + `benchmark_lib.sh` `num_prompts` patch |
 
 The skill parses the `case` blocks of these scripts at runtime to discover currently supported tags.
+
+For vLLM, the two profiler options the workflow relies on — `--profiler-config.capture_torch_profiler` (graph-capture traces) and `--profiler-config.detailed_trace_annotation` (roofline annotations) — come from a TraceLens patch on **v0.14-v0.25** and from upstream vLLM on **v0.26.0 and later** ([vllm-project/vllm#37524](https://github.com/vllm-project/vllm/pull/37524)). A patched image is therefore only needed for **v0.14-v0.25**; on **v0.26.0 and later** a stock upstream image works unchanged, since this workflow never needs TraceLens inside the container — the server only writes traces, and all analysis runs on the host against the mounted output directory. The server flags are identical either way. `capture_torch_profiler` is a boolean, and traces always land in `<torch_profiler_dir>/capture_traces`.
 
 ### Profiling Modes
 

--- a/TraceLens/Agent/Profiling/skills/magpie-benchmark-profiling/reference.md
+++ b/TraceLens/Agent/Profiling/skills/magpie-benchmark-profiling/reference.md
@@ -71,11 +71,13 @@ benchmark:
 
 ### Step 1b: Check Docker Image for Profiling Patches
 
-After reading the config, ask the user whether their Docker image already includes TraceLens profiling patches. These patches are required for capturing kernel-level detail (shapes, roofline data, call stacks) in both eager and graph-mode traces.
+After reading the config, work out whether the image needs profiling patches at all. The patches only exist to expose the profiler options used in Step 2b; TraceLens itself does **not** need to be installed inside the container, because the server only writes traces and every analysis step in this workflow runs on the host against the mounted output directory.
 
-Ask:
+**For vLLM, check the version first.** Both profiler options ship in upstream vLLM from **v0.26.0** onwards ([vllm-project/vllm#37524](https://github.com/vllm-project/vllm/pull/37524)), so a stock v0.26.0+ image is ready as-is — skip the rest of this step and go to Step 2. Only **v0.14-v0.25** need a patched image.
 
-> "Does the Docker image in your config (or the default image Magpie will select) already have TraceLens profiling patches applied? If you're unsure, I can build a patched image for you."
+If the framework is SGLang, or the vLLM version is below v0.26.0 or unknown, ask:
+
+> "Does the Docker image in your config (or the default image Magpie will select) already have the profiling patches applied? If you're unsure, I can build a patched image for you."
 
 #### If the user's image is already patched
 
@@ -107,6 +109,8 @@ ssh <node> "cd <TraceLens_repo> && \
 ```
 
 Where `<version_tag>` is one of the `vXX` tags listed in the script's `case` statement.
+
+The script only carries arms for versions that still need a patch, and rejects anything newer with a message saying the options are upstream. If the user asks for a version it does not list, do not look for a workaround — tell them to run the stock upstream image for that version. The profiler flags in Step 2b are identical for patched and upstream images, so nothing else in this workflow changes.
 
 **For SGLang (`framework: sglang`):**
 
@@ -184,13 +188,13 @@ Add these flags to `EXTRA_VLLM_ARGS` in the user's YAML config (append to any ex
 ```yaml
 benchmark:
   envs:
-    EXTRA_VLLM_ARGS: "... --profiler-config.capture_torch_profiler_dir /workspace/torch_trace/capture_traces --profiler-config.detailed_trace_annotation True"
+    EXTRA_VLLM_ARGS: "... --profiler-config.capture_torch_profiler True --profiler-config.detailed_trace_annotation True"
 ```
 
-Use the literal path `/workspace/torch_trace/capture_traces` rather than `${TRACE_DIR}/capture_traces`. Bash does not recursively expand variables — `$EXTRA_VLLM_ARGS` is word-split but its contents are not re-evaluated for variable references, so `${TRACE_DIR}` would be passed as a literal string to vLLM. For `--run-mode local`, replace `/workspace/torch_trace` with the actual host-side trace directory.
-
-- `--profiler-config.capture_torch_profiler_dir /workspace/torch_trace/capture_traces` — enables graph-capture tracing. vLLM writes separate traces for CUDA graph capture phases into this directory, which are needed for downstream TraceLens analysis of graph-replayed operations.
+- `--profiler-config.capture_torch_profiler True` — enables graph-capture tracing. vLLM writes separate traces for the CUDA graph capture phases into `<torch_profiler_dir>/capture_traces` (i.e. `/workspace/torch_trace/capture_traces` under Magpie's container mount), which are needed for downstream TraceLens analysis of graph-replayed operations.
 - `--profiler-config.detailed_trace_annotation True` — enables detailed annotations in the trace (iteration boundaries, phase labels, scheduling metadata). These annotations are required by `split_inference_trace_annotation` for accurate trace splitting.
+
+Both flags take the same form on every supported version: they come from the TraceLens patch on vLLM **v0.14-v0.25** and from upstream vLLM on **v0.26.0 and later**.
 
 ##### Common SGLang flags
 
@@ -334,7 +338,7 @@ Replace `10` with a different multiplier if the user requests it. Without this f
 ##### Option B: Profile the entire benchmark
 
 Do **not** add `start_step`/`delay_iterations` args or increase `num_prompts`. The common flags from the shared section above **still apply** and must be present:
-- **vLLM:** No `delay_iterations` / `max_iterations` — the profiler captures everything from start to finish. The common vLLM flags (`capture_torch_profiler_dir`, `detailed_trace_annotation`) must be in `EXTRA_VLLM_ARGS`.
+- **vLLM:** No `delay_iterations` / `max_iterations` — the profiler captures everything from start to finish. The common vLLM flags (`capture_torch_profiler`, `detailed_trace_annotation`) must be in `EXTRA_VLLM_ARGS`.
 - **SGLang:** `num_steps` stays at `1` (or user can manually increase it without setting `start_step`). The common SGLang flags (env vars `SGLANG_PROFILE_WITH_STACK`/`SGLANG_PROFILE_RECORD_SHAPE`, `EXTRA_SGLANG_ARGS` with graph-capture flags, and the `shape_discovery`/`roofline_annotations` patch to `benchmark_serving.py`) must all be applied.
 - `num_prompts` stays at `CONC` — keeps the trace to a manageable size since every iteration is profiled.
 

--- a/docs/how-to/generate-perf-report-pytorch-inference.md
+++ b/docs/how-to/generate-perf-report-pytorch-inference.md
@@ -87,6 +87,12 @@ image and patch file automatically:
 | `v22` | `vllm/vllm-openai-rocm:v0.22.0` | v0.22.0 | `config_vllm_v0.22.0.patch` |
 | `v23` | `vllm/vllm-openai-rocm:v0.23.0` | v0.23.0 | `config_vllm_v0.23.0.patch` |
 | `v24` | `vllm/vllm-openai-rocm:v0.24.0` | v0.24.0 | `config_vllm_v0.24.0.patch` |
+| `v25` | `vllm/vllm-openai-rocm:v0.25.0` | v0.25.0 | `config_vllm_v0.25.0.patch` |
+
+```{note}
+The profiler options these patches add
+([vllm-project/vllm#37524](https://github.com/vllm-project/vllm/pull/37524)) were merged into upstream vLLM and ship in **v0.26.0 and later**, so those versions need no patched image at all.
+```
 
 ```bash
 bash examples/custom_workflows/inference_analysis/build_docker_vllm.sh \
@@ -192,12 +198,14 @@ To apply them:
 
 #### Trace collection flags
 
-**vLLM.** The `config_vllm_v*.patch` patches (available for v0.14-v0.24) add two
-`ProfilerConfig` flags. Pass them as server arguments:
+**vLLM.** Two `ProfilerConfig` flags control graph-capture tracing and roofline
+annotations. They are added by the `config_vllm_v*.patch` patches on **v0.14-v0.25**
+and are built into upstream vLLM from **v0.26.0** onwards. Pass them as server
+arguments:
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--profiler-config.capture_torch_profiler_dir DIR` | `str` | `""` | Directory where a profiler trace of the HIP/CUDA-graph capture phase is saved (rank 0 only). Requires `--profiler-config.profiler torch`. Leave empty to disable graph-capture profiling. |
+| `--profiler-config.capture_torch_profiler` | `bool` | `False` | When `True`, a profiler trace of the HIP/CUDA-graph capture phase is written (rank 0 only) to a `capture_traces` subdirectory of `--profiler-config.torch_profiler_dir`. Requires `--profiler-config.profiler torch`. |
 | `--profiler-config.detailed_trace_annotation` | `bool` | `False` | When `True`, execution-step annotations include roofline metrics (`sk`, `sqsq`, `sqsk`) for context and generation requests. When `False`, annotations record only request and token counts. Enable for full roofline analysis. |
 
 Example - enable both flags alongside a steady-state window profile:
@@ -205,7 +213,7 @@ Example - enable both flags alongside a steady-state window profile:
 ```bash
 --profiler-config.profiler torch \
 --profiler-config.torch_profiler_dir /workspace/torch_trace \
---profiler-config.capture_torch_profiler_dir /workspace/torch_trace/capture_traces \
+--profiler-config.capture_torch_profiler True \
 --profiler-config.detailed_trace_annotation True \
 --profiler-config.delay_iterations 5402 \
 --profiler-config.max_iterations 256 \
@@ -213,8 +221,16 @@ Example - enable both flags alongside a steady-state window profile:
 ```
 
 ```{note}
-`capture_torch_profiler_dir` is only available when `--profiler-config.profiler torch`
-is set. The capture trace is written once at server startup during HIP/CUDA-graph
+`capture_torch_profiler` is a boolean switch, not a path: the capture directory is
+always `<torch_profiler_dir>/capture_traces`. Earlier TraceLens releases exposed
+this as `capture_torch_profiler_dir DIR`, which took the destination directory
+explicitly; that name no longer exists in any patch or in upstream vLLM, so update
+older command lines to the boolean form. The flag is only available when
+`--profiler-config.profiler torch` is set.
+```
+
+```{note}
+The capture trace is written once at server startup during HIP/CUDA-graph
 construction; the steady-state replay trace is written to `torch_profiler_dir`
 during the benchmark. Pass both paths to the report generator using
 `--capture_folder` and `--profile_json_path` respectively.

--- a/examples/custom_workflows/inference_analysis/build_docker_vllm.sh
+++ b/examples/custom_workflows/inference_analysis/build_docker_vllm.sh
@@ -10,8 +10,13 @@ set -e
 usage() {
     echo "Usage: $0 <vllm-version> <path-to-TraceLens> [--base-image <image>] [docker build args...]"
     echo ""
-    echo "  vllm-version    One of: v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24 (shorthand for v0.14.0, v0.15.0, v0.16.0, v0.17.0, v0.18.0, v0.19.0, v0.20.0, v0.21.0, v0.22.0, v0.23.0, v0.24.0)"
+    echo "  vllm-version    One of: v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25 (shorthand for v0.14.0 ... v0.25.0)"
     echo "  --base-image    Override the default base Docker image for the selected vllm version"
+    echo ""
+    echo "  Each version applies the matching vllm_patches/config_vllm_*.patch, which adds the"
+    echo "  profiler_config.capture_torch_profiler and profiler_config.detailed_trace_annotation"
+    echo "  options. vLLM v0.26.0 and later ship both options upstream, so they need no image"
+    echo "  from this script - run a stock upstream image and analyse the traces on the host."
     echo ""
     echo "Examples:"
     echo "  $0 v14 /home/user/TraceLens -t tracelens-vllm"
@@ -72,9 +77,16 @@ case "${VLLM_VERSION}" in
         BASE_IMAGE="vllm/vllm-openai-rocm:v0.24.0"
         PATCH_FILE="config_vllm_v0.24.0.patch"
         ;;
+    v25)
+        BASE_IMAGE="vllm/vllm-openai-rocm:v0.25.0"
+        PATCH_FILE="config_vllm_v0.25.0.patch"
+        ;;
     *)
         echo "Error: unsupported vllm version '${VLLM_VERSION}'"
-        echo "Supported versions: v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24"
+        echo "Supported versions: v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25"
+        echo ""
+        echo "vLLM v0.26.0 and later ship capture_torch_profiler and detailed_trace_annotation"
+        echo "upstream, so no patched image is needed: run a stock upstream image."
         exit 1
         ;;
 esac
@@ -102,8 +114,8 @@ if [ -n "${CUSTOM_BASE_IMAGE}" ]; then
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PATCH_PATH="examples/custom_workflows/inference_analysis/vllm_patches/${PATCH_FILE}"
 
+PATCH_PATH="examples/custom_workflows/inference_analysis/vllm_patches/${PATCH_FILE}"
 if [ ! -f "${TRACELENS_REPO}/${PATCH_PATH}" ]; then
     echo "Error: patch file not found: ${TRACELENS_REPO}/${PATCH_PATH}"
     exit 1

--- a/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.14.0.patch
+++ b/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.14.0.patch
@@ -1,15 +1,15 @@
 diff --git a/vllm/config/profiler.py b/vllm/config/profiler.py
-index 76cc546f3..74a021f10 100644
+index 76cc546..d4c019d 100644
 --- a/vllm/config/profiler.py
 +++ b/vllm/config/profiler.py
 @@ -53,6 +53,17 @@ class ProfilerConfig:
      """If `True`, enables memory profiling in the torch profiler.
      Disabled by default."""
  
-+    capture_torch_profiler_dir: str = ""
-+    """Directory to save profiler traces captured during CUDA graph capture.
-+    If set and non-empty, a torch profiler will be enabled during graph capture
-+    on rank 0. Must be an absolute path."""
++    capture_torch_profiler: bool = False
++    """If `True`, enables a torch profiler during CUDA graph capture on rank 0.
++    Traces are saved to a `capture_traces` subdirectory under `torch_profiler_dir`.
++    Requires `profiler` to be set to 'torch'."""
 +
 +    detailed_trace_annotation: bool = False
 +    """If `True`, uses detailed annotations with roofline metrics (sk, sqsq,
@@ -20,29 +20,19 @@ index 76cc546f3..74a021f10 100644
      ignore_frontend: bool = False
      """If `True`, disables the front-end profiling of AsyncLLM when using the 
      'torch' profiler. This is needed to reduce overhead when using delay/limit options,
-@@ -196,4 +207,20 @@ class ProfilerConfig:
+@@ -196,4 +207,10 @@ class ProfilerConfig:
                      os.path.expanduser(profiler_dir)
                  )
  
-+        capture_dir = self.capture_torch_profiler_dir
-+        if capture_dir and self.profiler != "torch":
++        if self.capture_torch_profiler and self.profiler != "torch":
 +            raise ValueError(
-+                "capture_torch_profiler_dir is only applicable when profiler is set to 'torch'"
++                "capture_torch_profiler is only applicable when profiler is "
++                "set to 'torch'"
 +            )
-+        if capture_dir:
-+            is_capture_gs_path = (
-+                capture_dir.startswith("gs://")
-+                and capture_dir[5:]
-+                and capture_dir[5] != "/"
-+            )
-+            if not is_capture_gs_path:
-+                self.capture_torch_profiler_dir = os.path.abspath(
-+                    os.path.expanduser(capture_dir)
-+                )
 +
          return self
 diff --git a/vllm/v1/worker/gpu_model_runner.py b/vllm/v1/worker/gpu_model_runner.py
-index 525ad5db4..bb182e02e 100644
+index 525ad5d..742a1e9 100644
 --- a/vllm/v1/worker/gpu_model_runner.py
 +++ b/vllm/v1/worker/gpu_model_runner.py
 @@ -7,7 +7,7 @@ import itertools
@@ -62,7 +52,7 @@ index 525ad5db4..bb182e02e 100644
 +        # Setup torch profiler for graph capture traces (conditional)
 +        from vllm.distributed.parallel_state import get_world_group
 +        local_rank = get_world_group().local_rank
-+        enable_profiler = (local_rank == 0) and self.vllm_config.profiler_config.capture_torch_profiler_dir
++        enable_profiler = (local_rank == 0) and self.vllm_config.profiler_config.capture_torch_profiler
 +
 +        if enable_profiler:
 +            trace_dir = self.vllm_config.profiler_config.torch_profiler_dir + "/capture_traces"
@@ -145,7 +135,7 @@ index 525ad5db4..bb182e02e 100644
  
      def initialize_attn_backend(self, kv_cache_config: KVCacheConfig) -> None:
 diff --git a/vllm/v1/worker/gpu_worker.py b/vllm/v1/worker/gpu_worker.py
-index 562664524..d92867007 100644
+index 5626645..d928670 100644
 --- a/vllm/v1/worker/gpu_worker.py
 +++ b/vllm/v1/worker/gpu_worker.py
 @@ -556,19 +556,87 @@ class Worker(WorkerBase):

--- a/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.15.0.patch
+++ b/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.15.0.patch
@@ -1,14 +1,15 @@
 diff --git a/vllm/config/profiler.py b/vllm/config/profiler.py
+index e3cedf3..ead6dd7 100644
 --- a/vllm/config/profiler.py
 +++ b/vllm/config/profiler.py
-@@ -67,6 +67,17 @@
+@@ -67,6 +67,17 @@ class ProfilerConfig:
      """If `True`, enables memory profiling in the torch profiler.
      Disabled by default."""
  
-+    capture_torch_profiler_dir: str = ""
-+    """Directory to save profiler traces captured during CUDA graph capture.
-+    If set and non-empty, a torch profiler will be enabled during graph capture
-+    on rank 0. Must be an absolute path."""
++    capture_torch_profiler: bool = False
++    """If `True`, enables a torch profiler during CUDA graph capture on rank 0.
++    Traces are saved to a `capture_traces` subdirectory under `torch_profiler_dir`.
++    Requires `profiler` to be set to 'torch'."""
 +
 +    detailed_trace_annotation: bool = False
 +    """If `True`, uses detailed annotations with roofline metrics (sk, sqsq,
@@ -19,24 +20,19 @@ diff --git a/vllm/config/profiler.py b/vllm/config/profiler.py
      ignore_frontend: bool = False
      """If `True`, disables the front-end profiling of AsyncLLM when using the
      'torch' profiler. This is needed to reduce overhead when using delay/limit options,
-@@ -204,4 +215,14 @@
+@@ -204,4 +215,10 @@ class ProfilerConfig:
          if profiler_dir and not _is_uri_path(profiler_dir):
              self.torch_profiler_dir = os.path.abspath(os.path.expanduser(profiler_dir))
  
-+        capture_dir = self.capture_torch_profiler_dir
-+        if capture_dir and self.profiler != "torch":
++        if self.capture_torch_profiler and self.profiler != "torch":
 +            raise ValueError(
-+                "capture_torch_profiler_dir is only applicable when profiler is set to 'torch'"
-+            )
-+        if capture_dir and not _is_uri_path(capture_dir):
-+            self.capture_torch_profiler_dir = os.path.abspath(
-+                os.path.expanduser(capture_dir)
++                "capture_torch_profiler is only applicable when profiler is "
++                "set to 'torch'"
 +            )
 +
          return self
-
 diff --git a/vllm/v1/worker/gpu_model_runner.py b/vllm/v1/worker/gpu_model_runner.py
-index 64f6263cc..9eb356b5f 100644
+index 64f6263..15782ab 100644
 --- a/vllm/v1/worker/gpu_model_runner.py
 +++ b/vllm/v1/worker/gpu_model_runner.py
 @@ -8,7 +8,7 @@ import threading
@@ -56,7 +52,7 @@ index 64f6263cc..9eb356b5f 100644
 +        # Setup torch profiler for graph capture traces (conditional)
 +        from vllm.distributed.parallel_state import get_world_group
 +        local_rank = get_world_group().local_rank
-+        enable_profiler = (local_rank == 0) and self.vllm_config.profiler_config.capture_torch_profiler_dir
++        enable_profiler = (local_rank == 0) and self.vllm_config.profiler_config.capture_torch_profiler
 +        
 +        if enable_profiler:
 +            trace_dir = self.vllm_config.profiler_config.torch_profiler_dir + "/capture_traces"
@@ -128,7 +124,7 @@ index 64f6263cc..9eb356b5f 100644
  
      def initialize_attn_backend(self, kv_cache_config: KVCacheConfig) -> None:
 diff --git a/vllm/v1/worker/gpu_worker.py b/vllm/v1/worker/gpu_worker.py
-index 4c02c0598..ddae9dace 100644
+index 4c02c05..ddae9da 100644
 --- a/vllm/v1/worker/gpu_worker.py
 +++ b/vllm/v1/worker/gpu_worker.py
 @@ -557,19 +557,87 @@ class Worker(WorkerBase):

--- a/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.16.0.patch
+++ b/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.16.0.patch
@@ -1,14 +1,15 @@
 diff --git a/vllm/config/profiler.py b/vllm/config/profiler.py
+index b3b8844..5394344 100644
 --- a/vllm/config/profiler.py
 +++ b/vllm/config/profiler.py
-@@ -64,6 +64,17 @@
+@@ -64,6 +64,17 @@ class ProfilerConfig:
      """If `True`, enables memory profiling in the torch profiler.
      Disabled by default."""
  
-+    capture_torch_profiler_dir: str = ""
-+    """Directory to save profiler traces captured during CUDA graph capture.
-+    If set and non-empty, a torch profiler will be enabled during graph capture
-+    on rank 0. Must be an absolute path."""
++    capture_torch_profiler: bool = False
++    """If `True`, enables a torch profiler during CUDA graph capture on rank 0.
++    Traces are saved to a `capture_traces` subdirectory under `torch_profiler_dir`.
++    Requires `profiler` to be set to 'torch'."""
 +
 +    detailed_trace_annotation: bool = False
 +    """If `True`, uses detailed annotations with roofline metrics (sk, sqsq,
@@ -19,24 +20,19 @@ diff --git a/vllm/config/profiler.py b/vllm/config/profiler.py
      ignore_frontend: bool = False
      """If `True`, disables the front-end profiling of AsyncLLM when using the
      'torch' profiler. This is needed to reduce overhead when using delay/limit options,
-@@ -121,4 +132,14 @@
+@@ -121,4 +132,10 @@ class ProfilerConfig:
          if profiler_dir and not _is_uri_path(profiler_dir):
              self.torch_profiler_dir = os.path.abspath(os.path.expanduser(profiler_dir))
  
-+        capture_dir = self.capture_torch_profiler_dir
-+        if capture_dir and self.profiler != "torch":
++        if self.capture_torch_profiler and self.profiler != "torch":
 +            raise ValueError(
-+                "capture_torch_profiler_dir is only applicable when profiler is set to 'torch'"
-+            )
-+        if capture_dir and not _is_uri_path(capture_dir):
-+            self.capture_torch_profiler_dir = os.path.abspath(
-+                os.path.expanduser(capture_dir)
++                "capture_torch_profiler is only applicable when profiler is "
++                "set to 'torch'"
 +            )
 +
          return self
-
 diff --git a/vllm/v1/worker/gpu_model_runner.py b/vllm/v1/worker/gpu_model_runner.py
-index a7c2a8800..4b2e16fbc 100644
+index a7c2a88..05d040c 100644
 --- a/vllm/v1/worker/gpu_model_runner.py
 +++ b/vllm/v1/worker/gpu_model_runner.py
 @@ -8,7 +8,7 @@ import threading
@@ -56,7 +52,7 @@ index a7c2a8800..4b2e16fbc 100644
 +        # Setup torch profiler for graph capture traces (conditional)
 +        from vllm.distributed.parallel_state import get_world_group
 +        local_rank = get_world_group().local_rank
-+        enable_profiler = (local_rank == 0) and self.vllm_config.profiler_config.capture_torch_profiler_dir
++        enable_profiler = (local_rank == 0) and self.vllm_config.profiler_config.capture_torch_profiler
 +        
 +        if enable_profiler:
 +            trace_dir = self.vllm_config.profiler_config.torch_profiler_dir + "/capture_traces"
@@ -125,7 +121,7 @@ index a7c2a8800..4b2e16fbc 100644
  
      def initialize_attn_backend(self, kv_cache_config: KVCacheConfig) -> None:
 diff --git a/vllm/v1/worker/gpu_worker.py b/vllm/v1/worker/gpu_worker.py
-index 969627170..110d174ce 100644
+index 9696271..110d174 100644
 --- a/vllm/v1/worker/gpu_worker.py
 +++ b/vllm/v1/worker/gpu_worker.py
 @@ -579,19 +579,87 @@ class Worker(WorkerBase):

--- a/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.17.0.patch
+++ b/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.17.0.patch
@@ -1,15 +1,15 @@
 diff --git a/vllm/config/profiler.py b/vllm/config/profiler.py
-index b3b8844f7..3c80d91a3 100644
+index b3b8844..5394344 100644
 --- a/vllm/config/profiler.py
 +++ b/vllm/config/profiler.py
 @@ -64,6 +64,17 @@ class ProfilerConfig:
      """If `True`, enables memory profiling in the torch profiler.
      Disabled by default."""
  
-+    capture_torch_profiler_dir: str = ""
-+    """Directory to save profiler traces captured during CUDA graph capture.
-+    If set and non-empty, a torch profiler will be enabled during graph capture
-+    on rank 0. Must be an absolute path."""
++    capture_torch_profiler: bool = False
++    """If `True`, enables a torch profiler during CUDA graph capture on rank 0.
++    Traces are saved to a `capture_traces` subdirectory under `torch_profiler_dir`.
++    Requires `profiler` to be set to 'torch'."""
 +
 +    detailed_trace_annotation: bool = False
 +    """If `True`, uses detailed annotations with roofline metrics (sk, sqsq,
@@ -20,23 +20,19 @@ index b3b8844f7..3c80d91a3 100644
      ignore_frontend: bool = False
      """If `True`, disables the front-end profiling of AsyncLLM when using the
      'torch' profiler. This is needed to reduce overhead when using delay/limit options,
-@@ -121,4 +132,14 @@ class ProfilerConfig:
+@@ -121,4 +132,10 @@ class ProfilerConfig:
          if profiler_dir and not _is_uri_path(profiler_dir):
              self.torch_profiler_dir = os.path.abspath(os.path.expanduser(profiler_dir))
  
-+        capture_dir = self.capture_torch_profiler_dir
-+        if capture_dir and self.profiler != "torch":
++        if self.capture_torch_profiler and self.profiler != "torch":
 +            raise ValueError(
-+                "capture_torch_profiler_dir is only applicable when profiler is set to 'torch'"
-+            )
-+        if capture_dir and not _is_uri_path(capture_dir):
-+            self.capture_torch_profiler_dir = os.path.abspath(
-+                os.path.expanduser(capture_dir)
++                "capture_torch_profiler is only applicable when profiler is "
++                "set to 'torch'"
 +            )
 +
          return self
 diff --git a/vllm/v1/worker/gpu_model_runner.py b/vllm/v1/worker/gpu_model_runner.py
-index e4ddefc81..3942904f9 100644
+index e4ddefc..44b76ec 100644
 --- a/vllm/v1/worker/gpu_model_runner.py
 +++ b/vllm/v1/worker/gpu_model_runner.py
 @@ -8,7 +8,7 @@ import threading
@@ -56,7 +52,7 @@ index e4ddefc81..3942904f9 100644
 +        # Setup torch profiler for graph capture traces (conditional)
 +        from vllm.distributed.parallel_state import get_world_group
 +        local_rank = get_world_group().local_rank
-+        enable_profiler = (local_rank == 0) and self.vllm_config.profiler_config.capture_torch_profiler_dir
++        enable_profiler = (local_rank == 0) and self.vllm_config.profiler_config.capture_torch_profiler
 +        
 +        if enable_profiler:
 +            trace_dir = self.vllm_config.profiler_config.torch_profiler_dir + "/capture_traces"
@@ -125,7 +121,7 @@ index e4ddefc81..3942904f9 100644
  
      def initialize_attn_backend(self, kv_cache_config: KVCacheConfig) -> None:
 diff --git a/vllm/v1/worker/gpu_worker.py b/vllm/v1/worker/gpu_worker.py
-index c0654abd5..89f429147 100644
+index c0654ab..89f4291 100644
 --- a/vllm/v1/worker/gpu_worker.py
 +++ b/vllm/v1/worker/gpu_worker.py
 @@ -635,19 +635,87 @@ class Worker(WorkerBase):

--- a/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.18.0.patch
+++ b/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.18.0.patch
@@ -1,15 +1,15 @@
 diff --git a/vllm/config/profiler.py b/vllm/config/profiler.py
-index 6a40b9dad..c2f32a485 100644
+index 6a40b9d..89bb817 100644
 --- a/vllm/config/profiler.py
 +++ b/vllm/config/profiler.py
 @@ -66,6 +66,17 @@ class ProfilerConfig:
      """If `True`, enables memory profiling in the torch profiler.
      Disabled by default."""
  
-+    capture_torch_profiler_dir: str = ""
-+    """Directory to save profiler traces captured during CUDA graph capture.
-+    If set and non-empty, a torch profiler will be enabled during graph capture
-+    on rank 0. Must be an absolute path."""
++    capture_torch_profiler: bool = False
++    """If `True`, enables a torch profiler during CUDA graph capture on rank 0.
++    Traces are saved to a `capture_traces` subdirectory under `torch_profiler_dir`.
++    Requires `profiler` to be set to 'torch'."""
 +
 +    detailed_trace_annotation: bool = False
 +    """If `True`, uses detailed annotations with roofline metrics (sk, sqsq,
@@ -20,24 +20,20 @@ index 6a40b9dad..c2f32a485 100644
      ignore_frontend: bool = False
      """If `True`, disables the front-end profiling of AsyncLLM when using the
      'torch' profiler. This is needed to reduce overhead when using delay/limit options,
-@@ -143,5 +154,15 @@ class ProfilerConfig:
+@@ -143,5 +154,11 @@ class ProfilerConfig:
          # These paths should not be converted to absolute paths
          if profiler_dir and not _is_uri_path(profiler_dir):
              self.torch_profiler_dir = os.path.abspath(os.path.expanduser(profiler_dir))
 +        
-+        capture_dir = self.capture_torch_profiler_dir
-+        if capture_dir and self.profiler != "torch":
++        if self.capture_torch_profiler and self.profiler != "torch":
 +            raise ValueError(
-+                "capture_torch_profiler_dir is only applicable when profiler is set to 'torch'"
-+            )
-+        if capture_dir and not _is_uri_path(capture_dir):
-+            self.capture_torch_profiler_dir = os.path.abspath(
-+                os.path.expanduser(capture_dir)
++                "capture_torch_profiler is only applicable when profiler is "
++                "set to 'torch'"
 +            )
  
          return self
 diff --git a/vllm/v1/worker/gpu_model_runner.py b/vllm/v1/worker/gpu_model_runner.py
-index 98e1dab36..a22fcc79d 100644
+index 98e1dab..0e5179e 100644
 --- a/vllm/v1/worker/gpu_model_runner.py
 +++ b/vllm/v1/worker/gpu_model_runner.py
 @@ -8,7 +8,7 @@ import threading
@@ -57,7 +53,7 @@ index 98e1dab36..a22fcc79d 100644
 +        # Setup torch profiler for graph capture traces (conditional)
 +        from vllm.distributed.parallel_state import get_world_group
 +        local_rank = get_world_group().local_rank
-+        enable_profiler = (local_rank == 0) and self.vllm_config.profiler_config.capture_torch_profiler_dir
++        enable_profiler = (local_rank == 0) and self.vllm_config.profiler_config.capture_torch_profiler
 +        if enable_profiler:
 +            trace_dir = self.vllm_config.profiler_config.torch_profiler_dir + "/capture_traces"
 +            profiler = torch.profiler.profile(
@@ -143,7 +139,7 @@ index 98e1dab36..a22fcc79d 100644
              torch.accelerator.synchronize()
          self.maybe_remove_all_loras(self.lora_config)
 diff --git a/vllm/v1/worker/gpu_worker.py b/vllm/v1/worker/gpu_worker.py
-index 6d117175b..87084142c 100644
+index 6d11717..8708414 100644
 --- a/vllm/v1/worker/gpu_worker.py
 +++ b/vllm/v1/worker/gpu_worker.py
 @@ -737,19 +737,87 @@ class Worker(WorkerBase):

--- a/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.19.0.patch
+++ b/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.19.0.patch
@@ -1,15 +1,15 @@
 diff --git a/vllm/config/profiler.py b/vllm/config/profiler.py
-index 68fa78854..ea2f98225 100644
+index 68fa788..1c69c14 100644
 --- a/vllm/config/profiler.py
 +++ b/vllm/config/profiler.py
 @@ -66,6 +66,17 @@ class ProfilerConfig:
      """If `True`, enables memory profiling in the torch profiler.
      Disabled by default."""
  
-+    capture_torch_profiler_dir: str = ""
-+    """Directory to save profiler traces captured during CUDA graph capture.
-+    If set and non-empty, a torch profiler will be enabled during graph capture
-+    on rank 0. Must be an absolute path."""
++    capture_torch_profiler: bool = False
++    """If `True`, enables a torch profiler during CUDA graph capture on rank 0.
++    Traces are saved to a `capture_traces` subdirectory under `torch_profiler_dir`.
++    Requires `profiler` to be set to 'torch'."""
 +
 +    detailed_trace_annotation: bool = False
 +    """If `True`, uses detailed annotations with roofline metrics (sk, sqsq,
@@ -20,24 +20,20 @@ index 68fa78854..ea2f98225 100644
      ignore_frontend: bool = False
      """If `True`, disables the front-end profiling of AsyncLLM when using the
      'torch' profiler. This is needed to reduce overhead when using delay/limit options,
-@@ -143,5 +154,15 @@ class ProfilerConfig:
+@@ -143,5 +154,11 @@ class ProfilerConfig:
          # These paths should not be converted to absolute paths
          if profiler_dir and not _is_uri_path(profiler_dir):
              self.torch_profiler_dir = os.path.abspath(os.path.expanduser(profiler_dir))
 +        
-+        capture_dir = self.capture_torch_profiler_dir
-+        if capture_dir and self.profiler != "torch":
++        if self.capture_torch_profiler and self.profiler != "torch":
 +            raise ValueError(
-+                "capture_torch_profiler_dir is only applicable when profiler is set to 'torch'"
-+            )
-+        if capture_dir and not _is_uri_path(capture_dir):
-+            self.capture_torch_profiler_dir = os.path.abspath(
-+                os.path.expanduser(capture_dir)
++                "capture_torch_profiler is only applicable when profiler is "
++                "set to 'torch'"
 +            )
  
          return self
 diff --git a/vllm/v1/worker/gpu_model_runner.py b/vllm/v1/worker/gpu_model_runner.py
-index 2e62206da..3194ea16f 100644
+index 2e62206..00fce72 100644
 --- a/vllm/v1/worker/gpu_model_runner.py
 +++ b/vllm/v1/worker/gpu_model_runner.py
 @@ -8,7 +8,7 @@ import threading
@@ -57,7 +53,7 @@ index 2e62206da..3194ea16f 100644
 +        # Setup torch profiler for graph capture traces (conditional)
 +        from vllm.distributed.parallel_state import get_world_group
 +        local_rank = get_world_group().local_rank
-+        enable_profiler = (local_rank == 0) and self.vllm_config.profiler_config.capture_torch_profiler_dir
++        enable_profiler = (local_rank == 0) and self.vllm_config.profiler_config.capture_torch_profiler
 +        if enable_profiler:
 +            trace_dir = self.vllm_config.profiler_config.torch_profiler_dir + "/capture_traces"
 +            profiler = torch.profiler.profile(
@@ -144,7 +140,7 @@ index 2e62206da..3194ea16f 100644
              torch.accelerator.synchronize()
          self.maybe_remove_all_loras(self.lora_config)
 diff --git a/vllm/v1/worker/gpu_worker.py b/vllm/v1/worker/gpu_worker.py
-index 91dcdc2b9..42455389a 100644
+index 91dcdc2..4245538 100644
 --- a/vllm/v1/worker/gpu_worker.py
 +++ b/vllm/v1/worker/gpu_worker.py
 @@ -718,19 +718,87 @@ class Worker(WorkerBase):

--- a/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.20.0.patch
+++ b/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.20.0.patch
@@ -1,15 +1,15 @@
 diff --git a/vllm/config/profiler.py b/vllm/config/profiler.py
-index 68fa788..eb8d6c2 100644
+index 68fa788..f0e29d0 100644
 --- a/vllm/config/profiler.py
 +++ b/vllm/config/profiler.py
 @@ -66,6 +66,17 @@ class ProfilerConfig:
      """If `True`, enables memory profiling in the torch profiler.
      Disabled by default."""
  
-+    capture_torch_profiler_dir: str = ""
-+    """Directory to save profiler traces captured during CUDA graph capture.
-+    If set and non-empty, a torch profiler will be enabled during graph capture
-+    on rank 0. Must be an absolute path."""
++    capture_torch_profiler: bool = False
++    """If `True`, enables a torch profiler during CUDA graph capture on rank 0.
++    Traces are saved to a `capture_traces` subdirectory under `torch_profiler_dir`.
++    Requires `profiler` to be set to 'torch'."""
 +
 +    detailed_trace_annotation: bool = False
 +    """If `True`, uses detailed annotations with roofline metrics (sk, sqsq,
@@ -20,23 +20,19 @@ index 68fa788..eb8d6c2 100644
      ignore_frontend: bool = False
      """If `True`, disables the front-end profiling of AsyncLLM when using the
      'torch' profiler. This is needed to reduce overhead when using delay/limit options,
-@@ -144,4 +155,14 @@ class ProfilerConfig:
+@@ -144,4 +155,10 @@ class ProfilerConfig:
          if profiler_dir and not _is_uri_path(profiler_dir):
              self.torch_profiler_dir = os.path.abspath(os.path.expanduser(profiler_dir))
  
-+        capture_dir = self.capture_torch_profiler_dir
-+        if capture_dir and self.profiler != "torch":
++        if self.capture_torch_profiler and self.profiler != "torch":
 +            raise ValueError(
-+                "capture_torch_profiler_dir is only applicable when profiler is set to 'torch'"
-+            )
-+        if capture_dir and not _is_uri_path(capture_dir):
-+            self.capture_torch_profiler_dir = os.path.abspath(
-+                os.path.expanduser(capture_dir)
++                "capture_torch_profiler is only applicable when profiler is "
++                "set to 'torch'"
 +            )
 +
          return self
 diff --git a/vllm/v1/worker/gpu_model_runner.py b/vllm/v1/worker/gpu_model_runner.py
-index a0ba47f..e8150c6 100644
+index a0ba47f..212c807 100644
 --- a/vllm/v1/worker/gpu_model_runner.py
 +++ b/vllm/v1/worker/gpu_model_runner.py
 @@ -8,7 +8,7 @@ import threading
@@ -56,7 +52,7 @@ index a0ba47f..e8150c6 100644
 +        # Setup torch profiler for graph capture traces (conditional)
 +        from vllm.distributed.parallel_state import get_world_group
 +        local_rank = get_world_group().local_rank
-+        enable_profiler = (local_rank == 0) and self.vllm_config.profiler_config.capture_torch_profiler_dir
++        enable_profiler = (local_rank == 0) and self.vllm_config.profiler_config.capture_torch_profiler
 +        if enable_profiler:
 +            trace_dir = self.vllm_config.profiler_config.torch_profiler_dir + "/capture_traces"
 +            profiler = torch.profiler.profile(

--- a/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.22.0.patch
+++ b/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.22.0.patch
@@ -1,15 +1,15 @@
 diff --git a/vllm/config/profiler.py b/vllm/config/profiler.py
-index 68fa78854..eb8d6c264 100644
+index 68fa788..f0e29d0 100644
 --- a/vllm/config/profiler.py
 +++ b/vllm/config/profiler.py
 @@ -66,6 +66,17 @@ class ProfilerConfig:
      """If `True`, enables memory profiling in the torch profiler.
      Disabled by default."""
  
-+    capture_torch_profiler_dir: str = ""
-+    """Directory to save profiler traces captured during CUDA graph capture.
-+    If set and non-empty, a torch profiler will be enabled during graph capture
-+    on rank 0. Must be an absolute path."""
++    capture_torch_profiler: bool = False
++    """If `True`, enables a torch profiler during CUDA graph capture on rank 0.
++    Traces are saved to a `capture_traces` subdirectory under `torch_profiler_dir`.
++    Requires `profiler` to be set to 'torch'."""
 +
 +    detailed_trace_annotation: bool = False
 +    """If `True`, uses detailed annotations with roofline metrics (sk, sqsq,
@@ -20,23 +20,19 @@ index 68fa78854..eb8d6c264 100644
      ignore_frontend: bool = False
      """If `True`, disables the front-end profiling of AsyncLLM when using the
      'torch' profiler. This is needed to reduce overhead when using delay/limit options,
-@@ -144,4 +155,14 @@ class ProfilerConfig:
+@@ -144,4 +155,10 @@ class ProfilerConfig:
          if profiler_dir and not _is_uri_path(profiler_dir):
              self.torch_profiler_dir = os.path.abspath(os.path.expanduser(profiler_dir))
  
-+        capture_dir = self.capture_torch_profiler_dir
-+        if capture_dir and self.profiler != "torch":
++        if self.capture_torch_profiler and self.profiler != "torch":
 +            raise ValueError(
-+                "capture_torch_profiler_dir is only applicable when profiler is set to 'torch'"
-+            )
-+        if capture_dir and not _is_uri_path(capture_dir):
-+            self.capture_torch_profiler_dir = os.path.abspath(
-+                os.path.expanduser(capture_dir)
++                "capture_torch_profiler is only applicable when profiler is "
++                "set to 'torch'"
 +            )
 +
          return self
 diff --git a/vllm/v1/worker/gpu_model_runner.py b/vllm/v1/worker/gpu_model_runner.py
-index d51bf2284..c53faa282 100644
+index d51bf22..d03ca66 100644
 --- a/vllm/v1/worker/gpu_model_runner.py
 +++ b/vllm/v1/worker/gpu_model_runner.py
 @@ -8,7 +8,7 @@ import threading
@@ -56,7 +52,7 @@ index d51bf2284..c53faa282 100644
 +        # Setup torch profiler for graph capture traces (conditional)
 +        from vllm.distributed.parallel_state import get_world_group
 +        local_rank = get_world_group().local_rank
-+        enable_profiler = (local_rank == 0) and self.vllm_config.profiler_config.capture_torch_profiler_dir
++        enable_profiler = (local_rank == 0) and self.vllm_config.profiler_config.capture_torch_profiler
 +        if enable_profiler:
 +            trace_dir = self.vllm_config.profiler_config.torch_profiler_dir + "/capture_traces"
 +            profiler = torch.profiler.profile(
@@ -143,7 +139,7 @@ index d51bf2284..c53faa282 100644
              torch.accelerator.synchronize()
          self.maybe_remove_all_loras(self.lora_config)
 diff --git a/vllm/v1/worker/gpu_worker.py b/vllm/v1/worker/gpu_worker.py
-index 582c6a17c..6b8b6dfd8 100644
+index 582c6a1..6b8b6df 100644
 --- a/vllm/v1/worker/gpu_worker.py
 +++ b/vllm/v1/worker/gpu_worker.py
 @@ -756,19 +756,87 @@ class Worker(WorkerBase):

--- a/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.23.0.patch
+++ b/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.23.0.patch
@@ -1,15 +1,15 @@
 diff --git a/vllm/config/profiler.py b/vllm/config/profiler.py
-index 68fa78854..eb8d6c264 100644
+index 68fa788..f0e29d0 100644
 --- a/vllm/config/profiler.py
 +++ b/vllm/config/profiler.py
 @@ -66,6 +66,17 @@ class ProfilerConfig:
      """If `True`, enables memory profiling in the torch profiler.
      Disabled by default."""
  
-+    capture_torch_profiler_dir: str = ""
-+    """Directory to save profiler traces captured during CUDA graph capture.
-+    If set and non-empty, a torch profiler will be enabled during graph capture
-+    on rank 0. Must be an absolute path."""
++    capture_torch_profiler: bool = False
++    """If `True`, enables a torch profiler during CUDA graph capture on rank 0.
++    Traces are saved to a `capture_traces` subdirectory under `torch_profiler_dir`.
++    Requires `profiler` to be set to 'torch'."""
 +
 +    detailed_trace_annotation: bool = False
 +    """If `True`, uses detailed annotations with roofline metrics (sk, sqsq,
@@ -20,23 +20,19 @@ index 68fa78854..eb8d6c264 100644
      ignore_frontend: bool = False
      """If `True`, disables the front-end profiling of AsyncLLM when using the
      'torch' profiler. This is needed to reduce overhead when using delay/limit options,
-@@ -144,4 +155,14 @@ class ProfilerConfig:
+@@ -144,4 +155,10 @@ class ProfilerConfig:
          if profiler_dir and not _is_uri_path(profiler_dir):
              self.torch_profiler_dir = os.path.abspath(os.path.expanduser(profiler_dir))
  
-+        capture_dir = self.capture_torch_profiler_dir
-+        if capture_dir and self.profiler != "torch":
++        if self.capture_torch_profiler and self.profiler != "torch":
 +            raise ValueError(
-+                "capture_torch_profiler_dir is only applicable when profiler is set to 'torch'"
-+            )
-+        if capture_dir and not _is_uri_path(capture_dir):
-+            self.capture_torch_profiler_dir = os.path.abspath(
-+                os.path.expanduser(capture_dir)
++                "capture_torch_profiler is only applicable when profiler is "
++                "set to 'torch'"
 +            )
 +
          return self
 diff --git a/vllm/v1/worker/gpu_model_runner.py b/vllm/v1/worker/gpu_model_runner.py
-index 801a8574a..cd158b535 100644
+index 801a857..91266be 100644
 --- a/vllm/v1/worker/gpu_model_runner.py
 +++ b/vllm/v1/worker/gpu_model_runner.py
 @@ -8,7 +8,7 @@ import threading
@@ -56,7 +52,7 @@ index 801a8574a..cd158b535 100644
 +        # Setup torch profiler for graph capture traces (conditional)
 +        from vllm.distributed.parallel_state import get_world_group
 +        local_rank = get_world_group().local_rank
-+        enable_profiler = (local_rank == 0) and self.vllm_config.profiler_config.capture_torch_profiler_dir
++        enable_profiler = (local_rank == 0) and self.vllm_config.profiler_config.capture_torch_profiler
 +        if enable_profiler:
 +            trace_dir = self.vllm_config.profiler_config.torch_profiler_dir + "/capture_traces"
 +            profiler = torch.profiler.profile(
@@ -143,7 +139,7 @@ index 801a8574a..cd158b535 100644
              torch.accelerator.synchronize()
          self.maybe_remove_all_loras(self.lora_config)
 diff --git a/vllm/v1/worker/gpu_worker.py b/vllm/v1/worker/gpu_worker.py
-index 052e1fe76..7ea4d8b14 100644
+index 052e1fe..7ea4d8b 100644
 --- a/vllm/v1/worker/gpu_worker.py
 +++ b/vllm/v1/worker/gpu_worker.py
 @@ -781,19 +781,87 @@ class Worker(WorkerBase):

--- a/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.24.0.patch
+++ b/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.24.0.patch
@@ -1,15 +1,15 @@
 diff --git a/vllm/config/profiler.py b/vllm/config/profiler.py
-index 68fa78854..eb8d6c264 100644
+index 68fa788..f0e29d0 100644
 --- a/vllm/config/profiler.py
 +++ b/vllm/config/profiler.py
 @@ -66,6 +66,17 @@ class ProfilerConfig:
      """If `True`, enables memory profiling in the torch profiler.
      Disabled by default."""
  
-+    capture_torch_profiler_dir: str = ""
-+    """Directory to save profiler traces captured during CUDA graph capture.
-+    If set and non-empty, a torch profiler will be enabled during graph capture
-+    on rank 0. Must be an absolute path."""
++    capture_torch_profiler: bool = False
++    """If `True`, enables a torch profiler during CUDA graph capture on rank 0.
++    Traces are saved to a `capture_traces` subdirectory under `torch_profiler_dir`.
++    Requires `profiler` to be set to 'torch'."""
 +
 +    detailed_trace_annotation: bool = False
 +    """If `True`, uses detailed annotations with roofline metrics (sk, sqsq,
@@ -20,23 +20,19 @@ index 68fa78854..eb8d6c264 100644
      ignore_frontend: bool = False
      """If `True`, disables the front-end profiling of AsyncLLM when using the
      'torch' profiler. This is needed to reduce overhead when using delay/limit options,
-@@ -144,4 +155,14 @@ class ProfilerConfig:
+@@ -144,4 +155,10 @@ class ProfilerConfig:
          if profiler_dir and not _is_uri_path(profiler_dir):
              self.torch_profiler_dir = os.path.abspath(os.path.expanduser(profiler_dir))
  
-+        capture_dir = self.capture_torch_profiler_dir
-+        if capture_dir and self.profiler != "torch":
++        if self.capture_torch_profiler and self.profiler != "torch":
 +            raise ValueError(
-+                "capture_torch_profiler_dir is only applicable when profiler is set to 'torch'"
-+            )
-+        if capture_dir and not _is_uri_path(capture_dir):
-+            self.capture_torch_profiler_dir = os.path.abspath(
-+                os.path.expanduser(capture_dir)
++                "capture_torch_profiler is only applicable when profiler is "
++                "set to 'torch'"
 +            )
 +
          return self
 diff --git a/vllm/v1/worker/gpu_model_runner.py b/vllm/v1/worker/gpu_model_runner.py
-index 74938a823..af48209fc 100644
+index 74938a8..cfffdab 100644
 --- a/vllm/v1/worker/gpu_model_runner.py
 +++ b/vllm/v1/worker/gpu_model_runner.py
 @@ -8,7 +8,7 @@ import threading
@@ -56,7 +52,7 @@ index 74938a823..af48209fc 100644
 +        # Setup torch profiler for graph capture traces (conditional)
 +        from vllm.distributed.parallel_state import get_world_group
 +        local_rank = get_world_group().local_rank
-+        enable_profiler = (local_rank == 0) and self.vllm_config.profiler_config.capture_torch_profiler_dir
++        enable_profiler = (local_rank == 0) and self.vllm_config.profiler_config.capture_torch_profiler
 +        if enable_profiler:
 +            trace_dir = self.vllm_config.profiler_config.torch_profiler_dir + "/capture_traces"
 +            profiler = torch.profiler.profile(
@@ -143,7 +139,7 @@ index 74938a823..af48209fc 100644
              torch.accelerator.synchronize()
          self.maybe_remove_all_loras(self.lora_config)
 diff --git a/vllm/v1/worker/gpu_worker.py b/vllm/v1/worker/gpu_worker.py
-index 5e266a313..2344a6405 100644
+index 5e266a3..2344a64 100644
 --- a/vllm/v1/worker/gpu_worker.py
 +++ b/vllm/v1/worker/gpu_worker.py
 @@ -811,19 +811,87 @@ class Worker(WorkerBase):

--- a/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.25.0.patch
+++ b/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.25.0.patch
@@ -32,7 +32,7 @@ index 68fa788..f0e29d0 100644
 +
          return self
 diff --git a/vllm/v1/worker/gpu_model_runner.py b/vllm/v1/worker/gpu_model_runner.py
-index 98b2fbf..65afa1f 100644
+index e9b23f1..2805319 100644
 --- a/vllm/v1/worker/gpu_model_runner.py
 +++ b/vllm/v1/worker/gpu_model_runner.py
 @@ -8,7 +8,7 @@ import threading
@@ -40,21 +40,26 @@ index 98b2fbf..65afa1f 100644
  from collections import defaultdict
  from collections.abc import Callable, Iterable, Iterator, Sequence
 -from contextlib import contextmanager
-+from contextlib import contextmanager, nullcontext
++from contextlib import AbstractContextManager, contextmanager, nullcontext
  from copy import copy, deepcopy
  from dataclasses import dataclass, replace
  from functools import reduce
-@@ -6200,6 +6200,30 @@ class GPUModelRunner(
+@@ -6663,6 +6663,44 @@ class GPUModelRunner(
          # Capture the large shapes first so that the smaller shapes
          # can reuse the memory pool allocated for the large shapes.
          set_cudagraph_capturing_enabled(True)
 +
 +        # Setup torch profiler for graph capture traces (conditional)
 +        from vllm.distributed.parallel_state import get_world_group
++
 +        local_rank = get_world_group().local_rank
-+        enable_profiler = (local_rank == 0) and self.vllm_config.profiler_config.capture_torch_profiler
++        enable_profiler = (
++            local_rank == 0
++        ) and self.vllm_config.profiler_config.capture_torch_profiler
 +        if enable_profiler:
-+            trace_dir = self.vllm_config.profiler_config.torch_profiler_dir + "/capture_traces"
++            trace_dir = (
++                self.vllm_config.profiler_config.torch_profiler_dir + "/capture_traces"
++            )
 +            profiler = torch.profiler.profile(
 +                activities=[
 +                    torch.profiler.ProfilerActivity.CPU,
@@ -64,18 +69,27 @@ index 98b2fbf..65afa1f 100644
 +                profile_memory=True,
 +                with_stack=True,
 +                on_trace_ready=torch.profiler.tensorboard_trace_handler(
-+                    trace_dir, worker_name=f"graph_capture_rank_{local_rank}",use_gzip=True
++                    trace_dir,
++                    worker_name=f"graph_capture_rank_{local_rank}",
++                    use_gzip=True,
 +                ),
 +            )
-+            logger.info("Rank %d: Torch profiler enabled for CUDA graph capture, traces will be saved to: %s", local_rank, trace_dir)
++            logger.info_once(
++                "Rank %d: Torch profiler enabled for CUDA graph capture, "
++                "traces will be saved to: %s",
++                local_rank,
++                trace_dir,
++            )
 +        else:
 +            profiler = nullcontext()
-+            logger.info("Rank %d: Torch profiler disabled for CUDA graph capture", local_rank)
++            logger.info_once(
++                "Rank %d: Torch profiler disabled for CUDA graph capture", local_rank
++            )
 +
          with self._freeze_gc(), graph_capture(device=self.device):
              torch.accelerator.synchronize()
              torch.accelerator.empty_cache()
-@@ -6212,6 +6236,7 @@ class GPUModelRunner(
+@@ -6675,6 +6713,7 @@ class GPUModelRunner(
                  self._capture_cudagraphs(
                      batch_descriptors=batch_descs,
                      cudagraph_runtime_mode=runtime_mode,
@@ -83,15 +97,18 @@ index 98b2fbf..65afa1f 100644
                  )
                  torch.accelerator.synchronize()
  
-@@ -6254,6 +6279,7 @@ class GPUModelRunner(
+@@ -6718,7 +6757,10 @@ class GPUModelRunner(
          profile_seq_lens: int | None = None,
          allow_microbatching: bool = False,
          num_warmups: int | None = None,
-+        profiler: "ContextManager[Any]" = nullcontext(),
++        profiler: AbstractContextManager[Any] | None = None,
      ):
++        if profiler is None:
++            profiler = nullcontext()
          if num_warmups is None:
              num_warmups = self.compilation_config.cudagraph_num_of_warmups
-@@ -6270,22 +6296,27 @@ class GPUModelRunner(
+         force_attention = cudagraph_runtime_mode == CUDAGraphMode.FULL
+@@ -6734,22 +6776,29 @@ class GPUModelRunner(
                  num_active_loras=desc.num_active_loras,
                  profile_seq_lens=profile_seq_lens,
              )
@@ -106,31 +123,33 @@ index 98b2fbf..65afa1f 100644
 -            is_graph_capturing=True,
 -            profile_seq_lens=profile_seq_lens,
 -        )
-+        with profiler:
-+            with torch.profiler.record_function(
++        with (
++            profiler,
++            torch.profiler.record_function(
 +                f"capture_{desc.num_tokens}_{cudagraph_runtime_mode.name}"
-+            ):
-+                self._dummy_run(
-+                    desc.num_tokens,
-+                    cudagraph_runtime_mode=cudagraph_runtime_mode,
-+                    uniform_decode=desc.uniform,
-+                    allow_microbatching=allow_microbatching,
-+                    skip_eplb=True,
-+                    remove_lora=False,
-+                    num_active_loras=desc.num_active_loras,
-+                    is_graph_capturing=True,
-+                    profile_seq_lens=profile_seq_lens,
-+                )
++            ),
++        ):
++            self._dummy_run(
++                desc.num_tokens,
++                cudagraph_runtime_mode=cudagraph_runtime_mode,
++                uniform_decode=desc.uniform,
++                allow_microbatching=allow_microbatching,
++                skip_eplb=True,
++                remove_lora=False,
++                num_active_loras=desc.num_active_loras,
++                is_graph_capturing=True,
++                profile_seq_lens=profile_seq_lens,
++            )
  
      def _capture_cudagraphs(
          self,
          batch_descriptors: list[BatchDescriptor],
          cudagraph_runtime_mode: CUDAGraphMode,
-+        profiler: "ContextManager[Any]" = nullcontext(),
++        profiler: AbstractContextManager[Any] | None = None,
      ):
          assert (
              cudagraph_runtime_mode != CUDAGraphMode.NONE
-@@ -6328,6 +6359,7 @@ class GPUModelRunner(
+@@ -6792,6 +6841,7 @@ class GPUModelRunner(
                  batch_desc,
                  cudagraph_runtime_mode=cudagraph_runtime_mode,
                  allow_microbatching=allow_microbatching,
@@ -139,42 +158,55 @@ index 98b2fbf..65afa1f 100644
              torch.accelerator.synchronize()
          self.maybe_remove_all_loras(self.lora_config)
 diff --git a/vllm/v1/worker/gpu_worker.py b/vllm/v1/worker/gpu_worker.py
-index 18c7941..222f26b 100644
+index 03433ed..d29c60d 100644
 --- a/vllm/v1/worker/gpu_worker.py
 +++ b/vllm/v1/worker/gpu_worker.py
-@@ -758,19 +758,87 @@ class Worker(WorkerBase):
+@@ -928,19 +928,104 @@ class Worker(WorkerBase):
  
          iteration_details = compute_iteration_details(scheduler_output)
  
 -        annotation = "".join(
 -            [
 -                "execute_context_",
+-                str(iteration_details.num_ctx_requests),
+-                "(",
+-                str(iteration_details.num_ctx_tokens),
+-                ")_generation_",
+-                str(iteration_details.num_generation_requests),
+-                "(",
+-                str(iteration_details.num_generation_tokens),
+-                ")",
+-            ]
+-        )
 +        if self.vllm_config.profiler_config.detailed_trace_annotation:
 +            # Compute roofline-model metrics per request, split by phase
 +            # (context vs generation). These help estimate compute and
 +            # memory intensity from the trace.
 +            #
 +            # Per-request quantities:
-+            #   sq = number of scheduled (new) tokens for this request
-+            #   sk = total sequence length (computed + scheduled tokens)
++            #   query_len = number of scheduled (new) tokens for this request
++            #   seq_len   = total sequence length (computed + scheduled tokens)
 +            #
-+            # Aggregated across requests in each phase (c_=context, g_=gen):
-+            #   sk   = sum of sk        (total KV length)
-+            #   sqsq = sum of sq*sq     (proxy for QK^T compute cost)
-+            #   sqsk = sum of sq*sk     (proxy for QK^T compute cost for decode and chunked prefill)
-+            #   bs   = total scheduled tokens across all requests
-+            c_sk = 0
-+            c_sqsq = 0
-+            c_sqsk = 0
-+            g_sk = 0
-+            g_sqsq = 0
-+            g_sqsk = 0
-+            bs = 0
++            # Aggregated across requests in each phase
++            # (ctx_=context, gen_=generation):
++            #   seq_len_sum = sum of seq_len   (total KV length)
++            #   qq_compute  = sum of query_len*query_len
++            #                 (proxy for QK^T compute cost)
++            #   qk_compute  = sum of query_len*seq_len
++            #                 (proxy for QK^T compute cost for decode and
++            #                  chunked prefill)
++            #   total_scheduled_tokens = scheduled tokens across all requests
++            ctx_seq_len_sum = 0
++            ctx_qq_compute = 0
++            ctx_qk_compute = 0
++            gen_seq_len_sum = 0
++            gen_qq_compute = 0
++            gen_qk_compute = 0
++            total_scheduled_tokens = 0
 +
 +            # Build a map of req_id -> num_computed_tokens for all requests
 +            new_req_ids = {
-+                new_req.req_id
-+                for new_req in scheduler_output.scheduled_new_reqs
++                new_req.req_id for new_req in scheduler_output.scheduled_new_reqs
 +            }
 +            num_computed_tokens_ids = {
 +                new_req.req_id: new_req.num_computed_tokens
@@ -187,55 +219,63 @@ index 18c7941..222f26b 100644
 +                num_computed_tokens_ids[req_id] = num_computed_tokens
 +
 +            # Accumulate per-phase metrics
-+            for req_id, num_tokens in (
-+                scheduler_output.num_scheduled_tokens.items()
-+            ):
-+                sq = num_tokens
-+                bs += sq
-+                sk = num_computed_tokens_ids.get(req_id, 0) + sq
++            for req_id, num_tokens in scheduler_output.num_scheduled_tokens.items():
++                query_len = num_tokens
++                total_scheduled_tokens += query_len
++                seq_len = num_computed_tokens_ids.get(req_id, 0) + query_len
 +                if (
-+                    scheduler_output.scheduled_cached_reqs.is_context_phase(
-+                        req_id
-+                    )
++                    scheduler_output.scheduled_cached_reqs.is_context_phase(req_id)
 +                    or req_id in new_req_ids
 +                ):
-+                    c_sk += sk
-+                    c_sqsq += sq * sq
-+                    c_sqsk += sq * sk
++                    ctx_seq_len_sum += seq_len
++                    ctx_qq_compute += query_len * query_len
++                    ctx_qk_compute += query_len * seq_len
 +                else:
-+                    g_sk += sk
-+                    g_sqsq += sq * sq
-+                    g_sqsk += sq * sk
-+            annotation = "".join([
-+                "execute_", str(bs), "_context_",
-                 str(iteration_details.num_ctx_requests),
--                "(",
--                str(iteration_details.num_ctx_tokens),
-+                "(sq", str(iteration_details.num_ctx_tokens),
-+                "sk", str(c_sk),
-+                "sqsq", str(c_sqsq),
-+                "sqsk", str(c_sqsk),
-                 ")_generation_",
-                 str(iteration_details.num_generation_requests),
--                "(",
--                str(iteration_details.num_generation_tokens),
-+                "(sq", str(iteration_details.num_generation_tokens),
-+                "sk", str(g_sk),
-+                "sqsq", str(g_sqsq),
-+                "sqsk", str(g_sqsk),
-                 ")",
--            ]
--        )
-+            ])
++                    gen_seq_len_sum += seq_len
++                    gen_qq_compute += query_len * query_len
++                    gen_qk_compute += query_len * seq_len
++            annotation = "".join(
++                [
++                    "execute_",
++                    str(total_scheduled_tokens),
++                    "_context_",
++                    str(iteration_details.num_ctx_requests),
++                    "(sq",
++                    str(iteration_details.num_ctx_tokens),
++                    "sk",
++                    str(ctx_seq_len_sum),
++                    "sqsq",
++                    str(ctx_qq_compute),
++                    "sqsk",
++                    str(ctx_qk_compute),
++                    ")_generation_",
++                    str(iteration_details.num_generation_requests),
++                    "(sq",
++                    str(iteration_details.num_generation_tokens),
++                    "sk",
++                    str(gen_seq_len_sum),
++                    "sqsq",
++                    str(gen_qq_compute),
++                    "sqsk",
++                    str(gen_qk_compute),
++                    ")",
++                ]
++            )
 +        else:
-+            annotation = "".join([
-+                "execute_context_",
-+                str(iteration_details.num_ctx_requests),
-+                "(", str(iteration_details.num_ctx_tokens), ")",
-+                "_generation_",
-+                str(iteration_details.num_generation_requests),
-+                "(", str(iteration_details.num_generation_tokens), ")",
-+            ])
++            annotation = "".join(
++                [
++                    "execute_context_",
++                    str(iteration_details.num_ctx_requests),
++                    "(",
++                    str(iteration_details.num_ctx_tokens),
++                    ")",
++                    "_generation_",
++                    str(iteration_details.num_generation_requests),
++                    "(",
++                    str(iteration_details.num_generation_tokens),
++                    ")",
++                ]
++            )
          return self.profiler.annotate_context_manager(annotation)
  
      @torch.inference_mode()


### PR DESCRIPTION
This pull request updates TraceLens profiling support for vLLM to reflect upstream changes in vLLM v0.26.0 and later. It adds support for vLLM v0.25.0, switches the profiler patch and documentation to use the new `--profiler-config.capture_torch_profiler` boolean flag (instead of the old directory-based flag), and clarifies when a patched image is required. The documentation and scripts now guide users to use stock upstream images for vLLM v0.26.0+, and only build patched images for v0.14-v0.25.

**Key changes:**

**vLLM patching and version support**
- Added support for vLLM v0.25.0 in `build_docker_vllm.sh`, including a new patch file and updated version selection logic and documentation. [[1]](diffhunk://#diff-e87f62fd28a41719f1735a23b6aacd929284e4f592d3311e5f5ffc13fa24aa26L13-R20) [[2]](diffhunk://#diff-e87f62fd28a41719f1735a23b6aacd929284e4f592d3311e5f5ffc13fa24aa26R80-R89) [[3]](diffhunk://#diff-6381ef4673e8ef27e9c84a1efec3bf4c08494583e9c1e39fe28a87a82ce159a1R90-R95)
- Updated all documentation and scripts to clarify that vLLM v0.26.0 and later ship the required profiler options upstream, so no patched image is needed for these versions. [[1]](diffhunk://#diff-02a6ad57f2191797e842bfd698595c59f9338fe3e047f09fa31ce0843d6cbd63L57-R57) [[2]](diffhunk://#diff-cc21a4d84c3f36a10a15e19a1c4a4df7577315cf1ee9d3f5cccc0d31dcfa492dL74-R80) [[3]](diffhunk://#diff-cc21a4d84c3f36a10a15e19a1c4a4df7577315cf1ee9d3f5cccc0d31dcfa492dR113-R114) [[4]](diffhunk://#diff-6381ef4673e8ef27e9c84a1efec3bf4c08494583e9c1e39fe28a87a82ce159a1R90-R95) [[5]](diffhunk://#diff-e87f62fd28a41719f1735a23b6aacd929284e4f592d3311e5f5ffc13fa24aa26L13-R20) [[6]](diffhunk://#diff-e87f62fd28a41719f1735a23b6aacd929284e4f592d3311e5f5ffc13fa24aa26R80-R89)

**Profiler flag changes**
- Replaced the deprecated `--profiler-config.capture_torch_profiler_dir` string argument with the new `--profiler-config.capture_torch_profiler` boolean flag in all code, patch files, and documentation. The trace directory is now always `<torch_profiler_dir>/capture_traces`. [[1]](diffhunk://#diff-e52de35a2f127f650a0c366525b4b165b1536da40a0fa588affe361a325bdb25L2-R12) [[2]](diffhunk://#diff-e52de35a2f127f650a0c366525b4b165b1536da40a0fa588affe361a325bdb25L23-R35) [[3]](diffhunk://#diff-e52de35a2f127f650a0c366525b4b165b1536da40a0fa588affe361a325bdb25L65-R55) [[4]](diffhunk://#diff-9e247fc5fd178a9e0c2cdc8069a08d05bdf8d6fa3221b0586a744469d5ad7f3dR2-R12) [[5]](diffhunk://#diff-9e247fc5fd178a9e0c2cdc8069a08d05bdf8d6fa3221b0586a744469d5ad7f3dL22-R35) [[6]](diffhunk://#diff-9e247fc5fd178a9e0c2cdc8069a08d05bdf8d6fa3221b0586a744469d5ad7f3dL59-R55) [[7]](diffhunk://#diff-6381ef4673e8ef27e9c84a1efec3bf4c08494583e9c1e39fe28a87a82ce159a1L195-R233) [[8]](diffhunk://#diff-cc21a4d84c3f36a10a15e19a1c4a4df7577315cf1ee9d3f5cccc0d31dcfa492dL187-R198) [[9]](diffhunk://#diff-cc21a4d84c3f36a10a15e19a1c4a4df7577315cf1ee9d3f5cccc0d31dcfa492dL337-R341)

**Documentation improvements**
- Updated all user-facing documentation (`README.md`, reference guides, and how-to docs) to explain the new profiler flag, the version-specific requirements for patched images, and how to configure trace collection correctly on all supported versions. [[1]](diffhunk://#diff-02a6ad57f2191797e842bfd698595c59f9338fe3e047f09fa31ce0843d6cbd63R138-R139) [[2]](diffhunk://#diff-cc21a4d84c3f36a10a15e19a1c4a4df7577315cf1ee9d3f5cccc0d31dcfa492dL187-R198) [[3]](diffhunk://#diff-6381ef4673e8ef27e9c84a1efec3bf4c08494583e9c1e39fe28a87a82ce159a1L195-R233)

**Code and patch maintenance**
- Cleaned up and clarified patch application logic in `build_docker_vllm.sh` and ensured all patch files for v0.14-v0.25 are consistent with the new flag. [[1]](diffhunk://#diff-e87f62fd28a41719f1735a23b6aacd929284e4f592d3311e5f5ffc13fa24aa26L105-R118) [[2]](diffhunk://#diff-e52de35a2f127f650a0c366525b4b165b1536da40a0fa588affe361a325bdb25L2-R12) [[3]](diffhunk://#diff-9e247fc5fd178a9e0c2cdc8069a08d05bdf8d6fa3221b0586a744469d5ad7f3dR2-R12)

These updates ensure that TraceLens profiling works seamlessly across all supported vLLM versions, simplifies configuration for users, and keeps all documentation up to date with upstream changes.
<!--
Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.

See LICENSE for license information.
-->

