### PR TITLE
ci: run unit and lint only when Python, tests, or package deps change

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,9 +10,23 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "**/*.py"
+      - "tests/**"
+      - "setup.py"
+      - "MANIFEST.in"
+      - ".importlinter"
+      - ".github/workflows/lint.yml"
   pull_request:
     branches:
       - main
+    paths:
+      - "**/*.py"
+      - "tests/**"
+      - "setup.py"
+      - "MANIFEST.in"
+      - ".importlinter"
+      - ".github/workflows/lint.yml"
 
 jobs:
   lint:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,7 @@ on:
       - "MANIFEST.in"
       - ".importlinter"
       - ".github/workflows/lint.yml"
+      - ".github/workflows/unit-tests.yml"
   pull_request:
     branches:
       - main
@@ -27,6 +28,7 @@ on:
       - "MANIFEST.in"
       - ".importlinter"
       - ".github/workflows/lint.yml"
+      - ".github/workflows/unit-tests.yml"
 
 jobs:
   lint:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,6 @@ on:
       - "MANIFEST.in"
       - ".importlinter"
       - ".github/workflows/lint.yml"
-      - ".github/workflows/unit-tests.yml"
   pull_request:
     branches:
       - main
@@ -28,7 +27,6 @@ on:
       - "MANIFEST.in"
       - ".importlinter"
       - ".github/workflows/lint.yml"
-      - ".github/workflows/unit-tests.yml"
 
 jobs:
   lint:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,7 +17,6 @@ on:
       - ".coveragerc"
       - "codecov.yml"
       - ".github/workflows/unit-tests.yml"
-      - ".github/workflows/lint.yml"
   pull_request:
     branches: [ main ]
     paths:
@@ -28,7 +27,6 @@ on:
       - ".coveragerc"
       - "codecov.yml"
       - ".github/workflows/unit-tests.yml"
-      - ".github/workflows/lint.yml"
 
 jobs:
   unit-tests:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,6 +17,7 @@ on:
       - ".coveragerc"
       - "codecov.yml"
       - ".github/workflows/unit-tests.yml"
+      - ".github/workflows/lint.yml"
   pull_request:
     branches: [ main ]
     paths:
@@ -27,6 +28,7 @@ on:
       - ".coveragerc"
       - "codecov.yml"
       - ".github/workflows/unit-tests.yml"
+      - ".github/workflows/lint.yml"
 
 jobs:
   unit-tests:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -9,8 +9,24 @@ name: Unit Tests
 on:
   push:
     branches: [ main ]
+    paths:
+      - "**/*.py"
+      - "tests/**"
+      - "setup.py"
+      - "MANIFEST.in"
+      - ".coveragerc"
+      - "codecov.yml"
+      - ".github/workflows/unit-tests.yml"
   pull_request:
     branches: [ main ]
+    paths:
+      - "**/*.py"
+      - "tests/**"
+      - "setup.py"
+      - "MANIFEST.in"
+      - ".coveragerc"
+      - "codecov.yml"
+      - ".github/workflows/unit-tests.yml"
 
 jobs:
   unit-tests:


### PR DESCRIPTION
## Summary
- Add `paths` filters to the unit-tests and lint workflows so they skip unrelated changes (docs, skills markdown, examples-only, etc.).
- Trigger on Python sources, the `tests/` tree, wheel/package metadata (`setup.py`, `MANIFEST.in`), relevant CI/lint config, and the workflow files themselves.

## Test plan
- [ ] Confirm this PR still runs Unit Tests and Lint (workflow files are in the path filters).
- [ ] Open or check a docs-only / non-Python PR and verify Unit Tests and Lint do not start.
- [ ] Touch a `.py` file or `tests/` fixture and verify both workflows run.


Made with [Cursor](https://cursor.com)