### PR TITLE
Add perf model for vllm::rocm_aiter_sparse_attn_indexer (GLM5)

### DIFF
--- a/TraceLens/PerfModel/extensions/attention_perf_model_extensions.py
+++ b/TraceLens/PerfModel/extensions/attention_perf_model_extensions.py
@@ -865,3 +865,104 @@ class gdn_attention_core(InferenceAttention):
 
     def get_maf_type(self):
         return "matrix"
+
+
+class rocm_aiter_sparse_attn_indexer(InferenceAttention):
+    """
+    Performance model for vllm::rocm_aiter_sparse_attn_indexer (DeepSeek sparse
+    attention "lightning indexer": fp8 MQA index-score + top-k selection).
+
+    Scores each query token against its context keys (single shared MQA key)
+    and writes a top-k index list; no value aggregation, so only the QK score
+    term is counted.
+
+    Expected Input Dims from trace:
+        [2] k cache (num_slots, 1, cache_row); cache_row = head_dim + block scales
+        [3] q       (N_Q, H, head_dim)
+        [4] k current-chunk (N_Q, head_dim)
+    Expected Input type from trace:
+        [2] unsigned char (fp8 k cache), [3] Float8_e4m3fn (q), [4] BFloat16 (k)
+    Expected Concrete Inputs from trace:
+        [8] index_topk
+    """
+
+    @staticmethod
+    def get_param_details(event):
+        try:
+            annotation = str(event.get("annotation"))
+            stats = InferenceAttention._parse_chunk_stats(annotation)
+
+            dims = event["args"]["Input Dims"]
+            types = event["args"].get("Input type", []) or []
+            N_Q, H, head_dim = dims[3][0], dims[3][1], dims[3][2]
+            # Cache row width (fp8 key + per-block e8m0 scales), 1 B/elem.
+            cache_row = dims[2][-1] if len(dims) > 2 and dims[2] else head_dim
+
+            concrete = event["args"].get("Concrete Inputs", []) or []
+            index_topk = 0
+            if len(concrete) > 8 and str(concrete[8]).strip().isdigit():
+                index_topk = int(concrete[8])
+
+            params = {
+                "B": 1,
+                "N_Q": N_Q,
+                "H_Q": H,
+                "H_KV": 1,  # MQA: single shared key per token
+                "N_KV": stats["c_sk"] + stats["g_sk"],
+                "d_h_qk": head_dim,
+                "d_h_v": head_dim,
+                "dropout": 0.0,
+                "causal": True,
+                "flash_impl": True,
+                "index_topk": index_topk,
+                "cache_row": cache_row,
+                "dtype_Q": types[3] if len(types) > 3 else "c10::Float8_e4m3fn",
+                "dtype_KV": types[2] if len(types) > 2 else "unsigned char",
+                "dtype_Kcur": types[4] if len(types) > 4 else "c10::BFloat16",
+            }
+            params.update(stats)
+            return params
+        except (NotImplementedError, ValueError, IndexError, KeyError, TypeError):
+            return InferenceAttention.no_perf_param_details()
+
+    def flops(self):
+        p = self.param_details
+        if p.get("_no_perf") or p.get("_no_flops"):
+            return None
+        if p["c_sq"] == 0 and p["g_sq"] == 0:
+            raise NotImplementedError(
+                "sparse_attn_indexer perf model requires sq/sk annotations"
+            )
+        H, d = self.H_Q, self.d_h_qk
+        ctx_qk = H * (2 * p["c_sqsk"] - p["c_sqsq"]) * d  # prefill (causal)
+        gen_qk = H * (2 * p["g_sqsk"]) * d  # decode
+        return ctx_qk + gen_qk
+
+    def bytes(self, bytes_per_element=None):
+        p = self.param_details
+        if p.get("_no_perf"):
+            return None
+        bpe_q = name2bpe(p.get("dtype_Q")) or 1
+        bpe_kcur = name2bpe(p.get("dtype_Kcur")) or 2
+        N_Q, H, d = self.N_Q, self.H_Q, self.d_h_qk
+        total_sk = p["c_sk"] + p["g_sk"]
+        cached_sk = max(total_sk - N_Q, 0)
+        # MQA: keys read once (shared across the H index heads), not per head.
+        read_q = N_Q * H * d * bpe_q
+        read_k_cached = cached_sk * p["cache_row"]  # fp8 key + scales, 1 B/elem
+        read_k_current = N_Q * d * bpe_kcur
+        read_weights = N_Q * H * 4  # fp32 per-head weights
+        # Sole HBM output is the top-k index list (int32); logits are streamed.
+        avg_ctx = total_sk / N_Q if N_Q else 0
+        topk = min(p["index_topk"], avg_ctx) if p["index_topk"] else avg_ctx
+        write_topk = N_Q * topk * 4
+        return read_q + read_k_cached + read_k_current + read_weights + write_topk
+
+    def get_compute_precision(self):
+        if self.param_details.get("_no_perf"):
+            return None
+        dtype = self.param_details.get("dtype_Q")
+        return torch_dtype_map(dtype) if dtype else None
+
+    def get_maf_type(self):
+        return "matrix"

--- a/TraceLens/PerfModel/extensions/pseudo_ops_perf_utils.py
+++ b/TraceLens/PerfModel/extensions/pseudo_ops_perf_utils.py
@@ -52,6 +52,7 @@ def get_pseudo_op_mappings():
         "aiter::mxfp4_moe_sort_hip": moe_perf_model_extensions.MoeSortScatterGather,
         # Attention pseudo ops
         "vllm::unified_attention_with_output": attention_perf_model_extensions.vllm_unified_attention_with_output,
+        "vllm::rocm_aiter_sparse_attn_indexer": attention_perf_model_extensions.rocm_aiter_sparse_attn_indexer,
         "aiter::mha_varlen_fwd": attention_perf_model_extensions.mha_varlen_fwd,
         "aiter::fmha_v3_varlen_fwd": attention_perf_model_extensions.aiter_fmha_v3_varlen_fwd,
         "aiter::mha_batch_prefill": attention_perf_model_extensions.aiter_mha_batch_prefill,

--- a/TraceLens/Reporting/generate_perf_report_pytorch_inference.py
+++ b/TraceLens/Reporting/generate_perf_report_pytorch_inference.py
@@ -595,6 +595,7 @@ def generate_perf_report_pytorch(
     perf_analyzer.tree.apply_annotation(
         name_filters=[
             "vllm::unified_attention_with_output",
+            "vllm::rocm_aiter_sparse_attn_indexer",
             "aiter::mha_varlen_fwd",
             "pseudo_mla_decode_fwd",
             "pseudo_mla_prefill_fwd",


### PR DESCRIPTION
The DeepSeek sparse-attention "lightning indexer" kernel had no perf model, so it reported 0 FLOPs/bytes and was dropped from roofline scoring despite being a meaningful chunk of GLM5 decode time. This adds rocm_aiter_sparse_attn_indexer (subclassing InferenceAttention to reuse the vLLM annotation parsing for exact QK-pair aggregates).

- FLOPs: fp8 MQA index-score QK only (no PV — the kernel scores + selects top-k, no value aggregation).
- Bytes: fused MQA traffic — keys read once across heads (cached fp8 rows + current bf16 key), fp32 weights read, int32 top-k write.
- Registers the op and adds it to the inference report's annotation name-filter so it gets the seqlen aggregates its model needs.
- Verified end-to-end: the indexer now reports non-zero GFLOPS/Data Moved on GLM5 with no regressions.
