### PR TITLE
Bump artifact actions to Node 24 in unit-tests workflow

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -44,7 +44,7 @@ jobs:
             --junitxml=junit.xml -o junit_family=legacy
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-report
           path: coverage.xml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Upload junit report
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: junit-report
           path: junit.xml
@@ -67,12 +67,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download coverage report
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: coverage-report
 
       - name: Download junit report
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: junit-report
 


### PR DESCRIPTION
## Summary
- Upgrade `actions/upload-artifact` from v4 to v6 in the unit-tests workflow
- Upgrade `actions/download-artifact` from v4 to v8 in the codecov follow-up job
- Removes the Node 20 deprecation warning on the "Upload junit report" step (and related artifact upload/download steps)

## Context
GitHub Actions is deprecating Node 20 on hosted runners. The junit/coverage artifact steps were still using v4 actions that run on Node 20 by default.

## Test plan
- [ ] Unit Tests workflow completes without Node 20 deprecation warnings on artifact steps
- [ ] Coverage and junit artifacts are still uploaded and consumed by the Codecov job


Made with [Cursor](https://cursor.com)