### PR TITLE
Fix Dependabot security alerts for black and streamlit

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install black==26.1.0 ruff==0.16.1 import-linter==2.13  # Pin for CI reproducibility; use same versions locally
+        pip install black==26.3.1 ruff==0.16.1 import-linter==2.13  # Pin for CI reproducibility; use same versions locally
 
     - name: Run Black
       # only run black on changed files based on this example:

--- a/examples/custom_workflows/UI/requirements.txt
+++ b/examples/custom_workflows/UI/requirements.txt
@@ -1,3 +1,3 @@
 pandas
-streamlit==1.44.1
+streamlit==1.54.0
 torch

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         ],
         "dev": [
             "pytest",
-            "black==26.1.0",
+            "black==26.3.1",
         ],
     },
     description="A library for automating the analysis of ML model performance traces",


### PR DESCRIPTION
## Summary
- Bump `black` from 26.1.0 to 26.3.1 in `setup.py` and CI lint workflow to fix [GHSA-9ccg-6jwh-wqhg](https://github.com/psf/black/security/advisories/GHSA-9ccg-6jwh-wqhg) (high: arbitrary file writes from unsanitized cache file names)
- Bump `streamlit` from 1.44.1 to 1.54.0 in the custom workflows UI requirements to fix unauthenticated SSRF on Windows (medium) and `@st.cache_data` hash collision via fixed sampling seed (low)

Resolves all 3 open Dependabot alerts on the default branch.

## Test plan
- [ ] CI lint workflow passes with `black==26.3.1`
- [ ] `pip install -e ".[dev]"` succeeds with updated black pin
- [ ] `pip install -r examples/custom_workflows/UI/requirements.txt` succeeds with `streamlit==1.54.0`
- [ ] Dependabot alerts close after merge


Made with [Cursor](https://cursor.com)