### PR TITLE
feat(arch): add MI355X arch spec with estimated MAF values

### DIFF
--- a/TraceLens/Agent/Analysis/utils/arch/MI355X.json
+++ b/TraceLens/Agent/Analysis/utils/arch/MI355X.json
@@ -1,0 +1,17 @@
+{
+    "name": "MI355X",
+    "mem_bw_gbps": 8000,
+    "memory_gb": 288,
+    "max_achievable_tflops": {
+        "matrix_fp16": 1518,
+        "matrix_bf16": 1613,
+        "matrix_fp32": 93,
+        "matrix_fp64": 47,
+        "matrix_fp8": 2905,
+        "matrix_int8": 2960,
+        "vector_fp16": 157,
+        "vector_bf16": 157,
+        "vector_fp32": 157,
+        "vector_fp64": 79
+    }
+}

--- a/TraceLens/Agent/Analysis/utils/arch/README.md
+++ b/TraceLens/Agent/Analysis/utils/arch/README.md
@@ -10,5 +10,14 @@ These performance metrics are derived from the following sources:
 - [Understanding Peak and Max-Achievable FLOPS](https://rocm.blogs.amd.com/software-tools-optimization/Understanding_Peak_and_Max-Achievable_FLOPS/README.html)
 - [AMD Instinct MI300X](https://www.amd.com/en/products/accelerators/instinct/mi300/mi300x.html)
 - [AMD Instinct MI325X](https://www.amd.com/en/products/accelerators/instinct/mi300/mi325x.html)
+- [AMD Instinct MI355X](https://www.amd.com/en/products/accelerators/instinct/mi350/mi355x.html)
+
+**MI355X.json caveat:** memory/vector values are AMD-published specs (288 GB HBM3E,
+8 TB/s, 157.3 TFLOPS vector FP16/FP32, 78.6 TFLOPS FP64). The `matrix_*` MAF
+entries are ESTIMATES derived by applying MI325X's measured MAF:peak ratios to
+MI355X published peak matrix rates — replace them by running
+`python -m TraceLens.PerfModel.benchmarking.microbench --device 0
+--output TraceLens/Agent/Analysis/utils/arch/MI355X.json` on real MI355X
+hardware (see PerfModel/benchmarking/README.md).
 
 They represent peak performance bounds used to estimate the optimization headroom available given measured kernel performance. In practice, real kernels may not reach these bounds.


### PR DESCRIPTION
## Summary

The analysis-orchestrator skill lists **MI350X / MI355X / MI455X** as platform options, but `Agent/Analysis/utils/arch/` only shipped `MI300X.json` and `MI325X.json`. As a result `orchestrator_prepare.py --platform MI355X` was rejected, and MI355X traces had to be analyzed against the MI325X roofline (wrong on both compute and bandwidth: BF16 MAF 843 vs ~1.6k, HBM 6.0 vs 8.0 TB/s).

This PR adds `MI355X.json` so the platform resolves natively.

## Values

| Field | Value | Source |
|---|---|---|
| memory | 288 GB HBM3E | AMD product page |
| mem_bw | 8.0 TB/s | AMD product page |
| vector FP16/FP32 | 157.3 TFLOPS | AMD product page |
| vector FP64 | 78.6 TFLOPS | AMD product page |
| matrix BF16/FP16 MAF | 1613 / 1518 TFLOPS | **estimated** |
| matrix FP8 / INT8 MAF | 2905 / 2960 TFLOPS | **estimated** |
| matrix FP32 / FP64 MAF | 93 / 47 TFLOPS | **estimated** |

**Matrix MAF entries are estimates** — MAF is a hardware-measured quantity (per the [ROCm max-achievable-FLOPS methodology](https://rocm.blogs.amd.com/software-tools-optimization/Understanding_Peak_and_Max-Achievable_FLOPS/README.html)), and no MI355X MAF measurement is published. They are derived by applying MI325X's measured MAF:peak ratios (0.58–0.65 across precisions) to AMD-published MI355X peak matrix rates. The `arch/README.md` caveat documents this and points to the repo's existing microbench flow (`python -m TraceLens.PerfModel.benchmarking.microbench --output .../MI355X.json`) for replacing them with measured values on real hardware.

## Verification

- `load_arch('MI355X')` resolves; `list_platforms()` includes it
- `orchestrator_prepare.py --platform MI355X` accepts the choice
- Steps 1–5 of the orchestrator pipeline ran clean on `tests/traces/mi355/eager_trace.json.gz` with the new arch file

## Note

`MI350X.json` and `MI455X.json` remain unshipped; happy to add them the same way if useful (MI350X shares the MI355X memory/vector envelope per AMD's MI350-series page).