### PR TITLE
fix(validation): accept empty kernel-fusion fallback findings

### DIFF
--- a/TraceLens/Agent/Analysis/utils/validation_utils.py
+++ b/TraceLens/Agent/Analysis/utils/validation_utils.py
@@ -129,6 +129,20 @@ def _category_findings_empty(filepath):
     return isinstance(cf, list) and len(cf) == 0
 
 
+def _fusion_no_data(filepath):
+    """True when kernel_fusion_metrics.json has no impact estimates (kernel-fusion-analyzer § empty fallback)."""
+    mp = _metrics_json_for_findings(filepath)
+    try:
+        with open(mp) as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return False
+    if data.get("status") == "NO_DATA":
+        return True
+    est = data.get("impact_estimates")
+    return isinstance(est, list) and len(est) == 0
+
+
 def validate_findings_file(filepath, tier, comparison_scope=None):
     """Validate a single findings file against the sub-agent spec contract.
 
@@ -160,21 +174,23 @@ def validate_findings_file(filepath, tier, comparison_scope=None):
 
     errors = []
 
-    header_positions = []
-    for h in _REQUIRED_FINDINGS_HEADERS:
-        pos = content.find(h)
-        if pos < 0:
-            errors.append(f"Missing required section: {h}")
-        header_positions.append(pos)
+    relaxed_empty = tier == "compute" and _category_findings_empty(filepath)
+    relaxed_empty = relaxed_empty or (tier == "fusion" and _fusion_no_data(filepath))
 
-    if all(p >= 0 for p in header_positions):
+    header_positions = []
+    if not relaxed_empty:
+        for h in _REQUIRED_FINDINGS_HEADERS:
+            pos = content.find(h)
+            if pos < 0:
+                errors.append(f"Missing required section: {h}")
+            header_positions.append(pos)
+
+    if header_positions and all(p >= 0 for p in header_positions):
         if header_positions[0] > header_positions[1]:
             errors.append("## Recommendations must appear before ## Detailed Analysis")
 
     rec_start = content.find("## Recommendations")
     da_start = content.find("## Detailed Analysis")
-
-    relaxed_empty = tier == "compute" and _category_findings_empty(filepath)
 
     p_items = []
     if rec_start >= 0:
@@ -999,7 +1015,7 @@ class MarkerValidator:
         if file_class == "category_findings" and rel not in cls.COMPUTE_NO_P_ITEM:
             if not skip_p_item_required and "p_item" not in seen_kinds:
                 errors.append(f"{rel}: missing required kind=p_item")
-        if file_class == "system_findings" and "p_item" not in seen_kinds:
+        if file_class == "system_findings" and not skip_p_item_required and "p_item" not in seen_kinds:
             errors.append(f"{rel}: missing required kind=p_item")
         n_headings = len(_P_ITEM_RE.findall(text))
         n_markers = sum(


### PR DESCRIPTION
## Summary

The kernel-fusion analyzer emits an honest `"No kernel fusion opportunities detected."` fallback findings file when no fusion candidates exist, but `validate_findings_file` rejected it with three errors:

- `Missing required section: ## Recommendations`
- `Missing required section: ## Detailed Analysis`
- `kernel_fusion_findings.md: missing required kind=p_item`

This made the empty-fusion case unvalidatable in the agentic analysis-orchestrator workflow: any trace with no fusion candidates failed Step 8 (`validate_subagent_outputs`), even though the analyzer's fallback output is correct by design.

## Changes

`TraceLens/Agent/Analysis/utils/validation_utils.py`:

1. **New `_fusion_no_data(filepath)` helper** — returns True when `kernel_fusion_metrics.json` reports `status == "NO_DATA"` or has an empty `impact_estimates` list (the analyzer's empty-fallback signals).
2. **Extend the existing `relaxed_empty` path to the fusion tier** — `validate_findings_file` now skips the required-section check for fusion findings files that are genuine empty fallbacks, mirroring the existing compute-tier empty-category handling (`_category_findings_empty`).
3. **`MarkerValidator.check_findings_file`** — the `system_findings` `kind=p_item` requirement now honors `skip_p_item_required` (previously hard-required). This is load-bearing because `kernel_fusion` is a system-tier category, so its fallback findings file lives in `system_findings/` and legitimately carries no P-item markers.

## Verification

Before/after on a real trace with no fusion candidates (`system_findings/kernel_fusion_findings.md`):

| | Without fix | With fix |
|---|---|---|
| Missing required section: ## Recommendations | ❌ | ✅ |
| Missing required section: ## Detailed Analysis | ❌ | ✅ |
| missing required kind=p_item | ❌ | ✅ |

`validate_findings_file` returns `(True, [])` with the fix; the empty-fusion fallback now validates end-to-end in the orchestrator pipeline.

## Impact

Unblocks the analysis-orchestrator Step 8 validation for workloads where the kernel-fusion analysis legitimately finds no candidates (e.g. fully-fused training traces, traces where <75% of kernels have perf models). No behavior change for non-empty findings files.