### PR TITLE
Specify 1m context length in docs

### DIFF
--- a/TraceLens/Agent/Analysis/README.md
+++ b/TraceLens/Agent/Analysis/README.md
@@ -77,7 +77,7 @@ Roofline analysis compares each measured kernel against your GPU's max-achievabl
 
 ### To run manually:
 
-1. **In an agent chat with a capable frontier model, invoke one of:**
+1. **In an agent chat with a capable frontier model that has a context length of 1M, invoke one of:**
    - Standalone (single eager trace):
     ```
     "Follow the analysis orchestrator installed with TraceLens and run the full agentic analysis workflow on <path_to_trace.json>"

--- a/TraceLens/Agent/Profiling/README.md
+++ b/TraceLens/Agent/Profiling/README.md
@@ -47,7 +47,7 @@ pip install git+https://github.com/AMD-AGI/TraceLens.git
 
 ### To run via Cursor chat:
 
-1. **In a Cursor chat with Claude Opus 4.7 High, invoke:**
+1. **In a Cursor chat with Claude Opus 4.7 High with context length 1M, invoke:**
    ```
    "Follow the Magpie Benchmark + Profiling skill installed with TraceLens and run the benchmark + trace collection workflow on <path_to_config.yaml>"
    ```


### PR DESCRIPTION
TraceLens Agent needs a context length of around 1M. Docs now specify this requirement.