### PR TITLE
TL Agent Deterministic Fallback

### DIFF
--- a/TraceLens/Agent/Analysis/skills/analysis-orchestrator/SKILL.md
+++ b/TraceLens/Agent/Analysis/skills/analysis-orchestrator/SKILL.md
@@ -29,7 +29,7 @@ Follow **[reference.md](reference.md)** for every step (user prompts, `<prefix>`
 ```
 0. Query User Inputs (Platform, Trace Path(s), Analysis Mode, Environment Setup)
 1. Generate Performance Report (branches on analysis mode: training vs inference then, comparison scope)
-2. Trace-Quality Gate — deterministic fallback analysis if the gate fails
+2. Trace-Quality Gate → Deterministic fallback analysis
 3-6. Prepare Category Data (GPU Util, Top Ops, Tree Data, Multi-Kernel Data, Category Filtering)
 7. System-Level Analysis (PARALLEL) → system_findings/
 8. Compute Kernel Subagents (PARALLEL) → category_findings/

--- a/TraceLens/Agent/Analysis/skills/analysis-orchestrator/SKILL.md
+++ b/TraceLens/Agent/Analysis/skills/analysis-orchestrator/SKILL.md
@@ -29,19 +29,20 @@ Follow **[reference.md](reference.md)** for every step (user prompts, `<prefix>`
 ```
 0. Query User Inputs (Platform, Trace Path(s), Analysis Mode, Environment Setup)
 1. Generate Performance Report (branches on analysis mode: training vs inference then, comparison scope)
-2-5. Prepare Category Data (GPU Util, Top Ops, Tree Data, Multi-Kernel Data, Category Filtering)
-6. System-Level Analysis (PARALLEL) → system_findings/
-7. Compute Kernel Subagents (PARALLEL) → category_findings/
-   7.5. Aggregate → priority_data.json::findings[]
-8. Validate Subagent Outputs
-9. load_findings + Model Identification (subagent) → metadata/model_info.json
-10. Render performance PNG if agent_extension.py is absent
-11. Generate analysis.md (orchestrator writes via <prefix> tee), optional extension, embed PNG
+2. Trace-Quality Gate — deterministic fallback analysis if the gate fails
+3-6. Prepare Category Data (GPU Util, Top Ops, Tree Data, Multi-Kernel Data, Category Filtering)
+7. System-Level Analysis (PARALLEL) → system_findings/
+8. Compute Kernel Subagents (PARALLEL) → category_findings/
+  8.5. Aggregate → priority_data.json::findings[]
+9. Validate Subagent Outputs
+10. load_findings + Model Identification (subagent) → metadata/model_info.json
+11. Render performance PNG if agent_extension.py is absent
+12. Generate analysis.md (orchestrator writes via <prefix> tee), optional extension, embed PNG
 ```
 
 ## Rules
 
-- **Subagents:** Use the Task tool **only** where reference.md says “subagent” (Steps **6**, **7**, **9**). The orchestrator runs everything else, including Step 7.5, using the command prefix from `<output_dir>/cache/cmd_prefix.txt` (`{CMD}` substitution).
+- **Subagents:** Use the Task tool **only** where reference.md says “subagent” (Steps **7**, **8**, **10**). The orchestrator runs everything else, including Step 8.5, using the command prefix from `<output_dir>/cache/cmd_prefix.txt` (`{CMD}` substitution).
 - **Language:** Prefer vendor-agnostic terms (GPU kernels, collective communication, vendor GEMM library, DNN primitives, GPU graph). When quoting trace data, real kernel names are fine.
 - **Subagent prompts:** Point each subagent at the checked-in agent file under `TraceLens/Agent/Analysis/skills/analysis-orchestrator/agents/<name>.md` (see reference.md for exact paths and prompt shells).
 

--- a/TraceLens/Agent/Analysis/skills/analysis-orchestrator/agents/kernel-fusion-analyzer.md
+++ b/TraceLens/Agent/Analysis/skills/analysis-orchestrator/agents/kernel-fusion-analyzer.md
@@ -6,7 +6,7 @@ See LICENSE for license information.
 
 ---
 name: kernel-fusion-analyzer
-description: Analyze kernel fusion opportunities from pre-extracted candidate data. Use when orchestrator detects fusion candidates in Step 4b.
+description: Analyze kernel fusion opportunities from pre-extracted candidate data. Use when orchestrator detects fusion candidates in Step 5b.
 model: claude-opus-4-7-high
 ---
 

--- a/TraceLens/Agent/Analysis/skills/analysis-orchestrator/reference.md
+++ b/TraceLens/Agent/Analysis/skills/analysis-orchestrator/reference.md
@@ -263,14 +263,12 @@ All commands below append `<suffix_1>` and `<suffix_2>`, resolved by `<compariso
 
 ```bash
 <prefix> python3 -c \"
-import sys
 from TraceLens.Agent.Analysis.utils import check_graph_replay_coverage
-v = check_graph_replay_coverage(sys.argv[1])
-status = 'GRAPH_UNDER_RECORDED' if v.graph_under_recorded else 'OK'
+coverage = check_graph_replay_coverage(<unified_perf_csv>)
+status = 'GRAPH_UNDER_RECORDED' if coverage.graph_under_recorded else 'OK'
 print(f'STATUS={status}')
-print(f'GRAPH_REPLAY_FRACTION={v.graph_replay_fraction}')
-print(f'REASON={v.reason}')
-\" '<unified_perf_csv>'
+print(f'GRAPH_REPLAY_FRACTION={coverage.graph_replay_fraction}')
+" 
 ```
 <graph_replay_fraction> refers to the returned GRAPH_REPLAY_FRACTION value.
 
@@ -282,7 +280,7 @@ print(f'REASON={v.reason}')
    <prefix> python3 -m TraceLens.Agent.Analysis.utils.deterministic_fallback \
      --unified-perf-csv '<unified_perf_csv>' \
      --output-dir '<output_dir>' \ 
-     --graph-replay-fraction '<graph_replay_fraction>'
+     --graph-replay-fraction <graph_replay_fraction>
    ```
 3. **Skip Steps 3-12.** The writer already produced `<output_dir>/analysis.md`
 

--- a/TraceLens/Agent/Analysis/skills/analysis-orchestrator/reference.md
+++ b/TraceLens/Agent/Analysis/skills/analysis-orchestrator/reference.md
@@ -10,7 +10,7 @@ This document is the detailed specification for the TraceLens **analysis-orchest
 
 ## Workflow overview
 
-The orchestrator runs a staged pipeline (Steps 0–11): collect inputs and environment prefix, generate perf reports, prepare category data via `orchestrator_prepare.py`, run system-level and compute-kernel subagents in parallel, aggregate and validate findings, identify the model, render plots when no extension is present, and write `analysis.md` via remote `tee` heredocs. Only Steps 6, 7, and 9 delegate to Task subagents; all other steps run in the main agent.
+The orchestrator runs a staged pipeline (Steps 0–12): collect inputs and environment prefix, generate perf reports, prepare category data via `orchestrator_prepare.py`, run system-level and compute-kernel subagents in parallel, aggregate and validate findings, identify the model, render plots when no extension is present, and write `analysis.md` via remote `tee` heredocs. Only Steps 7, 8, and 10 delegate to Task subagents; all other steps run in the main agent.
 
 ---
 
@@ -27,18 +27,19 @@ Use vendor-agnostic terminology throughout such as GPU kernels, collective commu
 ```
 0. Query User Inputs (Platform, Trace Path(s), Analysis Mode, Environment Setup)
 1. Generate Performance Report (branches on analysis mode: training vs inference then, comparison scope)
-2-5. Prepare Category Data (GPU Util, Top Ops, Tree Data, Multi-Kernel Data, Category Filtering)
-6. System-Level Analysis (PARALLEL, CPU/Idle + Kernel Fusion + Multi-Kernel) → system_findings/
-7. Invoke Compute Kernel Subagents (PARALLEL, read category_findings[] from _metrics.json) → category_findings/
-   7.5. Aggregate per-category category_findings[] → priority_data.json::findings[] (globally sorted)
-8. Validate Subagent Outputs (system_findings/ + category_findings/)
-9. Prepare Report Data (load_findings) + Model Identification (subagent) → metadata/model_info.json
-10. Render performance PNG IF agent_extension.py is absent
-11. Generate Final Report (composable System + Compute sections), validate it,
+2. Trace-Quality Gate (deterministic fallback branch for graph-under-recorded traces)
+3-6. Prepare Category Data (GPU Util, Top Ops, Tree Data, Multi-Kernel Data, Category Filtering)
+7. System-Level Analysis (PARALLEL, CPU/Idle + Kernel Fusion + Multi-Kernel) → system_findings/
+8. Invoke Compute Kernel Subagents (PARALLEL, read category_findings[] from _metrics.json) → category_findings/
+   8.5. Aggregate per-category category_findings[] → priority_data.json::findings[] (globally sorted)
+9. Validate Subagent Outputs (system_findings/ + category_findings/)
+10. Prepare Report Data (load_findings) + Model Identification (subagent) → metadata/model_info.json
+11. Render performance PNG IF agent_extension.py is absent
+12. Generate Final Report (composable System + Compute sections), validate it,
     optionally invoke agent_extension.py (when present), then embed the PNG into the report.
 ```
 
-**Subagent usage:** Only invoke Task subagents in steps that explicitly say "subagent" (Steps 6, 7, 9). All other steps (including Step 7.5) must be performed directly by the orchestrator using the command prefix.
+**Subagent usage:** Only invoke Task subagents in steps that explicitly say "subagent" (Steps 7, 8, 10). All other steps (including Step 8.5) must be performed directly by the orchestrator using the command prefix.
 
 ---
 
@@ -255,7 +256,35 @@ All commands below append `<suffix_1>` and `<suffix_2>`, resolved by `<compariso
 
 ---
 
-## Steps 2-5: Prepare Category Data
+## Step 2: Trace-Quality Gate
+
+
+`<csv_dir>` is `<output_dir>/perf_report_csvs` (`standalone`) or `<output_dir>/perf_report_trace1_csvs` (`comparative`, primary trace).
+
+```bash
+<prefix> python3 -c \"
+import sys
+from TraceLens.Agent.Analysis.utils import check_graph_replay_coverage
+v = check_graph_replay_coverage(sys.argv[1])
+print('GRAPH_UNDER_RECORDED' if v.graph_under_recorded else 'OK', v.graph_replay_fraction, v.reason)
+\" '<csv_dir>'
+```
+
+**`OK`:** Proceed
+**`GRAPH_UNDER_RECORDED`:**
+1. Emit `[DIAG:trace_quality:GRAPH_UNDER_RECORDED]`: Deterministic fallback report
+2. Run the deterministic fallback writer on `<csv_dir>`:
+   ```bash
+   <prefix> python3 -m TraceLens.Agent.Analysis.utils.deterministic_fallback \
+     --perf-csvs-dir '<csv_dir>' \
+     --output-dir '<output_dir>' \
+     --graph-replay-fraction <graph_replay_fraction>
+   ```
+3. **Skip Steps 3-12.** The writer already produced `<output_dir>/analysis.md`
+
+---
+
+## Steps 3-6: Prepare Category Data
 
 Execute the TraceLens Agentic Mode orchestrator preparation script:
 
@@ -269,11 +298,11 @@ Execute the TraceLens Agentic Mode orchestrator preparation script:
 ```
 
 This script performs:
-- **Step 2:** Assess GPU utilization (computation, idle, communication times)
-- **Step 3:** Identify top 10 operations by GPU time
-- **Step 4:** Pre-compute tree data for bottleneck operations (load trace ONCE)
-- **Step 4.5:** Pre-compute multi-kernel issue data (memcpy by direction, NCCL events, overlap metrics)
-- **Step 5:** Filter and export category-specific data
+- **Step 3:** Assess GPU utilization (computation, idle, communication times)
+- **Step 4:** Identify top 10 operations by GPU time
+- **Step 5:** Pre-compute tree data for bottleneck operations (load trace ONCE)
+- **Step 5.5:** Pre-compute multi-kernel issue data (memcpy by direction, NCCL events, overlap metrics)
+- **Step 6:** Filter and export category-specific data
 
 **Outputs:**
 - `category_data/<category>_ops.csv` - Filtered operations per category
@@ -285,13 +314,13 @@ This script performs:
 
 ---
 
-## Step 6: System-Level Analysis (PARALLEL)
+## Step 7: System-Level Analysis (PARALLEL)
 
 System-level analysis examines issues that affect the GPU pipeline as a whole -- idle time, memory transfer patterns, and communication/compute overlap. These are **not** about individual kernel efficiency.
 
 **Output directory:** `system_findings/`
 
-### 6.1 Read Manifest and Identify System-Level Subagents
+### 7.1 Read Manifest and Identify System-Level Subagents
 
 ```bash
 <prefix> python3 -c \"
@@ -301,9 +330,9 @@ load_manifest_categories(sys.argv[1])
 \" '<output_dir>'"
 ```
 
-This prints `system_categories` and `compute_categories` lists. Use `system_categories` for Step 6 and `compute_categories` for Step 7.
+This prints `system_categories` and `compute_categories` lists. Use `system_categories` for Step 7 and `compute_categories` for Step 8.
 
-### 6.2 Launch System-Level Subagents in PARALLEL
+### 7.2 Launch System-Level Subagents in PARALLEL
 
 Launch system-level sub-agents simultaneously using the Task tool. Do NOT wait between invocations.
 
@@ -347,12 +376,12 @@ Execute every step in the agent file. Return "DONE" when complete.
 3. Reading the metrics JSON output
 4. Identifying issues and generating findings
 
-### 6.3 Wait for System-Level Subagents to Complete
+### 7.3 Wait for System-Level Subagents to Complete
 
-The three subagents must complete before proceeding to Step 6.4.
+The three subagents must complete before proceeding to Step 7.4.
 Each writes findings to `system_findings/<name>_findings.md`.
 
-### 6.4 Verify System Outputs and Retry Failures (up to 1 retry per subagent)
+### 7.4 Verify System Outputs and Retry Failures (up to 1 retry per subagent)
 
 After all system-level subagents complete:
 
@@ -360,25 +389,25 @@ After all system-level subagents complete:
    - Does `system_findings/<category>_findings.md` exist?
    - If it exists, does it contain "Status: ERROR"?
 2. Collect a list of **failed** categories (missing file OR Status: ERROR).
-3. **Retry each failed category exactly once** by re-launching its subagent with the same prompt from Step 6.2. Wait for all retries to complete before proceeding.
+3. **Retry each failed category exactly once** by re-launching its subagent with the same prompt from Step 7.2. Wait for all retries to complete before proceeding.
 4. After retries, re-check outputs. Any category that still fails is excluded from aggregation.
 5. **CRITICAL: Do NOT attempt manual analysis of failed system checks — only automated subagent retry is allowed.**
 
 ---
 
-## Step 7: Invoke Compute Kernel Subagents (PARALLEL)
+## Step 8: Invoke Compute Kernel Subagents (PARALLEL)
 
 Compute kernel analysis examines individual operation category efficiency.
 
 **Output directory:** `category_findings/`
 
-### 7.1 Read Manifest and Identify Compute Kernel Categories
+### 8.1 Read Manifest and Identify Compute Kernel Categories
 
-Use `compute_categories` from the `load_manifest_categories()` call in Step 6.1.
+Use `compute_categories` from the `load_manifest_categories()` call in Step 7.1.
 
-### 7.2 Launch Compute Kernel Subagents in PARALLEL
+### 8.2 Launch Compute Kernel Subagents in PARALLEL
 
-For each entry in `compute_categories` (loaded in Step 6.1), resolve `{agent_file}` as `{entry.skill}.md` and launch a subagent with agent file `TraceLens/Agent/Analysis/skills/analysis-orchestrator/agents/{agent_file}`. Fall back to `generic-op-analyzer.md` if the file is absent.
+For each entry in `compute_categories` (loaded in Step 7.1), resolve `{agent_file}` as `{entry.skill}.md` and launch a subagent with agent file `TraceLens/Agent/Analysis/skills/analysis-orchestrator/agents/{agent_file}`. Fall back to `generic-op-analyzer.md` if the file is absent.
 
 Launch all subagents simultaneously in a single parallel batch.
 
@@ -435,12 +464,12 @@ Read and follow the FULL instructions in:
 Execute every step in the agent file. Return "DONE" when complete.
 ```
 
-### 7.3 Wait for All Compute Kernel Subagents to Complete
+### 8.3 Wait for All Compute Kernel Subagents to Complete
 
-All subagents must complete before proceeding to Step 7.4.
+All subagents must complete before proceeding to Step 8.4.
 Each subagent writes its findings to `category_findings/<category>_findings.md`.
 
-### 7.4 Verify Outputs and Retry Failures (up to 1 retry per subagent)
+### 8.4 Verify Outputs and Retry Failures (up to 1 retry per subagent)
 
 After all compute kernel subagents complete:
 
@@ -448,11 +477,11 @@ After all compute kernel subagents complete:
    - Does `category_findings/<category>_findings.md` exist?
    - If it exists, does it contain "Status: ERROR"?
 2. Collect a list of **failed** categories (missing file OR Status: ERROR).
-3. **Retry each failed category exactly once** by re-launching its subagent with the same prompt structure from Step 7.2. Launch all retries in parallel and wait for completion.
+3. **Retry each failed category exactly once** by re-launching its subagent with the same prompt structure from Step 8.2. Launch all retries in parallel and wait for completion.
 4. After retries, re-check outputs. Any category that still fails is excluded from aggregation and recommendations.
 5. **CRITICAL: Do NOT attempt to manually analyze failed categories — only automated subagent retry is allowed.**
 
-### 7.5 Aggregate findings → priority_data.json
+### 8.5 Aggregate findings → priority_data.json
 
 After all compute sub-agent `_metrics.json` files exist (each carrying its own `category_findings[]`), concatenate them into a globally-sorted `priority_data.json::findings[]` for the report template.
 
@@ -466,7 +495,7 @@ generate_priority_data(sys.argv[1])
 
 ---
 
-## Step 8: Validate Subagent Outputs
+## Step 9: Validate Subagent Outputs
 
 Before aggregating results, validate outputs from **both** tiers (system_findings/ and category_findings/).
 
@@ -486,7 +515,7 @@ This runs four checks:
 
 ---
 
-## Step 9: Prepare Report Data + Model Identification
+## Step 10: Prepare Report Data + Model Identification
 
 ```bash
 <prefix> python3 -c \"
@@ -496,7 +525,7 @@ load_findings(sys.argv[1])
 \" '<output_dir>'"
 ```
 
-### 9.1 Model Identification (Subagent, retry once on failure)
+### 10.1 Model Identification (Subagent, retry once on failure)
 
 Launch a Task subagent (generalPurpose) that reads and follows `TraceLens/Agent/Analysis/skills/analysis-orchestrator/agents/model-identification-agent.md` with context: <output_dir>. Wait for completion.
 
@@ -508,12 +537,12 @@ Assign <Model> to model value in `<output_dir>/metadata/model_info.json` or "Wor
 
 ---
 
-## Step 10: Render Plot (conditional)
+## Step 11: Render Plot (conditional)
 
-**Important:** Plot data is sourced from `priority_data.json` (written in Step 7.5). This step only renders the PNG when `agent_extension.py` is absent.
+**Important:** Plot data is sourced from `priority_data.json` (written in Step 8.5). This step only renders the PNG when `agent_extension.py` is absent.
 Look at the environment variable TL_EXTENSION to find python packages and directories to recursively search for `agent_extension.py`.
 If this environment variable is not present or the it is not found look in TraceLens/Agent/Analysis/utils/.
-If the file is present, **skip this step** — Step 11.2 will produce `perf_improvement.png` and Step 11.3 will embed it.
+If the file is present, **skip this step** — Step 12.2 will produce `perf_improvement.png` and Step 12.3 will embed it.
 Use <agent_extension_file> to represent the location of this file.
 
 ```bash
@@ -527,13 +556,13 @@ generate_perf_plot(sys.argv[1], sys.argv[2])
 fi
 ```
 
-If the plot fails (extension-absent branch), retry once. If still failing, proceed to Step 11 without the plot.
+If the plot fails (extension-absent branch), retry once. If still failing, proceed to Step 12 without the plot.
 
 ---
 
-## Step 11: Generate Final Report (<output_dir>/analysis.md)
+## Step 12: Generate Final Report (<output_dir>/analysis.md)
 
-**CRITICAL: Do NOT delegate Step 11 to a Task subagent.** The orchestrator must write the report directly.
+**CRITICAL: Do NOT delegate Step 12 to a Task subagent.** The orchestrator must write the report directly.
 
 1. **Read** the report template: `TraceLens/Agent/Analysis/skills/analysis-orchestrator/templates/analysis_template.md`
 2. **Write the report in sections** to `<output_dir>/analysis.md` using **only** `<prefix> tee` / `<prefix> tee -a` with single-quoted heredoc delimiters (see write order below). You MUST NOT use the IDE Write tool, Edit tool, StrReplace tool, `cat >`, `echo >`, `>>` redirect, or any other write method for `analysis.md` unless tee fails.
@@ -574,7 +603,7 @@ The report at `<output_dir>/analysis.md` must use these exact `##` headers — d
 6. `## Appendix`
 
 
-### 11.1 Validate Report Structure (Retry up to 2x)
+### 12.1 Validate Report Structure (Retry up to 2x)
 
 After writing `analysis.md`, validate that the report contains all required `##` section headers. If validation fails, modify the report with the missing sections.
 
@@ -610,11 +639,11 @@ h. For priority-consistency errors (R1 P-item count mismatch, R2 P-item category
 
 ---
 
-### 11.2 Optional extension (auto-detected)
+### 12.2 Optional extension (auto-detected)
 
 If `<agent_extension_file>` exists, run it as shown below. Its behavior is documented in the extension itself; the orchestrator does not need to inspect or reason about it.
 
-If the file is absent, skip this step silently. The analysis is complete; the simple plot from Step 10 stays in place.
+If the file is absent, skip this step silently. The analysis is complete; the simple plot from Step 11 stays in place.
 
 ```bash
 EXT='<agent_extension_file>'
@@ -629,9 +658,9 @@ This step is a hook for an optional extension; if `agent_extension.py` is not pr
 
 ---
 
-### 11.3 Embed Performance Improvement Plot
+### 12.3 Embed Performance Improvement Plot
 
-The PNG (`perf_improvement.png`) is already on disk from either Step 10.3 or Step 11.2 (whichever ran). This step only embeds its base64 sidecar into the report at the `{{PERF_PLOT}}` placeholder.
+The PNG (`perf_improvement.png`) is already on disk from either Step 11 or Step 12.2 (whichever ran). This step only embeds its base64 sidecar into the report at the `{{PERF_PLOT}}` placeholder.
 
 ```bash
 <prefix> python3 -c \"
@@ -646,7 +675,7 @@ If the plot is skipped, the `{{PERF_PLOT}}` placeholder is removed so the report
 
 ## Trace Feature Detection
 
-If Steps 1 or many of Steps 2-5 fail or produce unexpected results, check whether the trace uses the following features before retrying:
+If Steps 1 or many of Steps 3-6 fail or produce unexpected results, check whether the trace uses the following features before retrying:
 - **GPU Graph Replay**: raw trace JSON contains `hipGraphLaunch` or `cudaGraphLaunch`.
   - **Default mode** (analysis_mode = `default`): Inform the user with `[DIAG:trace_quality:GPU_GRAPH_REPLAY]` that GPU graph replay was detected and that the default analysis mode supports typical PyTorch traces. **Abort** -- do not retry or continue.
   - **Inference mode** (analysis_mode = `inference`): Graph launches are expected and supported if graph capture folder is provided, do not abort. If inference_exec_mode is `eager` (no capture folder was provided), continue.

--- a/TraceLens/Agent/Analysis/skills/analysis-orchestrator/reference.md
+++ b/TraceLens/Agent/Analysis/skills/analysis-orchestrator/reference.md
@@ -259,7 +259,7 @@ All commands below append `<suffix_1>` and `<suffix_2>`, resolved by `<compariso
 ## Step 2: Trace-Quality Gate
 
 
-`<csv_dir>` is `<output_dir>/perf_report_csvs` (`standalone`) or `<output_dir>/perf_report_trace1_csvs` (`comparative`, primary trace).
+`<unified_perf_csv>` is `<output_dir>/perf_report_csvs/unified_perf_summary.csv` (`standalone`) or `<output_dir>/perf_report_trace1_csvs/unified_perf_summary.csv` (`comparative`, primary trace).
 
 ```bash
 <prefix> python3 -c \"
@@ -267,16 +267,16 @@ import sys
 from TraceLens.Agent.Analysis.utils import check_graph_replay_coverage
 v = check_graph_replay_coverage(sys.argv[1])
 print('GRAPH_UNDER_RECORDED' if v.graph_under_recorded else 'OK', v.graph_replay_fraction, v.reason)
-\" '<csv_dir>'
+\" '<unified_perf_csv>'
 ```
 
 **`OK`:** Proceed
 **`GRAPH_UNDER_RECORDED`:**
 1. Emit `[DIAG:trace_quality:GRAPH_UNDER_RECORDED]`: Deterministic fallback report
-2. Run the deterministic fallback writer on `<csv_dir>`:
+2. Run the deterministic fallback writer on `<unified_perf_csv>`:
    ```bash
    <prefix> python3 -m TraceLens.Agent.Analysis.utils.deterministic_fallback \
-     --perf-csvs-dir '<csv_dir>' \
+     --unified-perf-csv '<unified_perf_csv>' \
      --output-dir '<output_dir>' \
      --graph-replay-fraction <graph_replay_fraction>
    ```

--- a/TraceLens/Agent/Analysis/skills/analysis-orchestrator/reference.md
+++ b/TraceLens/Agent/Analysis/skills/analysis-orchestrator/reference.md
@@ -266,19 +266,23 @@ All commands below append `<suffix_1>` and `<suffix_2>`, resolved by `<compariso
 import sys
 from TraceLens.Agent.Analysis.utils import check_graph_replay_coverage
 v = check_graph_replay_coverage(sys.argv[1])
-print('GRAPH_UNDER_RECORDED' if v.graph_under_recorded else 'OK', v.graph_replay_fraction, v.reason)
+status = 'GRAPH_UNDER_RECORDED' if v.graph_under_recorded else 'OK'
+print(f'STATUS={status}')
+print(f'GRAPH_REPLAY_FRACTION={v.graph_replay_fraction}')
+print(f'REASON={v.reason}')
 \" '<unified_perf_csv>'
 ```
+<graph_replay_fraction> refers to the returned GRAPH_REPLAY_FRACTION value.
 
-**`OK`:** Proceed
-**`GRAPH_UNDER_RECORDED`:**
+**`STATUS=OK`:** Proceed
+**`STATUS=GRAPH_UNDER_RECORDED`:**
 1. Emit `[DIAG:trace_quality:GRAPH_UNDER_RECORDED]`: Deterministic fallback report
 2. Run the deterministic fallback writer on `<unified_perf_csv>`:
    ```bash
    <prefix> python3 -m TraceLens.Agent.Analysis.utils.deterministic_fallback \
      --unified-perf-csv '<unified_perf_csv>' \
-     --output-dir '<output_dir>' \
-     --graph-replay-fraction <graph_replay_fraction>
+     --output-dir '<output_dir>' \ 
+     --graph-replay-fraction '<graph_replay_fraction>'
    ```
 3. **Skip Steps 3-12.** The writer already produced `<output_dir>/analysis.md`
 

--- a/TraceLens/Agent/Analysis/skills/analysis-orchestrator/templates/analysis_template.md
+++ b/TraceLens/Agent/Analysis/skills/analysis-orchestrator/templates/analysis_template.md
@@ -24,11 +24,11 @@ section that has STANDALONE / COMPARATIVE variants. Delete the unused variant.
 === GENERAL RULES ===
 1. Warnings section: Only include if there were errors or high-variance operations; omit entirely if all succeeded and no variance flags.
 2. Executive Summary: Max ~20 lines.
-3. Performance plot: The {{PERF_PLOT}} placeholder is replaced by Step 11.3 with a base64-embedded
+3. Performance plot: The {{PERF_PLOT}} placeholder is replaced by Step 12.3 with a base64-embedded
    PNG data URI (![Performance Breakdown](data:image/png;base64,...)) of a single horizontal stacked
    bar showing the run's compute-time breakdown by kernel category. The plot is purely descriptive
    (no error bars, no throughput cone, no savings estimates). If the plot was not generated
-   (Step 10.3 / Step 11.2 failed), the placeholder is removed.
+   (Step 11 / Step 12.2 failed), the placeholder is removed.
 4. Compute Kernel Optimizations: One P-item per entry in `priority_data.json::findings[]`,
    numbered P1, P2, ... in `findings[]` order (already globally sorted by `impact_score`). The
    P-item Impact line uses the canonical mid `impact_score` value; low/high values appear only
@@ -128,7 +128,7 @@ These are excluded from the recommendations below.
 ## Compute Kernel Optimizations
 
 Findings from per-category kernel analysis (GEMM, SDPA, elementwise, etc.).
-Summaries of recommendations from Step 7 sub-agents, focused on individual kernel efficiency.
+Summaries of recommendations from Step 8 sub-agents, focused on individual kernel efficiency.
 
 ### Top Operations
 

--- a/TraceLens/Agent/Analysis/utils/__init__.py
+++ b/TraceLens/Agent/Analysis/utils/__init__.py
@@ -11,6 +11,11 @@ from TraceLens.Agent.Analysis.category_analyses.analysis_utils import (
 )
 
 from .arch_utils import list_platforms, load_arch
+from .deterministic_fallback import (
+    GRAPH_REPLAY_FRACTION_MAX,
+    GraphReplayCoverage,
+    check_graph_replay_coverage,
+)
 from .plot_utils import (
     generate_and_embed_plot,
     generate_perf_plot,
@@ -30,6 +35,9 @@ from .validation_utils import (
 
 __all__ = [
     "build_category_findings",
+    "check_graph_replay_coverage",
+    "GraphReplayCoverage",
+    "GRAPH_REPLAY_FRACTION_MAX",
     "prepare_model_identification_data",
     "generate_and_embed_plot",
     "generate_perf_plot",

--- a/TraceLens/Agent/Analysis/utils/deterministic_fallback.py
+++ b/TraceLens/Agent/Analysis/utils/deterministic_fallback.py
@@ -9,8 +9,9 @@
 A graph-under-recorded trace hides its whole workload behind a single
 graph-replay launch (`hipGraphLaunch` / `cudaGraphLaunch`) or a torch-compile
 region, so per-op decomposition fails and the normal LLM analysis path cannot
-run. `check_graph_replay_coverage` reads the already-written `perf_report_csvs/`
-and returns a structured verdict gating the fallback (it excludes benign
+run. `check_graph_replay_coverage` reads the already-written
+`unified_perf_summary.csv` and returns a structured verdict gating the fallback
+(it excludes benign
 eager-launch/memcpy plumbing wrappers, which appear in healthy traces too).
 
 On a bad verdict, `render_fallback_report` emits a minimal but
@@ -24,6 +25,7 @@ default-agent `analysis.md` contract that `parse_analysis_md` reads:
 
 import argparse
 import csv
+import sys
 from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
@@ -34,26 +36,18 @@ from TraceLens.Agent.Analysis.category_analyses.analysis_utils import (
     HEURISTIC_FRACTION_MID,
 )
 
-# Giant cells in real traces exceed csv's 131072-char default and crash the
-# trace-quality gate; raise the limit to the largest value this platform accepts.
-_field_size_limit = 2**31 - 1
-while True:
-    try:
-        csv.field_size_limit(_field_size_limit)
-        break
-    except OverflowError:
-        _field_size_limit //= 2
+# Real traces have CSV cells far larger than csv's 131072-char default, which
+# would crash the trace-quality gate; lift the limit to the platform maximum.
+csv.field_size_limit(sys.maxsize)
 
 # Constants
 
 GRAPH_REPLAY_FRACTION_MAX = 0.10
-
 MAX_KERNEL_NAME_LEN = 75  # display truncation length (75 + marker = 78-char cell)
 MIN_PITEM_PERCENT_E2E = 0.5  # drop P-items below this %E2E share
 MAX_PITEM_COUNT = 40  # defensive hard cap on emitted P-items
 
 _TRUNCATION_MARKER = "..."  # ASCII marker appended to a truncated display name
-
 _WEIGHT_COLUMN = "Kernel Time (µs)_sum"
 _PERCENT_COLUMN = "Percentage (%)"
 _SYNTHETIC_OP_SUFFIX = " (Synthetic Op)"
@@ -64,8 +58,8 @@ _EM_DASH = "—"
 _GRAPH_REPLAY_WRAPPER_PREFIXES = ("hipGraphLaunch", "cudaGraphLaunch")
 _TORCH_COMPILED_PREFIX = "Torch-Compiled Region"
 
-# Generic launch/memcpy shims that are Synthetic Ops but benign runtime plumbing
-# (~0.5% in healthy traces). Excluded from both the graph-replay signal and the
+# Generic launch/memcpy shims that are Synthetic Ops but benign runtime plumbing.
+# Excluded from both the graph-replay signal and the
 # fallback candidate list.
 _PLUMBING_WRAPPER_PREFIXES = frozenset(
     {"hipLaunchKernel", "hipModuleLaunchKernel", "hipMemcpyAsync"}
@@ -93,18 +87,13 @@ class GraphReplayCoverage:
     graph_under_recorded: bool
     reason: str
     graph_replay_fraction: float
-    other_category_fraction: float
 
 
-def check_graph_replay_coverage(perf_csvs_dir: Path) -> GraphReplayCoverage:
-    perf_csvs_dir = Path(perf_csvs_dir)
-
+def check_graph_replay_coverage(unified_perf_csv: Path) -> GraphReplayCoverage:
     total_time = 0.0
     graph_replay_time = 0.0
-    with open(
-        perf_csvs_dir / "unified_perf_summary.csv", newline="", encoding="utf-8"
-    ) as fh:
-        for row in csv.DictReader(fh):
+    with open(unified_perf_csv, newline="", encoding="utf-8") as csv_file:
+        for row in csv.DictReader(csv_file):
             weight = float(row[_WEIGHT_COLUMN])
             total_time += weight
             if _is_graph_replay_wrapper(row["name"]):
@@ -112,13 +101,11 @@ def check_graph_replay_coverage(perf_csvs_dir: Path) -> GraphReplayCoverage:
 
     graph_replay_fraction = graph_replay_time / total_time if total_time > 0 else 0.0
     graph_under_recorded = graph_replay_fraction > GRAPH_REPLAY_FRACTION_MAX
-    other_category_fraction = _other_category_fraction(perf_csvs_dir)
 
     if graph_under_recorded:
         reason = (
             f"graph-replay fraction {graph_replay_fraction:.1%} > "
-            f"{GRAPH_REPLAY_FRACTION_MAX:.0%} "
-            f"(other-category {other_category_fraction:.0%})"
+            f"{GRAPH_REPLAY_FRACTION_MAX:.0%}"
         )
     else:
         reason = "graph-replay fraction within bounds"
@@ -127,12 +114,12 @@ def check_graph_replay_coverage(perf_csvs_dir: Path) -> GraphReplayCoverage:
         graph_under_recorded=graph_under_recorded,
         reason=reason,
         graph_replay_fraction=graph_replay_fraction,
-        other_category_fraction=other_category_fraction,
     )
 
 
-def render_fallback_report(perf_csvs_dir: Path, graph_replay_fraction: float) -> str:
-    rows = _load_surviving_rows(Path(perf_csvs_dir))
+def render_fallback_report(unified_perf_csv: Path, graph_replay_fraction: float) -> str:
+    with open(unified_perf_csv, newline="", encoding="utf-8") as csv_file:
+        rows = _surviving_rows(csv.DictReader(csv_file))
     rows.sort(key=lambda r: r["weight"], reverse=True)
 
     # Denominator is built over all surviving rows; the display filter below must
@@ -198,44 +185,26 @@ def _is_graph_replay_wrapper(name: str) -> bool:
     )
 
 
-def _other_category_fraction(perf_csvs_dir: Path) -> float:
-    # Optional corroborating cross-check; best-effort, never fatal.
-    path = perf_csvs_dir / "ops_summary_by_category.csv"
-    if not path.exists():
-        return 0.0
-    try:
-        with open(path, newline="", encoding="utf-8") as fh:
-            for row in csv.DictReader(fh):
-                if row.get("op category") == "other":
-                    return float(row["Percentage (%)"]) / 100.0
-    except (OSError, csv.Error, KeyError, ValueError):
-        return 0.0
-    return 0.0
-
-
-def _load_surviving_rows(perf_csvs_dir: Path):
+def _surviving_rows(csv_rows):
     rows = []
-    with open(
-        perf_csvs_dir / "unified_perf_summary.csv", newline="", encoding="utf-8"
-    ) as fh:
-        for row in csv.DictReader(fh):
-            name = row.get("name", "")
-            if "->" in name:
-                prefix, tail = name.split("->", 1)
-                if _is_plumbing_wrapper(prefix):
-                    continue
-                kernel = _strip_synthetic_suffix(tail)
-            else:
-                kernel = _strip_synthetic_suffix(name)
-            if _is_plumbing_wrapper(kernel):
+    for row in csv_rows:
+        name = row.get("name", "")
+        if "->" in name:
+            prefix, tail = name.split("->", 1)
+            if _is_plumbing_wrapper(prefix):
                 continue
-            rows.append(
-                {
-                    "kernel": kernel,
-                    "weight": float(row[_WEIGHT_COLUMN]),
-                    "percent": float(row[_PERCENT_COLUMN]),
-                }
-            )
+            kernel = _strip_synthetic_suffix(tail)
+        else:
+            kernel = _strip_synthetic_suffix(name)
+        if _is_plumbing_wrapper(kernel):
+            continue
+        rows.append(
+            {
+                "kernel": kernel,
+                "weight": float(row[_WEIGHT_COLUMN]),
+                "percent": float(row[_PERCENT_COLUMN]),
+            }
+        )
     return rows
 
 
@@ -265,16 +234,16 @@ def _normalize_kernel_name(raw: str) -> str:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--perf-csvs-dir", type=Path, required=True)
+    parser.add_argument("--unified-perf-csv", type=Path, required=True)
     parser.add_argument("--output-dir", type=Path, required=True)
     parser.add_argument("--graph-replay-fraction", type=float, default=None)
     args = parser.parse_args()
 
     frac = args.graph_replay_fraction
     if frac is None:
-        frac = check_graph_replay_coverage(args.perf_csvs_dir).graph_replay_fraction
+        frac = check_graph_replay_coverage(args.unified_perf_csv).graph_replay_fraction
 
-    report = render_fallback_report(args.perf_csvs_dir, frac)
+    report = render_fallback_report(args.unified_perf_csv, frac)
     args.output_dir.mkdir(parents=True, exist_ok=True)
     (args.output_dir / "analysis.md").write_text(report, encoding="utf-8")
 

--- a/TraceLens/Agent/Analysis/utils/deterministic_fallback.py
+++ b/TraceLens/Agent/Analysis/utils/deterministic_fallback.py
@@ -1,0 +1,283 @@
+###############################################################################
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Deterministic (no-LLM) bad-trace fallback: detector + `analysis.md` writer.
+
+A graph-under-recorded trace hides its whole workload behind a single
+graph-replay launch (`hipGraphLaunch` / `cudaGraphLaunch`) or a torch-compile
+region, so per-op decomposition fails and the normal LLM analysis path cannot
+run. `check_graph_replay_coverage` reads the already-written `perf_report_csvs/`
+and returns a structured verdict gating the fallback (it excludes benign
+eager-launch/memcpy plumbing wrappers, which appear in healthy traces too).
+
+On a bad verdict, `render_fallback_report` emits a minimal but
+downstream-parser-compatible report recovering only what a graph-collapsed trace
+still carries: device-kernel name, time, and %E2E. Every other cell is an em
+dash (intentionally unrecoverable, not missing). The output matches the
+default-agent `analysis.md` contract that `parse_analysis_md` reads:
+`#### P{rank}:` headings, a `reasoning-candidate` marker, and an
+`impact-begin kind=p_item category=unknown` marker per P-item.
+"""
+
+import argparse
+import csv
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+from TraceLens.Agent.Analysis.category_analyses.analysis_utils import (
+    HEURISTIC_FRACTION_HIGH,
+    HEURISTIC_FRACTION_LOW,
+    HEURISTIC_FRACTION_MID,
+)
+
+# Giant cells in real traces exceed csv's 131072-char default and crash the
+# trace-quality gate; raise the limit to the largest value this platform accepts.
+_field_size_limit = 2**31 - 1
+while True:
+    try:
+        csv.field_size_limit(_field_size_limit)
+        break
+    except OverflowError:
+        _field_size_limit //= 2
+
+# Constants
+
+GRAPH_REPLAY_FRACTION_MAX = 0.10
+
+MAX_KERNEL_NAME_LEN = 75  # display truncation length (75 + marker = 78-char cell)
+MIN_PITEM_PERCENT_E2E = 0.5  # drop P-items below this %E2E share
+MAX_PITEM_COUNT = 40  # defensive hard cap on emitted P-items
+
+_TRUNCATION_MARKER = "..."  # ASCII marker appended to a truncated display name
+
+_WEIGHT_COLUMN = "Kernel Time (µs)_sum"
+_PERCENT_COLUMN = "Percentage (%)"
+_SYNTHETIC_OP_SUFFIX = " (Synthetic Op)"
+_EM_DASH = "—"
+
+# Wrapper prefixes (matched on the left of the first `->`) that hide the whole
+# workload behind one replay launch: only these count as the pathology.
+_GRAPH_REPLAY_WRAPPER_PREFIXES = ("hipGraphLaunch", "cudaGraphLaunch")
+_TORCH_COMPILED_PREFIX = "Torch-Compiled Region"
+
+# Generic launch/memcpy shims that are Synthetic Ops but benign runtime plumbing
+# (~0.5% in healthy traces). Excluded from both the graph-replay signal and the
+# fallback candidate list.
+_PLUMBING_WRAPPER_PREFIXES = frozenset(
+    {"hipLaunchKernel", "hipModuleLaunchKernel", "hipMemcpyAsync"}
+)
+_PLUMBING_WRAPPER_STARTSWITH = ("Memcpy", "__amd_rocclr_")
+
+_TABLE_HEADER = (
+    "| Operation | Args | Kernel Path | Kernel Name | Time (ms) | %E2E | "
+    "Count | FLOPS/Byte | Efficiency | Bound |"
+)
+_TABLE_DIVIDER = "|" + "---|" * 10
+
+# {pct}/{max_pct} are pre-formatted percents; {drop_note} is the conditional
+# drop-count sentence (empty when nothing was dropped).
+_DEGRADED_BANNER = """> **⚠ Degraded (deterministic fallback) report.** This trace was
+> graph-under-recorded (graph-replay fraction {pct} > {max_pct});
+> per-op decomposition failed, so the LLM analysis path could not run.
+> Only **kernel name, time, and %E2E** are recoverable from a graph-collapsed
+> trace. Shapes, launcher path, quant operands, category, and efficiency were
+> **never captured** in this trace. Impact ranges are heuristic.{drop_note}"""
+
+
+@dataclass
+class GraphReplayCoverage:
+    graph_under_recorded: bool
+    reason: str
+    graph_replay_fraction: float
+    other_category_fraction: float
+
+
+def check_graph_replay_coverage(perf_csvs_dir: Path) -> GraphReplayCoverage:
+    perf_csvs_dir = Path(perf_csvs_dir)
+
+    total_time = 0.0
+    graph_replay_time = 0.0
+    with open(
+        perf_csvs_dir / "unified_perf_summary.csv", newline="", encoding="utf-8"
+    ) as fh:
+        for row in csv.DictReader(fh):
+            weight = float(row[_WEIGHT_COLUMN])
+            total_time += weight
+            if _is_graph_replay_wrapper(row["name"]):
+                graph_replay_time += weight
+
+    graph_replay_fraction = graph_replay_time / total_time if total_time > 0 else 0.0
+    graph_under_recorded = graph_replay_fraction > GRAPH_REPLAY_FRACTION_MAX
+    other_category_fraction = _other_category_fraction(perf_csvs_dir)
+
+    if graph_under_recorded:
+        reason = (
+            f"graph-replay fraction {graph_replay_fraction:.1%} > "
+            f"{GRAPH_REPLAY_FRACTION_MAX:.0%} "
+            f"(other-category {other_category_fraction:.0%})"
+        )
+    else:
+        reason = "graph-replay fraction within bounds"
+
+    return GraphReplayCoverage(
+        graph_under_recorded=graph_under_recorded,
+        reason=reason,
+        graph_replay_fraction=graph_replay_fraction,
+        other_category_fraction=other_category_fraction,
+    )
+
+
+def render_fallback_report(perf_csvs_dir: Path, graph_replay_fraction: float) -> str:
+    rows = _load_surviving_rows(Path(perf_csvs_dir))
+    rows.sort(key=lambda r: r["weight"], reverse=True)
+
+    # Denominator is built over all surviving rows; the display filter below must
+    # not feed back into it, or dropping the tail would inflate the survivors.
+    group_time = defaultdict(float)
+    for row in rows:
+        group_time[row["kernel"]] += row["weight"]
+    total_time = sum(group_time.values())
+
+    filtered = [row for row in rows if row["percent"] >= MIN_PITEM_PERCENT_E2E]
+    filtered = filtered[:MAX_PITEM_COUNT]
+    dropped = len(rows) - len(filtered)
+
+    drop_note = ""
+    if dropped > 0:
+        drop_note = (
+            f"\n> Dropped {dropped} P-items below {MIN_PITEM_PERCENT_E2E}% E2E "
+            f"(or beyond top-{MAX_PITEM_COUNT})."
+        )
+    banner = _DEGRADED_BANNER.format(
+        pct=f"{graph_replay_fraction:.0%}",
+        max_pct=f"{GRAPH_REPLAY_FRACTION_MAX:.0%}",
+        drop_note=drop_note,
+    )
+    lines = ["# Deterministic Fallback Analysis", "", banner, ""]
+
+    for rank, row in enumerate(filtered, start=1):
+        kernel = row["kernel"]
+        display = _normalize_kernel_name(kernel)
+        group_pct = (group_time[kernel] / total_time * 100.0) if total_time > 0 else 0.0
+        low = round(group_pct * HEURISTIC_FRACTION_LOW, 2)
+        mid = round(group_pct * HEURISTIC_FRACTION_MID, 2)
+        high = round(group_pct * HEURISTIC_FRACTION_HIGH, 2)
+
+        lines.append(f"<!-- reasoning-candidate tier=compute rank={rank} -->")
+        lines.append(f"#### P{rank}: {display}")
+        lines.append(
+            "<!-- impact-begin kind=p_item category=unknown "
+            f"low={low} mid={mid} high={high} -->"
+        )
+        lines.append("")
+        lines.append("**Data:**")
+        lines.append("")
+        lines.append(_TABLE_HEADER)
+        lines.append(_TABLE_DIVIDER)
+        time_ms = row["weight"] / 1000.0
+        lines.append(
+            f"| {_EM_DASH} | {_EM_DASH} | {_EM_DASH} | {kernel} | {time_ms:.3f} | "
+            f"{row['percent']:.2f} | {_EM_DASH} | {_EM_DASH} | {_EM_DASH} | "
+            f"{_EM_DASH} |"
+        )
+        lines.append("")
+
+    return "\n".join(lines) + "\n"
+
+
+def _is_graph_replay_wrapper(name: str) -> bool:
+    if "->" not in name:
+        return False
+    prefix = name.split("->", 1)[0]
+    return prefix in _GRAPH_REPLAY_WRAPPER_PREFIXES or prefix.startswith(
+        _TORCH_COMPILED_PREFIX
+    )
+
+
+def _other_category_fraction(perf_csvs_dir: Path) -> float:
+    # Optional corroborating cross-check; best-effort, never fatal.
+    path = perf_csvs_dir / "ops_summary_by_category.csv"
+    if not path.exists():
+        return 0.0
+    try:
+        with open(path, newline="", encoding="utf-8") as fh:
+            for row in csv.DictReader(fh):
+                if row.get("op category") == "other":
+                    return float(row["Percentage (%)"]) / 100.0
+    except (OSError, csv.Error, KeyError, ValueError):
+        return 0.0
+    return 0.0
+
+
+def _load_surviving_rows(perf_csvs_dir: Path):
+    rows = []
+    with open(
+        perf_csvs_dir / "unified_perf_summary.csv", newline="", encoding="utf-8"
+    ) as fh:
+        for row in csv.DictReader(fh):
+            name = row.get("name", "")
+            if "->" in name:
+                prefix, tail = name.split("->", 1)
+                if _is_plumbing_wrapper(prefix):
+                    continue
+                kernel = _strip_synthetic_suffix(tail)
+            else:
+                kernel = _strip_synthetic_suffix(name)
+            if _is_plumbing_wrapper(kernel):
+                continue
+            rows.append(
+                {
+                    "kernel": kernel,
+                    "weight": float(row[_WEIGHT_COLUMN]),
+                    "percent": float(row[_PERCENT_COLUMN]),
+                }
+            )
+    return rows
+
+
+def _is_plumbing_wrapper(prefix: str) -> bool:
+    return prefix in _PLUMBING_WRAPPER_PREFIXES or prefix.startswith(
+        _PLUMBING_WRAPPER_STARTSWITH
+    )
+
+
+def _strip_synthetic_suffix(name: str) -> str:
+    if name.endswith(_SYNTHETIC_OP_SUFFIX):
+        name = name[: -len(_SYNTHETIC_OP_SUFFIX)]
+    return name.strip()
+
+
+def _normalize_kernel_name(raw: str) -> str:
+    # Display-only shortening for the P-item heading; truncate long device symbols
+    # but never demangle (the matched symbol stays raw) and never return empty (an
+    # empty heading title fails the downstream heading match and drops the block).
+    s = raw.strip()
+    if len(s) > MAX_KERNEL_NAME_LEN:
+        s = s[:MAX_KERNEL_NAME_LEN] + _TRUNCATION_MARKER
+    if not s:
+        return raw
+    return s
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--perf-csvs-dir", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--graph-replay-fraction", type=float, default=None)
+    args = parser.parse_args()
+
+    frac = args.graph_replay_fraction
+    if frac is None:
+        frac = check_graph_replay_coverage(args.perf_csvs_dir).graph_replay_fraction
+
+    report = render_fallback_report(args.perf_csvs_dir, frac)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    (args.output_dir / "analysis.md").write_text(report, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/TraceLens/Agent/Analysis/utils/deterministic_fallback.py
+++ b/TraceLens/Agent/Analysis/utils/deterministic_fallback.py
@@ -81,11 +81,11 @@ _TABLE_DIVIDER = "|" + "---|" * 10
 # {pct}/{max_pct} are pre-formatted percents; {drop_note} is the conditional
 # drop-count sentence (empty when nothing was dropped).
 _DEGRADED_BANNER = """> **⚠ Degraded (deterministic fallback) report.** This trace was
-> graph-under-recorded (graph-replay fraction {pct} > {max_pct});
-> per-op decomposition failed, so the LLM analysis path could not run.
+> graph-under-recorded (graph-replay fraction {pct};
+> per-op decomposition failed, so the agentic analysis path did not execute.
 > Only **kernel name, time, and %E2E** are recoverable from a graph-collapsed
-> trace. Shapes, launcher path, quant operands, category, and efficiency were
-> **never captured** in this trace. Impact ranges are heuristic.{drop_note}"""
+> trace. Shapes, launcher path, quant operands, category, and efficiency are
+> not available in this trace. Impact estimates are heuristic.{drop_note}"""
 
 
 @dataclass

--- a/TraceLens/Agent/Analysis/utils/deterministic_fallback.py
+++ b/TraceLens/Agent/Analysis/utils/deterministic_fallback.py
@@ -34,6 +34,7 @@ from TraceLens.Agent.Analysis.category_analyses.analysis_utils import (
     HEURISTIC_FRACTION_HIGH,
     HEURISTIC_FRACTION_LOW,
     HEURISTIC_FRACTION_MID,
+    _KERNEL_NAME_TRUNC_LEN,
 )
 
 # Real traces have CSV cells far larger than csv's 131072-char default, which
@@ -43,15 +44,8 @@ csv.field_size_limit(sys.maxsize)
 # Constants
 
 GRAPH_REPLAY_FRACTION_MAX = 0.10
-MAX_KERNEL_NAME_LEN = 75  # display truncation length (75 + marker = 78-char cell)
 MIN_PITEM_PERCENT_E2E = 0.5  # drop P-items below this %E2E share
 MAX_PITEM_COUNT = 40  # defensive hard cap on emitted P-items
-
-_TRUNCATION_MARKER = "..."  # ASCII marker appended to a truncated display name
-_WEIGHT_COLUMN = "Kernel Time (µs)_sum"
-_PERCENT_COLUMN = "Percentage (%)"
-_SYNTHETIC_OP_SUFFIX = " (Synthetic Op)"
-_EM_DASH = "—"
 
 # Wrapper prefixes (matched on the left of the first `->`) that hide the whole
 # workload behind one replay launch: only these count as the pathology.
@@ -94,7 +88,7 @@ def check_graph_replay_coverage(unified_perf_csv: Path) -> GraphReplayCoverage:
     graph_replay_time = 0.0
     with open(unified_perf_csv, newline="", encoding="utf-8") as csv_file:
         for row in csv.DictReader(csv_file):
-            weight = float(row[_WEIGHT_COLUMN])
+            weight = float(row["Kernel Time (µs)_sum"])
             total_time += weight
             if _is_graph_replay_wrapper(row["name"]):
                 graph_replay_time += weight
@@ -167,9 +161,9 @@ def render_fallback_report(unified_perf_csv: Path, graph_replay_fraction: float)
         lines.append(_TABLE_DIVIDER)
         time_ms = row["weight"] / 1000.0
         lines.append(
-            f"| {_EM_DASH} | {_EM_DASH} | {_EM_DASH} | {kernel} | {time_ms:.3f} | "
-            f"{row['percent']:.2f} | {_EM_DASH} | {_EM_DASH} | {_EM_DASH} | "
-            f"{_EM_DASH} |"
+            f"| — | — | — | {kernel} | {time_ms:.3f} | "
+            f"{row['percent']:.2f} | — | — | — | "
+            f"— |"
         )
         lines.append("")
 
@@ -201,8 +195,8 @@ def _surviving_rows(csv_rows):
         rows.append(
             {
                 "kernel": kernel,
-                "weight": float(row[_WEIGHT_COLUMN]),
-                "percent": float(row[_PERCENT_COLUMN]),
+                "weight": float(row["Kernel Time (µs)_sum"]),
+                "percent": float(row["Percentage (%)"]),
             }
         )
     return rows
@@ -215,8 +209,9 @@ def _is_plumbing_wrapper(prefix: str) -> bool:
 
 
 def _strip_synthetic_suffix(name: str) -> str:
-    if name.endswith(_SYNTHETIC_OP_SUFFIX):
-        name = name[: -len(_SYNTHETIC_OP_SUFFIX)]
+    suffix = " (Synthetic Op)"
+    if name.endswith(suffix):
+        name = name[: -len(suffix)]
     return name.strip()
 
 
@@ -225,8 +220,8 @@ def _normalize_kernel_name(raw: str) -> str:
     # but never demangle (the matched symbol stays raw) and never return empty (an
     # empty heading title fails the downstream heading match and drops the block).
     s = raw.strip()
-    if len(s) > MAX_KERNEL_NAME_LEN:
-        s = s[:MAX_KERNEL_NAME_LEN] + _TRUNCATION_MARKER
+    if len(s) > _KERNEL_NAME_TRUNC_LEN:
+        s = s[:_KERNEL_NAME_TRUNC_LEN] + "..."
     if not s:
         return raw
     return s

--- a/TraceLens/Agent/Analysis/utils/deterministic_fallback.py
+++ b/TraceLens/Agent/Analysis/utils/deterministic_fallback.py
@@ -56,7 +56,14 @@ _TORCH_COMPILED_PREFIX = "Torch-Compiled Region"
 # Excluded from both the graph-replay signal and the
 # fallback candidate list.
 _PLUMBING_WRAPPER_PREFIXES = frozenset(
-    {"hipLaunchKernel", "hipModuleLaunchKernel", "hipMemcpyAsync"}
+    {
+        "hipLaunchKernel",
+        "hipModuleLaunchKernel",
+        "hipMemcpyAsync",
+        "cudaLaunchKernel",
+        "cudaLaunchKernelExC",
+        "cudaMemcpyAsync",
+    }
 )
 _PLUMBING_WRAPPER_STARTSWITH = ("Memcpy", "__amd_rocclr_")
 
@@ -119,8 +126,10 @@ def render_fallback_report(unified_perf_csv: Path, graph_replay_fraction: float)
     # Denominator is built over all surviving rows; the display filter below must
     # not feed back into it, or dropping the tail would inflate the survivors.
     group_time = defaultdict(float)
+    group_count = defaultdict(int)
     for row in rows:
-        group_time[row["kernel"]] += row["weight"]
+        group_time[row["op"]] += row["weight"]
+        group_count[row["op"]] += row["count"]
     total_time = sum(group_time.values())
 
     filtered = [row for row in rows if row["percent"] >= MIN_PITEM_PERCENT_E2E]
@@ -141,9 +150,9 @@ def render_fallback_report(unified_perf_csv: Path, graph_replay_fraction: float)
     lines = ["# Deterministic Fallback Analysis", "", banner, ""]
 
     for rank, row in enumerate(filtered, start=1):
-        kernel = row["kernel"]
-        display = _normalize_kernel_name(kernel)
-        group_pct = (group_time[kernel] / total_time * 100.0) if total_time > 0 else 0.0
+        op = row["op"]
+        display = _normalize_kernel_name(op)
+        group_pct = (group_time[op] / total_time * 100.0) if total_time > 0 else 0.0
         low = round(group_pct * HEURISTIC_FRACTION_LOW, 2)
         mid = round(group_pct * HEURISTIC_FRACTION_MID, 2)
         high = round(group_pct * HEURISTIC_FRACTION_HIGH, 2)
@@ -161,8 +170,8 @@ def render_fallback_report(unified_perf_csv: Path, graph_replay_fraction: float)
         lines.append(_TABLE_DIVIDER)
         time_ms = row["weight"] / 1000.0
         lines.append(
-            f"| — | — | — | {kernel} | {time_ms:.3f} | "
-            f"{row['percent']:.2f} | — | — | — | "
+            f"| — | — | — | {op} | {time_ms:.3f} | "
+            f"{row['percent']:.2f} | {group_count[op]} | — | — | "
             f"— |"
         )
         lines.append("")
@@ -187,16 +196,17 @@ def _surviving_rows(csv_rows):
             prefix, tail = name.split("->", 1)
             if _is_plumbing_wrapper(prefix):
                 continue
-            kernel = _strip_synthetic_suffix(tail)
+            op = _strip_synthetic_suffix(tail)
         else:
-            kernel = _strip_synthetic_suffix(name)
-        if _is_plumbing_wrapper(kernel):
+            op = _strip_synthetic_suffix(name)
+        if _is_plumbing_wrapper(op):
             continue
         rows.append(
             {
-                "kernel": kernel,
+                "op": op,
                 "weight": float(row["Kernel Time (µs)_sum"]),
                 "percent": float(row["Percentage (%)"]),
+                "count": int(float(row.get("operation_count", 0) or 0)),
             }
         )
     return rows
@@ -234,6 +244,7 @@ def main() -> None:
     parser.add_argument("--graph-replay-fraction", type=float, default=None)
     args = parser.parse_args()
 
+    # Fallback handling for displaying fraction when script invoked directly
     frac = args.graph_replay_fraction
     if frac is None:
         frac = check_graph_replay_coverage(args.unified_perf_csv).graph_replay_fraction

--- a/TraceLens/Agent/Analysis/utils/orchestrator_prepare.py
+++ b/TraceLens/Agent/Analysis/utils/orchestrator_prepare.py
@@ -7,7 +7,7 @@
 
 """
 TraceLens Agent - Orchestrator Preparation Script
-Steps 2-5: GPU Utilization, Top Ops, Tree Data Pre-computation, Category Filtering
+Steps 3-6: GPU Utilization, Top Ops, Tree Data Pre-computation, Category Filtering
 """
 
 import argparse
@@ -858,9 +858,9 @@ def main():
     platform_specs = load_arch(platform)
 
     # ============================================================================
-    # STEP 2: Assess GPU Utilization
+    # STEP 3: Assess GPU Utilization
     # ============================================================================
-    print("\n[STEP 2] Assessing GPU Utilization...")
+    print("\n[STEP 3] Assessing GPU Utilization...")
 
     gpu_timeline = pd.read_csv(os.path.join(trace1_csv_dir, "gpu_timeline.csv"))
     gpu_utilization_metrics = _gpu_utilization_metrics_from_gpu_timeline_df(
@@ -899,9 +899,9 @@ def main():
         print(f"  [DIAG:trace_quality:HIGH_IDLE] Compute utilization < 85%")
 
     # ============================================================================
-    # STEP 3: Identify Top Operations
+    # STEP 4: Identify Top Operations
     # ============================================================================
-    print("\n[STEP 3] Identifying Top Operations...")
+    print("\n[STEP 4] Identifying Top Operations...")
 
     ops_summary = pd.read_csv(os.path.join(trace1_csv_dir, "ops_summary.csv"))
 
@@ -932,9 +932,9 @@ def main():
             print(f"  {op_name:50s} | {time_val:10.2f} | {category}")
 
     # ============================================================================
-    # STEP 4: Pre-compute Tree Data (Optimization)
+    # STEP 5: Pre-compute Tree Data (Optimization)
     # ============================================================================
-    print("\n[STEP 4] Pre-computing Tree Data for Bottleneck Operations...")
+    print("\n[STEP 5] Pre-computing Tree Data for Bottleneck Operations...")
 
     try:
         print(f"  Loading trace: {trace_path}")
@@ -998,9 +998,9 @@ def main():
         print(f"  ✓ Identified bottleneck operations")
 
         # ====================================================================
-        # STEP 4.5: Pre-compute Multi-Kernel Issue Data
+        # STEP 5.5: Pre-compute Multi-Kernel Issue Data
         # ====================================================================
-        print("\n[STEP 4.5] Pre-computing Multi-Kernel Issue Data...")
+        print("\n[STEP 5.5] Pre-computing Multi-Kernel Issue Data...")
 
         try:
             gpu_analyser = GPUEventAnalyser(tree.events)
@@ -1164,9 +1164,9 @@ def main():
                 json.dump(multi_kernel_data, f, indent=2)
 
         # ====================================================================
-        # STEP 4b: Extract Kernel Fusion Candidates (Experimental)
+        # STEP 5b: Extract Kernel Fusion Candidates (Experimental)
         # ====================================================================
-        print("\n[STEP 4b] Extracting Kernel Fusion Candidates...")
+        print("\n[STEP 5b] Extracting Kernel Fusion Candidates...")
 
         fusion_candidates_file = f"{output_dir}/category_data/fusion_candidates.json"
 
@@ -1223,14 +1223,14 @@ def main():
 
     except Exception as e:
         print(
-            f"  [DIAG:pipeline:STEP2_5_FAIL] Error during tree data pre-computation: {e}"
+            f"  [DIAG:pipeline:STEP3_6_FAIL] Error during tree data pre-computation: {e}"
         )
         traceback.print_exc()
 
     # ============================================================================
-    # STEP 5: Filter and Export Category Data
+    # STEP 6: Filter and Export Category Data
     # ============================================================================
-    print("\n[STEP 5] Filtering and Exporting Category Data...")
+    print("\n[STEP 6] Filtering and Exporting Category Data...")
 
     unified_df = pd.read_csv(os.path.join(trace1_csv_dir, "unified_perf_summary.csv"))
 
@@ -1404,9 +1404,9 @@ def main():
             )
 
     # ============================================================================
-    # STEP 5.5: Calculate Time Metric Breakdown per Category
+    # STEP 6.5: Calculate Time Metric Breakdown per Category
     # ============================================================================
-    print("\n[STEP 5.5] Calculating Time Metric Breakdown per Category...")
+    print("\n[STEP 6.5] Calculating Time Metric Breakdown per Category...")
 
     # Calculate GPU kernel time vs CPU duration per category
     # GPU kernel time = actual GPU execution (use for bottleneck prioritization)
@@ -1519,7 +1519,7 @@ def main():
         json.dump(model_info, f, indent=2)
 
     print(f"\n{'='*80}")
-    print(f"✓ Orchestrator Preparation Complete (Steps 2-5)")
+    print(f"✓ Orchestrator Preparation Complete (Steps 3-6)")
     print(f"✓ Exported {len(exported_categories)} categories")
     print(f"✓ Manifest saved: {manifest_file}")
     if comparison_scope == "comparative":

--- a/TraceLens/Agent/Analysis/utils/validation_utils.py
+++ b/TraceLens/Agent/Analysis/utils/validation_utils.py
@@ -8,15 +8,15 @@
 
 Three validation levels, each at the boundary where issues are still fixable:
 
-Level 1 — validate_findings_file (Steps 6-7, within each sub-agent)
+Level 1 — validate_findings_file (Steps 7-8, within each sub-agent)
     Structural check on a single findings file, including marker structure
     via MarkerValidator (pairing, kind attributes, per-kind required attrs,
     mandatory p_item). Sub-agent retries on failure.
 
-Level 2 — validate_subagent_outputs (Step 8, batch)
+Level 2 — validate_subagent_outputs (Step 9, batch)
     Cross-cutting checks that need all files: time sanity, coverage, priority.
 
-Level 3 — validate_report (Step 11.1, after report assembly)
+Level 3 — validate_report (Step 12.1, after report assembly)
     Final analysis.md structure: headers, metrics table, placeholders,
     and report-level marker structure via MarkerValidator (pairing, kind
     attributes, mandatory top_ops).
@@ -436,7 +436,7 @@ def _validate_compute_data_tables(content, findings_path, comparison_scope=None)
     return errors
 
 
-# Level 2: cross-cutting batch checks (called at Step 8)
+# Level 2: cross-cutting batch checks (called at Step 9)
 
 
 def validate_subagent_outputs(output_dir):
@@ -523,9 +523,9 @@ def _check_priority_consistency(output_dir, manifest):
     """Verify priority_data.json invariants: findings sort, rank contiguity,
     and per-category rollup of priorities[].impact_score vs findings[] sum.
 
-    Non-blocking: returns WARN on any violation (preserves Step 8 semantics
+    Non-blocking: returns WARN on any violation (preserves Step 9 semantics
     matching _check_time_sanity / _check_coverage). manifest is accepted for
-    call-site symmetry with the other Step 8 checks.
+    call-site symmetry with the other Step 9 checks.
     """
     del manifest  # unused; kept for signature symmetry with sibling checks
     pd_path = os.path.join(output_dir, "priority_data.json")
@@ -592,7 +592,7 @@ def _check_priority_consistency(output_dir, manifest):
     return {"status": status, "messages": messages}
 
 
-# Level 3: final report validation (called at Step 11.1)
+# Level 3: final report validation (called at Step 12.1)
 
 
 def validate_report(output_dir, comparison_scope=None):
@@ -608,7 +608,7 @@ def validate_report(output_dir, comparison_scope=None):
       required attrs, mandatory kind=top_ops
 
     Findings files are validated separately by validate_findings_file
-    (Level 1, called within each sub-agent at Steps 6-7), which also
+    (Level 1, called within each sub-agent at Steps 7-8), which also
     enforces per-file marker structure.
 
     Args:
@@ -737,7 +737,7 @@ def _validate_report_args_column(content, output_dir):
     """Level-3 check: every Args cell in analysis.md must match some
     operations[].args verbatim across all category metrics JSONs.
 
-    Catches LLM reformatting introduced by the Step 11 orchestrator when it
+    Catches LLM reformatting introduced by the Step 12 orchestrator when it
     pastes per-category Detailed Analysis tables into the final report.
     """
     cat_data_dir = os.path.join(output_dir, "category_data")
@@ -768,7 +768,7 @@ def _validate_report_priority_consistency(content, output_dir):
     R3: Each marker's low/mid/high attrs match findings[N-1] impact_score_low / impact_score / impact_score_high.
     R4: Top Operations marker rows == len(priorities).
 
-    Silently skips when priority_data.json is absent (Step 8 already warns).
+    Silently skips when priority_data.json is absent (Step 9 already warns).
     Numeric attrs are compared as 2-decimal strings to match the writer's
     rounding in generate_priority_data. Every compute-tier finding now carries
     a numeric impact_score (quantified or heuristic estimate), so p_item

--- a/tests/test_analysis_agent_deterministic.py
+++ b/tests/test_analysis_agent_deterministic.py
@@ -1,0 +1,853 @@
+###############################################################################
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Tier-1 unit tests for the deterministic graph-under-recorded fallback.
+
+Covers the no-LLM fallback path in ``utils/deterministic_fallback``:
+- ``check_graph_replay_coverage`` (detector U1-U4)
+- ``render_fallback_report`` (writer U5-U9)
+
+Every fixture is a tiny SYNTHETIC ``unified_perf_summary.csv`` written under
+``tmp_path`` with hand-computed expected values, so a failing assertion points
+at the exact arithmetic. No GPU, no LLM, no network, no ``Local_Traces``.
+
+U7/U9 assert the downstream ``analysis.md`` parse contract using a LOCAL, vendored
+copy of the consumer's regexes (kept in sync manually, no external import) so the
+fallback md stays compatible with the default-agent contract.
+"""
+
+import csv
+import re
+
+import pytest
+
+from TraceLens.Agent.Analysis.utils.deterministic_fallback import (
+    GRAPH_REPLAY_FRACTION_MAX,
+    MAX_KERNEL_NAME_LEN,
+    MAX_PITEM_COUNT,
+    MIN_PITEM_PERCENT_E2E,
+    _normalize_kernel_name,
+    _PERCENT_COLUMN,
+    _WEIGHT_COLUMN,
+    check_graph_replay_coverage,
+    render_fallback_report,
+)
+
+# ---------------------------------------------------------------------------
+# Vendored downstream-parser regexes (U7/U9). Copied verbatim from the
+# ``analysis.md`` consumer so the tests assert the exact parse contract without
+# an external import.
+# ---------------------------------------------------------------------------
+_PITEM_MARKER_RE = re.compile(
+    r"<!--\s*impact-begin\s+kind=p_item\s+([^>]*?)-->",
+    re.IGNORECASE,
+)
+_REASONING_MARKER_RE = re.compile(
+    r"<!--\s*reasoning-candidate\s+tier=(\w+)\s+rank=(\d+)\s*-->",
+    re.IGNORECASE,
+)
+_HEADING_RE = re.compile(
+    r"^####\s+(?:[\U0001F300-\U0001FAFF☀-➿]+\s+)?P(\d+):\s*(.+?)\s*$",
+    re.MULTILINE,
+)
+
+# 9 canonical column tokens the downstream parser requires in order; "Kernel
+# Name" is an extra column allowed to interleave.
+_DATA_TABLE_HEADER_TOKENS = (
+    "operation",
+    "args",
+    "kernel path",
+    "time (ms)",
+    "%e2e",
+    "count",
+    "flops/byte",
+    "efficiency",
+    "bound",
+)
+_DATA_TABLE_CANONICAL_KEY_SET = frozenset(
+    tok.strip().lower() for tok in _DATA_TABLE_HEADER_TOKENS
+)
+
+_EM_DASH = "—"
+
+
+# ---------------------------------------------------------------------------
+# Vendored subset of the downstream ``analysis.md`` parser — kept in sync with
+# the consumer. This runs the REAL downstream parse path (reasoning-marker block
+# split -> **Data:** table extraction -> canonical 9-column validation -> one
+# candidate per data row) so U7 gates the exact class of contract bug that a
+# heading-count-only check would miss.
+# ---------------------------------------------------------------------------
+def _safe_float(value, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _parse_marker_attrs(blob: str) -> dict:
+    """Parse ``key=value`` attributes from an HTML-comment marker blob."""
+    return dict(re.findall(r"(\w+)=([^\s>]+)", blob))
+
+
+def _extract_pitem_categories(text: str) -> list:
+    """One dict per ``p_item`` marker (in order); markers must carry ``category=``."""
+    items = []
+    for match in _PITEM_MARKER_RE.finditer(text):
+        attrs = _parse_marker_attrs(match.group(1))
+        if "category" not in attrs:
+            continue
+        items.append(
+            {
+                "category": attrs.get("category", ""),
+                "impact_score_low": _safe_float(attrs.get("low")),
+                "impact_score": _safe_float(attrs.get("mid")),
+                "impact_score_high": _safe_float(attrs.get("high")),
+            }
+        )
+    return items
+
+
+def _split_data_blocks(text: str) -> list:
+    """Split into compute-tier reasoning blocks; drop any with no heading in slice."""
+    blocks = []
+    matches = list(_REASONING_MARKER_RE.finditer(text))
+    for idx, match in enumerate(matches):
+        tier = match.group(1).lower()
+        if tier != "compute":
+            continue
+        body_start = match.end()
+        body_end = matches[idx + 1].start() if idx + 1 < len(matches) else len(text)
+        body = text[body_start:body_end]
+        head_match = _HEADING_RE.search(body)
+        if not head_match:
+            continue
+        rank = int(head_match.group(1))
+        title = head_match.group(2).strip()
+        blocks.append((rank, title, body))
+    return blocks
+
+
+def _extract_data_table(body: str) -> list:
+    """Pull the markdown table after ``**Data:**``; ``[]`` when the marker is absent."""
+    marker = body.find("**Data:**")
+    if marker < 0:
+        return []
+    tail = body[marker + len("**Data:**") :]
+    rows = []
+    in_table = False
+    for line in tail.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            if in_table:
+                break
+            continue
+        if not stripped.startswith("|"):
+            if in_table:
+                break
+            continue
+        in_table = True
+        if set(stripped.replace("|", "").strip()) <= set("-: "):
+            continue
+        cells = [cell.strip() for cell in stripped.split("|")[1:-1]]
+        rows.append(cells)
+    return rows
+
+
+def _parse_candidates(md_text: str) -> list:
+    """Run the real downstream parse and return one candidate dict per data row.
+
+    Faithful subset of ``parse_analysis_md``: block split -> ``**Data:**`` table
+    extraction -> canonical 9-column (in-order, extras allowed) validation ->
+    one candidate per surviving data row carrying the P-item category.
+    """
+    pitems = _extract_pitem_categories(md_text)
+    blocks = _split_data_blocks(md_text)
+    if not blocks:
+        return []
+
+    headers_canonical = [tok.strip().lower() for tok in _DATA_TABLE_HEADER_TOKENS]
+    canonical_width = len(headers_canonical)
+
+    candidates = []
+    for rank, title, body in blocks:
+        rows = _extract_data_table(body)
+        if not rows:
+            continue
+        header_row = [cell.strip().lower() for cell in rows[0]]
+        if len(header_row) < canonical_width:
+            continue
+        normalized_header = []
+        for cell in header_row:
+            match = next(
+                (
+                    canon
+                    for canon in headers_canonical
+                    if canon == cell or canon in cell
+                ),
+                cell,
+            )
+            normalized_header.append(match)
+        canonical_in_header = [c for c in normalized_header if c in headers_canonical]
+        if canonical_in_header != headers_canonical:
+            continue
+        header_row = normalized_header
+        pitem_meta = pitems[rank - 1] if rank - 1 < len(pitems) else {}
+        category = pitem_meta.get("category", "")
+        impact_score = pitem_meta.get("impact_score", 0.0)
+        for cells in rows[1:]:
+            if len(cells) != len(header_row):
+                continue
+            record = dict(zip(header_row, cells))
+            name = record.get("operation", "").strip()
+            kernel_name = record.get("kernel name", "").strip()
+            # Relaxed-reader contract: a graph-collapsed row emits "—"
+            # for Operation because the python/aten op was never captured; the
+            # device kernel symbol is the identity. Substitute it rather than
+            # dropping the row. Drop only when there is no symbol either.
+            if not name or name in {"-", "—"}:
+                if not kernel_name or kernel_name in {"-", "—"}:
+                    continue
+                name = kernel_name
+            candidates.append(
+                {
+                    "rank": rank,
+                    "title": title,
+                    "operation": name,
+                    "kernel_name": kernel_name,
+                    "category": category,
+                    "impact_score": impact_score,
+                    "args": record.get("args", "").strip(),
+                    "time_ms": record.get("time (ms)", "").strip(),
+                    "percent_e2e": record.get("%e2e", "").strip(),
+                }
+            )
+    return candidates
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+def _make_perf_csv(tmp_path, rows):
+    """Write a synthetic ``unified_perf_summary.csv`` and return its dir.
+
+    ``rows`` is a list of ``(name, weight, percent)`` tuples. Only the three
+    columns the code reads are written; ``percent`` defaults to 0.0 if omitted.
+    """
+    perf_dir = tmp_path / "perf_report_csvs"
+    perf_dir.mkdir(exist_ok=True)
+    with open(
+        perf_dir / "unified_perf_summary.csv", "w", newline="", encoding="utf-8"
+    ) as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["name", _WEIGHT_COLUMN, _PERCENT_COLUMN])
+        for row in rows:
+            name, weight = row[0], row[1]
+            percent = row[2] if len(row) > 2 else 0.0
+            writer.writerow([name, weight, percent])
+    return perf_dir
+
+
+def _make_category_csv(perf_dir, categories):
+    """Write an optional ``ops_summary_by_category.csv`` for the other-frac path.
+
+    ``categories`` is a list of ``(op_category, percent)`` tuples.
+    """
+    with open(
+        perf_dir / "ops_summary_by_category.csv", "w", newline="", encoding="utf-8"
+    ) as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["op category", _PERCENT_COLUMN])
+        for cat, pct in categories:
+            writer.writerow([cat, pct])
+    return perf_dir
+
+
+def _data_row_cells(md, kernel):
+    """Return the split table-cell list for the data row of ``kernel`` (else None)."""
+    for line in md.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(f"| {kernel} |"):
+            # Drop the leading/trailing empty fields from the bounding pipes.
+            return [c.strip() for c in stripped.split("|")[1:-1]]
+    return None
+
+
+def _strip_banner(md):
+    """Remove the visible degraded call-out lines."""
+    return "\n".join(line for line in md.splitlines() if not line.startswith(">"))
+
+
+# ---------------------------------------------------------------------------
+# U1 — detector fires on a graph-collapsed fixture
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "wrapper",
+    [
+        ("hipGraphLaunch->k1 (Synthetic Op)", "hipGraphLaunch->k2 (Synthetic Op)"),
+        ("Torch-Compiled Region: 0/0->k (Synthetic Op)", None),
+    ],
+)
+def test_u1_detector_fires_on_graph_collapsed(tmp_path, wrapper):
+    graph_rows = [(name, 47.5, 47.5) for name in wrapper if name]
+    # Pad the graph weight to 95 total and add a benign plain kernel for the 5%.
+    rows = graph_rows + [("plain_kernel", 5.0, 5.0)]
+    # Normalize the graph weight to sum to 95 regardless of how many graph rows.
+    graph_total = sum(w for _, w, _ in graph_rows)
+    rows = [(name, w / graph_total * 95.0, p) for name, w, p in graph_rows] + [
+        ("plain_kernel", 5.0, 5.0)
+    ]
+
+    perf_dir = _make_perf_csv(tmp_path, rows)
+    verdict = check_graph_replay_coverage(perf_dir)
+
+    assert verdict.graph_under_recorded is True
+    assert verdict.graph_replay_fraction == pytest.approx(0.95)
+
+
+# ---------------------------------------------------------------------------
+# U2 — detector stays quiet on a healthy fixture
+# ---------------------------------------------------------------------------
+def test_u2_detector_quiet_on_healthy(tmp_path):
+    rows = [
+        ("aten::mm", 40.0, 40.0),
+        ("aten::softmax", 30.0, 30.0),
+        ("hipMemcpyAsync->copy_dtoh (Synthetic Op)", 15.0, 15.0),
+        ("hipModuleLaunchKernel->some_kernel (Synthetic Op)", 15.0, 15.0),
+    ]
+    perf_dir = _make_perf_csv(tmp_path, rows)
+    verdict = check_graph_replay_coverage(perf_dir)
+
+    assert verdict.graph_under_recorded is False
+    assert verdict.graph_replay_fraction == 0.0
+
+
+# ---------------------------------------------------------------------------
+# U3 — false-positive guard: benign launch/memcpy wrappers never count
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "wrapper_name",
+    [
+        "hipLaunchKernel->orphan (Synthetic Op)",
+        "hipModuleLaunchKernel->orphan (Synthetic Op)",
+        "hipMemcpyAsync->orphan (Synthetic Op)",
+        "MemcpyDtoH->orphan (Synthetic Op)",
+        "__amd_rocclr_copyBuffer->orphan (Synthetic Op)",
+    ],
+)
+def test_u3_false_positive_guard(tmp_path, wrapper_name):
+    rows = [
+        (wrapper_name, 40.0, 40.0),
+        ("aten::mm", 60.0, 60.0),
+    ]
+    perf_dir = _make_perf_csv(tmp_path, rows)
+    verdict = check_graph_replay_coverage(perf_dir)
+
+    assert verdict.graph_under_recorded is False
+    assert verdict.graph_replay_fraction == 0.0
+
+
+# ---------------------------------------------------------------------------
+# U4 — threshold boundary (strict `>` around 0.10)
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "graph_weight, expected",
+    [
+        (9.9, False),  # 0.099 < 0.10
+        (10.0, False),  # 0.100 == 0.10 -> strict > means still False
+        (10.1, True),  # 0.101 > 0.10
+    ],
+)
+def test_u4_threshold_boundary(tmp_path, graph_weight, expected):
+    assert GRAPH_REPLAY_FRACTION_MAX == 0.10
+    rows = [
+        ("hipGraphLaunch->k (Synthetic Op)", graph_weight, graph_weight),
+        ("aten::mm", 100.0 - graph_weight, 100.0 - graph_weight),
+    ]
+    perf_dir = _make_perf_csv(tmp_path, rows)
+    verdict = check_graph_replay_coverage(perf_dir)
+
+    assert verdict.graph_under_recorded is expected
+    assert verdict.graph_replay_fraction == pytest.approx(graph_weight / 100.0)
+
+
+# ---------------------------------------------------------------------------
+# U5 — wrapper-strip + exact-name grouping
+# ---------------------------------------------------------------------------
+def test_u5_wrapper_strip_and_exact_name_grouping(tmp_path):
+    rows = [
+        ("hipGraphLaunch->foo (Synthetic Op)", 10.0, 10.0),
+        ("hipGraphLaunch->foo (Synthetic Op)", 30.0, 30.0),
+        ("hipGraphLaunch->bar (Synthetic Op)", 20.0, 20.0),
+    ]
+    perf_dir = _make_perf_csv(tmp_path, rows)
+    md = render_fallback_report(perf_dir, 0.95)
+
+    # Bare names recovered from the WRAPPER->K (Synthetic Op) form.
+    headings = dict((int(rank), name) for rank, name in _HEADING_RE.findall(md))
+    assert set(headings.values()) == {"foo", "bar"}
+
+    # foo group = 10 + 30 = 40 of total 60 -> 66.667%; bar = 20 -> 33.333%.
+    # Impact low = round(pct * 0.15, 2). Both foo cards carry the SAME group value.
+    foo_low = round(40.0 / 60.0 * 100.0 * 0.15, 2)
+    bar_low = round(20.0 / 60.0 * 100.0 * 0.15, 2)
+    assert foo_low != bar_low  # distinct groups -> distinct impact
+
+    lows = [
+        float(re.search(r"low=([\d.]+)", blob).group(1))
+        for blob in _PITEM_MARKER_RE.findall(md)
+    ]
+    assert lows.count(foo_low) == 2  # two foo rows, one card each, same group value
+    assert lows.count(bar_low) == 1
+
+
+def test_u5_tile_variants_stay_separate_groups(tmp_path):
+    rows = [
+        ("hipGraphLaunch->f4gemm_192x128 (Synthetic Op)", 30.0, 30.0),
+        ("hipGraphLaunch->f4gemm_32x128 (Synthetic Op)", 10.0, 10.0),
+    ]
+    perf_dir = _make_perf_csv(tmp_path, rows)
+    md = render_fallback_report(perf_dir, 0.95)
+
+    names = {name for _, name in _HEADING_RE.findall(md)}
+    assert names == {"f4gemm_192x128", "f4gemm_32x128"}
+
+    # Different bare names => different groups => different %-of-total impact.
+    lows = sorted(
+        float(re.search(r"low=([\d.]+)", blob).group(1))
+        for blob in _PITEM_MARKER_RE.findall(md)
+    )
+    assert lows == sorted(
+        [round(10.0 / 40.0 * 100.0 * 0.15, 2), round(30.0 / 40.0 * 100.0 * 0.15, 2)]
+    )
+
+
+# ---------------------------------------------------------------------------
+# U5c — plumbing behind a graph-replay wrapper is dropped from the writer output.
+# Guards the leak where the wrapper prefix is graph-replay but the bare kernel
+# behind it is runtime plumbing (e.g. `hipGraphLaunch->__amd_rocclr_copyBuffer`).
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "plumbing_kernel",
+    ["__amd_rocclr_copyBuffer", "__amd_rocclr_fillBufferAligned", "MemcpyDtoD"],
+)
+def test_u5c_plumbing_behind_graph_replay_wrapper_dropped(tmp_path, plumbing_kernel):
+    rows = [
+        ("hipGraphLaunch->real_kernel (Synthetic Op)", 90.0, 90.0),
+        (f"hipGraphLaunch->{plumbing_kernel} (Synthetic Op)", 10.0, 10.0),
+        (f"Torch-Compiled Region: 0/0->{plumbing_kernel} (Synthetic Op)", 5.0, 5.0),
+    ]
+    perf_dir = _make_perf_csv(tmp_path, rows)
+    md = render_fallback_report(perf_dir, 0.95)
+
+    names = {name for _, name in _HEADING_RE.findall(md)}
+    assert names == {"real_kernel"}
+    assert plumbing_kernel not in md
+
+
+# ---------------------------------------------------------------------------
+# U6 — impact arithmetic (match the exact emitted string)
+# ---------------------------------------------------------------------------
+def test_u6_impact_arithmetic(tmp_path):
+    # Two equal-weight rows with distinct names -> each is its own group at 50%.
+    rows = [
+        ("hipGraphLaunch->foo (Synthetic Op)", 50.0, 50.0),
+        ("hipGraphLaunch->bar (Synthetic Op)", 50.0, 50.0),
+    ]
+    perf_dir = _make_perf_csv(tmp_path, rows)
+    md = render_fallback_report(perf_dir, 0.95)
+
+    # 50 * 0.15/0.30/0.45 = 7.5 / 15.0 / 22.5 (round(...,2) prints 15.0, not 15).
+    assert (
+        "impact-begin kind=p_item category=unknown low=7.5 mid=15.0 high=22.5 -->" in md
+    )
+
+
+# ---------------------------------------------------------------------------
+# U7 — parse contract (LOAD-BEARING) against vendored regexes
+# ---------------------------------------------------------------------------
+def test_u7_parse_contract(tmp_path):
+    # Two DISTINCT graph-replay kernels with distinct bare names and weights.
+    # Higher weight sorts first -> P1; the full downstream parse must yield one
+    # candidate per data row, i.e. TWO. This whole test drives the REAL parse
+    # path (_parse_candidates), not just a heading count, so it catches the
+    # class of contract bug where the md renders but parses to ZERO candidates.
+    rows = [
+        ("hipGraphLaunch->foo (Synthetic Op)", 60.0, 60.0),
+        ("hipGraphLaunch->bar (Synthetic Op)", 40.0, 40.0),
+    ]
+    perf_dir = _make_perf_csv(tmp_path, rows)
+    md = render_fallback_report(perf_dir, 0.95)
+
+    candidates = _parse_candidates(md)
+
+    # (1) LOAD-BEARING: the full parse yields exactly two candidates. This is
+    #     the assertion that would have caught both prior contract bugs, each of
+    #     which rendered headings but collapsed to zero downstream candidates.
+    assert len(candidates) == 2
+
+    # (2) rank -> kernel mapping (P1 = highest weight) and category propagation.
+    by_rank = {c["rank"]: c for c in candidates}
+    assert by_rank[1]["kernel_name"] == "foo"
+    assert by_rank[2]["kernel_name"] == "bar"
+    for cand in candidates:
+        assert cand["category"] == "unknown"
+
+    # (3) name/time/%E2E populated in the row; Args cell is the em dash.
+    assert by_rank[1]["operation"] == "foo"
+    assert by_rank[1]["args"] == _EM_DASH  # Args intentionally unrecoverable
+    assert by_rank[1]["time_ms"] == "0.060"  # 60 us -> 0.060 ms
+    assert by_rank[1]["percent_e2e"] == "60.00"
+
+    # (4) NEGATIVE — ### regression guard: downgrading the headings to three
+    #     hashes makes every block vanish under _HEADING_RE -> zero candidates.
+    downgraded = md.replace("#### P", "### P")
+    assert len(_parse_candidates(downgraded)) == 0
+
+    # (5) NEGATIVE — **Data:** regression guard (catches C1): with the Data
+    #     marker deleted, _extract_data_table returns [] -> zero candidates.
+    no_data = "\n".join(line for line in md.splitlines() if line.strip() != "**Data:**")
+    assert len(_parse_candidates(no_data)) == 0
+
+    # (6) NEGATIVE — marker/heading ORDER guard (catches C2): moving each
+    #     heading BEFORE its reasoning-candidate marker breaks the block split
+    #     (the heading no longer falls in the marker's body slice), so the
+    #     candidate count is wrong (not two). The correct order is load-bearing.
+    reordered = re.sub(
+        r"(<!-- reasoning-candidate tier=compute rank=\d+ -->)\n(#### P\d+: [^\n]+)",
+        r"\2\n\1",
+        md,
+    )
+    assert len(_parse_candidates(reordered)) != 2
+    # And in the REAL md every marker precedes its matching heading.
+    for rank in (1, 2):
+        marker_idx = md.index(f"reasoning-candidate tier=compute rank={rank}")
+        heading_idx = md.index(f"#### P{rank}:")
+        assert marker_idx < heading_idx
+
+
+# ---------------------------------------------------------------------------
+# U8 — separate-row vs grouped invariant; plumbing dropped
+# ---------------------------------------------------------------------------
+def test_u8_separate_rows_grouped_impact(tmp_path):
+    rows = [
+        ("hipGraphLaunch->foo (Synthetic Op)", 30.0, 30.0),
+        ("hipGraphLaunch->foo (Synthetic Op)", 10.0, 10.0),
+        ("hipGraphLaunch->bar (Synthetic Op)", 20.0, 20.0),
+        # Benign plumbing must be dropped from the candidate table entirely.
+        ("hipMemcpyAsync->copy (Synthetic Op)", 5.0, 5.0),
+    ]
+    perf_dir = _make_perf_csv(tmp_path, rows)
+    md = render_fallback_report(perf_dir, 0.95)
+
+    headings = _HEADING_RE.findall(md)
+    # One card per SURVIVING CSV kernel row (3), plumbing row dropped.
+    assert len(headings) == 3
+    assert _data_row_cells(md, "copy") is None  # plumbing not rendered
+
+    # Two foo rows share a bare name -> two cards, SAME name-grouped impact.
+    total = 60.0  # 30 + 10 + 20 (plumbing excluded from the group total)
+    foo_low = round(40.0 / total * 100.0 * 0.15, 2)
+    bar_low = round(20.0 / total * 100.0 * 0.15, 2)
+    lows = [
+        float(re.search(r"low=([\d.]+)", blob).group(1))
+        for blob in _PITEM_MARKER_RE.findall(md)
+    ]
+    assert lows.count(foo_low) == 2
+    assert lows.count(bar_low) == 1
+
+
+# ---------------------------------------------------------------------------
+# U9 — degraded banner present and inert to the parser
+# ---------------------------------------------------------------------------
+def test_u9_degraded_banner(tmp_path):
+    rows = [
+        ("hipGraphLaunch->foo (Synthetic Op)", 95.0, 95.0),
+        ("aten::mm", 5.0, 5.0),
+    ]
+    perf_dir = _make_perf_csv(tmp_path, rows)
+    frac = 0.95
+    md = render_fallback_report(perf_dir, frac)
+
+    # Visible call-out with the fraction rendered as a percent.
+    assert "> **⚠ Degraded (deterministic fallback) report.**" in md
+    assert "graph-replay fraction 95%" in md
+
+    # The banner is INERT: stripping it must not change any parsed candidate count.
+    stripped = _strip_banner(md)
+    assert len(_HEADING_RE.findall(md)) == len(_HEADING_RE.findall(stripped))
+    assert len(_PITEM_MARKER_RE.findall(md)) == len(_PITEM_MARKER_RE.findall(stripped))
+    assert len(_REASONING_MARKER_RE.findall(md)) == len(
+        _REASONING_MARKER_RE.findall(stripped)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Normalizer matrix — one case per name form (truncate-only, no demangling).
+# ---------------------------------------------------------------------------
+def test_normalizer_bare_triton_identity():
+    assert _normalize_kernel_name("_fwd_kernel") == "_fwd_kernel"
+
+
+def test_normalizer_clean_aiter_identity():
+    # A real ~50-char aiter config passes through untouched (< the 75 cap).
+    name = "aiter::f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128"
+    assert len(name) < MAX_KERNEL_NAME_LEN
+    assert _normalize_kernel_name(name) == name
+
+
+def test_normalizer_void_template_truncated_void_kept():
+    # `void ` is KEPT (matches the GOOD report); only length is trimmed.
+    raw = (
+        "void at::native::elementwise_kernel<128, 2, "
+        "at::native::gpu_kernel_impl<at::native::BinaryFunctor>>(int, char*)"
+    )
+    assert len(raw) > MAX_KERNEL_NAME_LEN
+    out = _normalize_kernel_name(raw)
+    assert out.startswith("void ")
+    assert out == raw[:MAX_KERNEL_NAME_LEN] + "..."
+    assert len(out) == MAX_KERNEL_NAME_LEN + 3
+
+
+def test_normalizer_tensile_truncated():
+    raw = "Cijk_Ailk_Bljk_HHS_BH_Bias_AS_MT128x160x16_MI16x16x16x1_SN_WG32_8_1_ABCD"
+    raw = raw + "_extra_tokens_pushing_well_past_the_cap"
+    assert len(raw) > MAX_KERNEL_NAME_LEN
+    out = _normalize_kernel_name(raw)
+    assert out == raw[:MAX_KERNEL_NAME_LEN] + "..."
+
+
+def test_normalizer_mangled_zn_truncated_not_demangled():
+    # Locks in the no-demangle decision: the symbol stays mangled, just shorter.
+    raw = "_ZN5aiter24add_rmsnorm_quant_kernelIN3std10bfloat16_tES2_Li256ELb1EEEvPT_"
+    raw = raw + "PKS1_iiffb"
+    assert len(raw) > MAX_KERNEL_NAME_LEN
+    out = _normalize_kernel_name(raw)
+    assert out.startswith("_ZN")
+    assert out.endswith("...")
+    assert out == raw[:MAX_KERNEL_NAME_LEN] + "..."
+
+
+def test_normalizer_never_returns_empty():
+    # The non-empty invariant: a blank input falls back to raw, never "".
+    assert _normalize_kernel_name("") == ""
+    assert _normalize_kernel_name("   ") == "   "
+
+
+def test_normalizer_length_boundary():
+    at_cap = "a" * MAX_KERNEL_NAME_LEN
+    over_cap = "a" * (MAX_KERNEL_NAME_LEN + 1)
+    assert _normalize_kernel_name(at_cap) == at_cap  # len 75 -> identity
+    assert _normalize_kernel_name(over_cap) == at_cap + "..."  # len 76 -> truncates
+
+
+# ---------------------------------------------------------------------------
+# Group-independence: distinct raw kernels whose DISPLAY collapses (differ only
+# past char 75) must stay separate groups with their own impact (group-by-raw,
+# normalize-for-display).
+# ---------------------------------------------------------------------------
+def test_group_independence_raw_key_not_display(tmp_path):
+    common = "C" * 80  # first 75 chars identical -> identical truncated display
+    name_a, name_b = common + "_aaa", common + "_bbb"
+    rows = [
+        (f"hipGraphLaunch->{name_a} (Synthetic Op)", 60.0, 60.0),
+        (f"hipGraphLaunch->{name_b} (Synthetic Op)", 40.0, 40.0),
+    ]
+    perf_dir = _make_perf_csv(tmp_path, rows)
+    md = render_fallback_report(perf_dir, 0.95)
+
+    # Two P-items render even though their titles are byte-identical.
+    headings = _HEADING_RE.findall(md)
+    assert len(headings) == 2
+    titles = {title for _, title in headings}
+    assert len(titles) == 1  # display collapsed, but two cards still emitted
+
+    # Impacts are per-raw-group (9.0 and 6.0), NOT a merged 15.0 for both.
+    lows = sorted(
+        float(re.search(r"low=([\d.]+)", blob).group(1))
+        for blob in _PITEM_MARKER_RE.findall(md)
+    )
+    assert lows == [round(40.0 * 0.15, 2), round(60.0 * 0.15, 2)]
+
+
+# ---------------------------------------------------------------------------
+# N3 columns: Operation cell == em dash (op never captured on a
+# graph-collapsed trace), Kernel Name cell == raw device symbol, and the P
+# heading carries the normalized short form.
+# ---------------------------------------------------------------------------
+def test_n3_operation_em_dash_kernel_name_raw(tmp_path):
+    raw = "void aiter::" + "x" * 100  # > cap -> display truncates, raw preserved
+    rows = [(f"hipGraphLaunch->{raw} (Synthetic Op)", 100.0, 100.0)]
+    perf_dir = _make_perf_csv(tmp_path, rows)
+    md = render_fallback_report(perf_dir, 0.95)
+
+    display = _normalize_kernel_name(raw)
+    assert display != raw
+    # The em-dash Operation cell means the data row no longer starts with the
+    # display name; find it by the raw Kernel Name instead.
+    cells = _data_row_cells(md, _EM_DASH)
+    assert cells is not None
+    assert cells[0] == _EM_DASH  # Operation cell == em dash
+    assert cells[3] == raw  # Kernel Name cell == raw device symbol
+    # The normalized short form still labels the P-item heading.
+    assert f"#### P1: {display}" in md
+
+
+# ---------------------------------------------------------------------------
+# Em-dash-Operation contract — every row emits an em-dash Operation cell, and the
+# relaxed reader recovers a candidate per row via the device kernel symbol.
+# ---------------------------------------------------------------------------
+def test_option_b_operation_is_em_dash_reader_substitutes_kernel_name(tmp_path):
+    rows = [
+        ("hipGraphLaunch->foo (Synthetic Op)", 60.0, 60.0),
+        ("hipGraphLaunch->bar (Synthetic Op)", 40.0, 40.0),
+    ]
+    perf_dir = _make_perf_csv(tmp_path, rows)
+    md = render_fallback_report(perf_dir, 0.95)
+
+    # Every rendered data row's Operation cell is the em dash (op never captured).
+    data_rows = [
+        line
+        for line in md.splitlines()
+        if line.startswith("| ") and "0.0" in line  # a data row (has a time cell)
+    ]
+    assert data_rows
+    for line in data_rows:
+        first_cell = line.split("|")[1].strip()
+        assert first_cell == _EM_DASH
+
+    # The relaxed reader still yields one candidate per row, keyed on the symbol.
+    candidates = _parse_candidates(md)
+    assert len(candidates) == 2
+    assert {c["operation"] for c in candidates} == {"foo", "bar"}
+    for c in candidates:
+        assert c["operation"] == c["kernel_name"]
+
+
+# ---------------------------------------------------------------------------
+# U10 — N4 %E2E floor + top-N cap + drop-logging.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "percent, expected_kept",
+    [
+        (0.49, 0),  # below floor -> dropped
+        (0.50, 1),  # == floor -> kept (strict >=)
+        (0.51, 1),  # above floor -> kept
+    ],
+)
+def test_u10_floor_boundary(tmp_path, percent, expected_kept):
+    assert MIN_PITEM_PERCENT_E2E == 0.5
+    rows = [("hipGraphLaunch->k (Synthetic Op)", 100.0, percent)]
+    perf_dir = _make_perf_csv(tmp_path, rows)
+    md = render_fallback_report(perf_dir, 0.95)
+
+    assert len(_HEADING_RE.findall(md)) == expected_kept
+    dropped = 1 - expected_kept
+    if dropped:
+        assert f"Dropped {dropped} P-items" in md
+    else:
+        assert "Dropped " not in md
+
+
+def test_u10_top_n_cap_and_drop_logging(tmp_path):
+    # MAX_PITEM_COUNT + 5 distinct kernels, all above the floor, descending weight.
+    n = MAX_PITEM_COUNT + 5
+    weights = [float(100 - i) for i in range(n)]
+    rows = [
+        (f"hipGraphLaunch->k{i:02d} (Synthetic Op)", w, 4.0)
+        for i, w in enumerate(weights)
+    ]
+    perf_dir = _make_perf_csv(tmp_path, rows)
+    md = render_fallback_report(perf_dir, 0.95)
+
+    # Exactly MAX_PITEM_COUNT render; the rest dropped, logged in the banner.
+    assert len(_HEADING_RE.findall(md)) == MAX_PITEM_COUNT
+    dropped = len(weights) - MAX_PITEM_COUNT
+    assert f"Dropped {dropped} P-items" in md
+
+    # Survivor impact uses the FULL total (all rows), not the top-N subtotal.
+    total_full = sum(weights)
+    p1_pct = weights[0] / total_full * 100.0
+    expected_p1_low = round(p1_pct * 0.15, 2)
+    lows = [
+        float(re.search(r"low=([\d.]+)", blob).group(1))
+        for blob in _PITEM_MARKER_RE.findall(md)
+    ]
+    assert lows[0] == expected_p1_low
+    # And that differs from what a top-N-only denominator would give.
+    top_n_pct = weights[0] / sum(weights[:MAX_PITEM_COUNT]) * 100.0
+    assert expected_p1_low != round(top_n_pct * 0.15, 2)
+
+
+def test_u10_no_drop_note_when_nothing_dropped(tmp_path):
+    rows = [("hipGraphLaunch->k (Synthetic Op)", 100.0, 60.0)]
+    perf_dir = _make_perf_csv(tmp_path, rows)
+    md = render_fallback_report(perf_dir, 0.95)
+
+    assert "Dropped " not in md  # drop-note sentence suppressed at zero
+
+
+# ---------------------------------------------------------------------------
+# U9 extension — the banner drop-note stays inert to the parser.
+# ---------------------------------------------------------------------------
+def test_u9_drop_note_inert(tmp_path):
+    rows = [
+        ("hipGraphLaunch->foo (Synthetic Op)", 60.0, 60.0),
+        ("hipGraphLaunch->bar (Synthetic Op)", 40.0, 40.0),
+    ]
+    perf_dir = _make_perf_csv(tmp_path, rows)
+    md = render_fallback_report(perf_dir, 0.95)
+
+    # Stripping the banner does not change the parsed candidate count.
+    assert len(_parse_candidates(md)) == 2
+    assert len(_parse_candidates(_strip_banner(md))) == 2
+
+
+# ---------------------------------------------------------------------------
+# U7 re-run — the Operation cell is the em dash, but the relaxed
+# reader substitutes the device kernel symbol, so candidates still parse with a
+# non-empty operation identity and `####` headings.
+# ---------------------------------------------------------------------------
+def test_u7_rerun_after_normalization(tmp_path):
+    long_raw = "void aiter::" + "y" * 90
+    rows = [
+        (f"hipGraphLaunch->{long_raw} (Synthetic Op)", 60.0, 60.0),
+        ("hipGraphLaunch->_fwd_kernel (Synthetic Op)", 40.0, 40.0),
+    ]
+    perf_dir = _make_perf_csv(tmp_path, rows)
+    md = render_fallback_report(perf_dir, 0.95)
+
+    candidates = _parse_candidates(md)
+    assert len(candidates) == 2
+    for cand in candidates:
+        # Operation resolves to the device kernel symbol via reader substitution.
+        assert cand["operation"]
+        assert cand["operation"] not in ("", _EM_DASH)
+        assert cand["operation"] == cand["kernel_name"]
+    for line in md.splitlines():
+        if "P1:" in line or "P2:" in line:
+            assert line.startswith("####")
+
+
+# ---------------------------------------------------------------------------
+# U11 — field-size crash fix: a field larger than csv's 131072 default must not
+# raise in the detector or the loader/writer.
+# ---------------------------------------------------------------------------
+def test_u11_giant_field_does_not_crash(tmp_path):
+    giant = "hipGraphLaunch->" + ("k" * 200000) + " (Synthetic Op)"
+    rows = [
+        (giant, 90.0, 90.0),
+        ("hipGraphLaunch->small (Synthetic Op)", 10.0, 10.0),
+    ]
+    perf_dir = _make_perf_csv(tmp_path, rows)
+
+    verdict = check_graph_replay_coverage(perf_dir)  # must not raise
+    assert verdict.graph_under_recorded is True
+
+    md = render_fallback_report(
+        perf_dir, verdict.graph_replay_fraction
+    )  # must not raise
+    assert "#### P1:" in md

--- a/tests/test_analysis_agent_deterministic.py
+++ b/tests/test_analysis_agent_deterministic.py
@@ -69,17 +69,20 @@ _EM_DASH = "—"
 def _make_perf_csv(tmp_path, rows):
     """Write a synthetic ``unified_perf_summary.csv`` and return its path.
 
-    ``rows`` is a list of ``(name, weight, percent)`` tuples. Only the three
-    columns the code reads are written; ``percent`` defaults to 0.0 if omitted.
+    ``rows`` is a list of ``(name, weight, percent[, count])`` tuples. ``percent``
+    defaults to 0.0 and ``count`` to 1 when omitted.
     """
     csv_path = tmp_path / "unified_perf_summary.csv"
     with open(csv_path, "w", newline="", encoding="utf-8") as fh:
         writer = csv.writer(fh)
-        writer.writerow(["name", "Kernel Time (µs)_sum", "Percentage (%)"])
+        writer.writerow(
+            ["name", "Kernel Time (µs)_sum", "Percentage (%)", "operation_count"]
+        )
         for row in rows:
             name, weight = row[0], row[1]
             percent = row[2] if len(row) > 2 else 0.0
-            writer.writerow([name, weight, percent])
+            count = row[3] if len(row) > 3 else 1
+            writer.writerow([name, weight, percent, count])
     return csv_path
 
 
@@ -341,6 +344,7 @@ def test_writer_structure_contract(tmp_path):
         assert row[3] == kernel  # Kernel Name cell == raw symbol
         assert row[4] == time_ms
         assert row[5] == pct
+        assert row[6] == "1"  # Count cell: one row per group, count=1
     assert cells is not None  # a data row exists
 
     # NEGATIVE — downgrading #### P to ### P makes _HEADING_RE find no headings.
@@ -377,6 +381,32 @@ def test_writer_separate_rows_grouped_impact(tmp_path):
     ]
     assert lows.count(foo_low) == 2
     assert lows.count(bar_low) == 1
+
+
+# ---------------------------------------------------------------------------
+# Count column: summed per name group (not em-dashed), from operation_count
+# ---------------------------------------------------------------------------
+def test_writer_count_summed_per_group(tmp_path):
+    rows = [
+        # Two foo rows -> counts 7 + 3 = 10 for the group.
+        ("hipGraphLaunch->foo (Synthetic Op)", 30.0, 30.0, 7),
+        ("hipGraphLaunch->foo (Synthetic Op)", 10.0, 10.0, 3),
+        ("hipGraphLaunch->bar (Synthetic Op)", 20.0, 20.0, 4),
+    ]
+    perf_csv = _make_perf_csv(tmp_path, rows)
+    md = render_fallback_report(perf_csv, 0.95)
+
+    # Count is cell index 6 (Operation, Args, Kernel Path, Kernel Name, Time,
+    # %E2E, Count, ...); every foo card shows the group sum, not the per-row count.
+    def _count_cells(kernel):
+        return [
+            [c.strip() for c in line.split("|")[1:-1]][6]
+            for line in md.splitlines()
+            if line.strip().startswith("| —") and f"| {kernel} |" in line
+        ]
+
+    assert _count_cells("foo") == ["10", "10"]  # 7 + 3, same on both foo cards
+    assert _count_cells("bar") == ["4"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_analysis_agent_deterministic.py
+++ b/tests/test_analysis_agent_deterministic.py
@@ -4,19 +4,13 @@
 # See LICENSE for license information.
 ###############################################################################
 
-"""Tier-1 unit tests for the deterministic graph-under-recorded fallback.
+"""Unit tests for the deterministic graph-under-recorded fallback.
 
-Covers the no-LLM fallback path in ``utils/deterministic_fallback``:
-- ``check_graph_replay_coverage`` (detector U1-U4)
-- ``render_fallback_report`` (writer U5-U9)
-
-Every fixture is a tiny SYNTHETIC ``unified_perf_summary.csv`` written under
-``tmp_path`` with hand-computed expected values, so a failing assertion points
-at the exact arithmetic. No GPU, no LLM, no network, no ``Local_Traces``.
-
-U7/U9 assert the downstream ``analysis.md`` parse contract using a LOCAL, vendored
-copy of the consumer's regexes (kept in sync manually, no external import) so the
-fallback md stays compatible with the default-agent contract.
+Covers the no-LLM fallback path in ``utils/deterministic_fallback``: the
+detector ``check_graph_replay_coverage`` and the ``render_fallback_report`` md
+writer. Every fixture is a tiny synthetic ``unified_perf_summary.csv`` written
+under ``tmp_path`` with hand-computed expected values, so a failing assertion
+points at the exact arithmetic. No GPU, no LLM, no network.
 """
 
 import csv
@@ -37,9 +31,8 @@ from TraceLens.Agent.Analysis.utils.deterministic_fallback import (
 )
 
 # ---------------------------------------------------------------------------
-# Vendored downstream-parser regexes (U7/U9). Copied verbatim from the
-# ``analysis.md`` consumer so the tests assert the exact parse contract without
-# an external import.
+# Structural regexes: match the markers/headings the producer emits, so the
+# tests assert the SHAPE of the fallback md directly.
 # ---------------------------------------------------------------------------
 _PITEM_MARKER_RE = re.compile(
     r"<!--\s*impact-begin\s+kind=p_item\s+([^>]*?)-->",
@@ -54,8 +47,8 @@ _HEADING_RE = re.compile(
     re.MULTILINE,
 )
 
-# 9 canonical column tokens the downstream parser requires in order; "Kernel
-# Name" is an extra column allowed to interleave.
+# The 9 canonical column tokens the producer emits in order; "Kernel Name" is an
+# extra column allowed to interleave.
 _DATA_TABLE_HEADER_TOKENS = (
     "operation",
     "args",
@@ -67,203 +60,28 @@ _DATA_TABLE_HEADER_TOKENS = (
     "efficiency",
     "bound",
 )
-_DATA_TABLE_CANONICAL_KEY_SET = frozenset(
-    tok.strip().lower() for tok in _DATA_TABLE_HEADER_TOKENS
-)
 
 _EM_DASH = "—"
-
-
-# ---------------------------------------------------------------------------
-# Vendored subset of the downstream ``analysis.md`` parser — kept in sync with
-# the consumer. This runs the REAL downstream parse path (reasoning-marker block
-# split -> **Data:** table extraction -> canonical 9-column validation -> one
-# candidate per data row) so U7 gates the exact class of contract bug that a
-# heading-count-only check would miss.
-# ---------------------------------------------------------------------------
-def _safe_float(value, default: float = 0.0) -> float:
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        return default
-
-
-def _parse_marker_attrs(blob: str) -> dict:
-    """Parse ``key=value`` attributes from an HTML-comment marker blob."""
-    return dict(re.findall(r"(\w+)=([^\s>]+)", blob))
-
-
-def _extract_pitem_categories(text: str) -> list:
-    """One dict per ``p_item`` marker (in order); markers must carry ``category=``."""
-    items = []
-    for match in _PITEM_MARKER_RE.finditer(text):
-        attrs = _parse_marker_attrs(match.group(1))
-        if "category" not in attrs:
-            continue
-        items.append(
-            {
-                "category": attrs.get("category", ""),
-                "impact_score_low": _safe_float(attrs.get("low")),
-                "impact_score": _safe_float(attrs.get("mid")),
-                "impact_score_high": _safe_float(attrs.get("high")),
-            }
-        )
-    return items
-
-
-def _split_data_blocks(text: str) -> list:
-    """Split into compute-tier reasoning blocks; drop any with no heading in slice."""
-    blocks = []
-    matches = list(_REASONING_MARKER_RE.finditer(text))
-    for idx, match in enumerate(matches):
-        tier = match.group(1).lower()
-        if tier != "compute":
-            continue
-        body_start = match.end()
-        body_end = matches[idx + 1].start() if idx + 1 < len(matches) else len(text)
-        body = text[body_start:body_end]
-        head_match = _HEADING_RE.search(body)
-        if not head_match:
-            continue
-        rank = int(head_match.group(1))
-        title = head_match.group(2).strip()
-        blocks.append((rank, title, body))
-    return blocks
-
-
-def _extract_data_table(body: str) -> list:
-    """Pull the markdown table after ``**Data:**``; ``[]`` when the marker is absent."""
-    marker = body.find("**Data:**")
-    if marker < 0:
-        return []
-    tail = body[marker + len("**Data:**") :]
-    rows = []
-    in_table = False
-    for line in tail.splitlines():
-        stripped = line.strip()
-        if not stripped:
-            if in_table:
-                break
-            continue
-        if not stripped.startswith("|"):
-            if in_table:
-                break
-            continue
-        in_table = True
-        if set(stripped.replace("|", "").strip()) <= set("-: "):
-            continue
-        cells = [cell.strip() for cell in stripped.split("|")[1:-1]]
-        rows.append(cells)
-    return rows
-
-
-def _parse_candidates(md_text: str) -> list:
-    """Run the real downstream parse and return one candidate dict per data row.
-
-    Faithful subset of ``parse_analysis_md``: block split -> ``**Data:**`` table
-    extraction -> canonical 9-column (in-order, extras allowed) validation ->
-    one candidate per surviving data row carrying the P-item category.
-    """
-    pitems = _extract_pitem_categories(md_text)
-    blocks = _split_data_blocks(md_text)
-    if not blocks:
-        return []
-
-    headers_canonical = [tok.strip().lower() for tok in _DATA_TABLE_HEADER_TOKENS]
-    canonical_width = len(headers_canonical)
-
-    candidates = []
-    for rank, title, body in blocks:
-        rows = _extract_data_table(body)
-        if not rows:
-            continue
-        header_row = [cell.strip().lower() for cell in rows[0]]
-        if len(header_row) < canonical_width:
-            continue
-        normalized_header = []
-        for cell in header_row:
-            match = next(
-                (
-                    canon
-                    for canon in headers_canonical
-                    if canon == cell or canon in cell
-                ),
-                cell,
-            )
-            normalized_header.append(match)
-        canonical_in_header = [c for c in normalized_header if c in headers_canonical]
-        if canonical_in_header != headers_canonical:
-            continue
-        header_row = normalized_header
-        pitem_meta = pitems[rank - 1] if rank - 1 < len(pitems) else {}
-        category = pitem_meta.get("category", "")
-        impact_score = pitem_meta.get("impact_score", 0.0)
-        for cells in rows[1:]:
-            if len(cells) != len(header_row):
-                continue
-            record = dict(zip(header_row, cells))
-            name = record.get("operation", "").strip()
-            kernel_name = record.get("kernel name", "").strip()
-            # Relaxed-reader contract: a graph-collapsed row emits "—"
-            # for Operation because the python/aten op was never captured; the
-            # device kernel symbol is the identity. Substitute it rather than
-            # dropping the row. Drop only when there is no symbol either.
-            if not name or name in {"-", "—"}:
-                if not kernel_name or kernel_name in {"-", "—"}:
-                    continue
-                name = kernel_name
-            candidates.append(
-                {
-                    "rank": rank,
-                    "title": title,
-                    "operation": name,
-                    "kernel_name": kernel_name,
-                    "category": category,
-                    "impact_score": impact_score,
-                    "args": record.get("args", "").strip(),
-                    "time_ms": record.get("time (ms)", "").strip(),
-                    "percent_e2e": record.get("%e2e", "").strip(),
-                }
-            )
-    return candidates
 
 
 # ---------------------------------------------------------------------------
 # Fixture helpers
 # ---------------------------------------------------------------------------
 def _make_perf_csv(tmp_path, rows):
-    """Write a synthetic ``unified_perf_summary.csv`` and return its dir.
+    """Write a synthetic ``unified_perf_summary.csv`` and return its path.
 
     ``rows`` is a list of ``(name, weight, percent)`` tuples. Only the three
     columns the code reads are written; ``percent`` defaults to 0.0 if omitted.
     """
-    perf_dir = tmp_path / "perf_report_csvs"
-    perf_dir.mkdir(exist_ok=True)
-    with open(
-        perf_dir / "unified_perf_summary.csv", "w", newline="", encoding="utf-8"
-    ) as fh:
+    csv_path = tmp_path / "unified_perf_summary.csv"
+    with open(csv_path, "w", newline="", encoding="utf-8") as fh:
         writer = csv.writer(fh)
         writer.writerow(["name", _WEIGHT_COLUMN, _PERCENT_COLUMN])
         for row in rows:
             name, weight = row[0], row[1]
             percent = row[2] if len(row) > 2 else 0.0
             writer.writerow([name, weight, percent])
-    return perf_dir
-
-
-def _make_category_csv(perf_dir, categories):
-    """Write an optional ``ops_summary_by_category.csv`` for the other-frac path.
-
-    ``categories`` is a list of ``(op_category, percent)`` tuples.
-    """
-    with open(
-        perf_dir / "ops_summary_by_category.csv", "w", newline="", encoding="utf-8"
-    ) as fh:
-        writer = csv.writer(fh)
-        writer.writerow(["op category", _PERCENT_COLUMN])
-        for cat, pct in categories:
-            writer.writerow([cat, pct])
-    return perf_dir
+    return csv_path
 
 
 def _data_row_cells(md, kernel):
@@ -282,7 +100,7 @@ def _strip_banner(md):
 
 
 # ---------------------------------------------------------------------------
-# U1 — detector fires on a graph-collapsed fixture
+# detector fires on a graph-collapsed fixture
 # ---------------------------------------------------------------------------
 @pytest.mark.parametrize(
     "wrapper",
@@ -291,7 +109,7 @@ def _strip_banner(md):
         ("Torch-Compiled Region: 0/0->k (Synthetic Op)", None),
     ],
 )
-def test_u1_detector_fires_on_graph_collapsed(tmp_path, wrapper):
+def test_detector_fires_on_graph_collapsed(tmp_path, wrapper):
     graph_rows = [(name, 47.5, 47.5) for name in wrapper if name]
     # Pad the graph weight to 95 total and add a benign plain kernel for the 5%.
     rows = graph_rows + [("plain_kernel", 5.0, 5.0)]
@@ -301,32 +119,32 @@ def test_u1_detector_fires_on_graph_collapsed(tmp_path, wrapper):
         ("plain_kernel", 5.0, 5.0)
     ]
 
-    perf_dir = _make_perf_csv(tmp_path, rows)
-    verdict = check_graph_replay_coverage(perf_dir)
+    perf_csv = _make_perf_csv(tmp_path, rows)
+    verdict = check_graph_replay_coverage(perf_csv)
 
     assert verdict.graph_under_recorded is True
     assert verdict.graph_replay_fraction == pytest.approx(0.95)
 
 
 # ---------------------------------------------------------------------------
-# U2 — detector stays quiet on a healthy fixture
+# detector stays quiet on a healthy fixture
 # ---------------------------------------------------------------------------
-def test_u2_detector_quiet_on_healthy(tmp_path):
+def test_detector_quiet_on_healthy(tmp_path):
     rows = [
         ("aten::mm", 40.0, 40.0),
         ("aten::softmax", 30.0, 30.0),
         ("hipMemcpyAsync->copy_dtoh (Synthetic Op)", 15.0, 15.0),
         ("hipModuleLaunchKernel->some_kernel (Synthetic Op)", 15.0, 15.0),
     ]
-    perf_dir = _make_perf_csv(tmp_path, rows)
-    verdict = check_graph_replay_coverage(perf_dir)
+    perf_csv = _make_perf_csv(tmp_path, rows)
+    verdict = check_graph_replay_coverage(perf_csv)
 
     assert verdict.graph_under_recorded is False
     assert verdict.graph_replay_fraction == 0.0
 
 
 # ---------------------------------------------------------------------------
-# U3 — false-positive guard: benign launch/memcpy wrappers never count
+# false-positive guard: benign launch/memcpy wrappers never count
 # ---------------------------------------------------------------------------
 @pytest.mark.parametrize(
     "wrapper_name",
@@ -338,20 +156,20 @@ def test_u2_detector_quiet_on_healthy(tmp_path):
         "__amd_rocclr_copyBuffer->orphan (Synthetic Op)",
     ],
 )
-def test_u3_false_positive_guard(tmp_path, wrapper_name):
+def test_detector_ignores_plumbing_wrappers(tmp_path, wrapper_name):
     rows = [
         (wrapper_name, 40.0, 40.0),
         ("aten::mm", 60.0, 60.0),
     ]
-    perf_dir = _make_perf_csv(tmp_path, rows)
-    verdict = check_graph_replay_coverage(perf_dir)
+    perf_csv = _make_perf_csv(tmp_path, rows)
+    verdict = check_graph_replay_coverage(perf_csv)
 
     assert verdict.graph_under_recorded is False
     assert verdict.graph_replay_fraction == 0.0
 
 
 # ---------------------------------------------------------------------------
-# U4 — threshold boundary (strict `>` around 0.10)
+# threshold boundary (strict `>` around 0.10)
 # ---------------------------------------------------------------------------
 @pytest.mark.parametrize(
     "graph_weight, expected",
@@ -361,30 +179,30 @@ def test_u3_false_positive_guard(tmp_path, wrapper_name):
         (10.1, True),  # 0.101 > 0.10
     ],
 )
-def test_u4_threshold_boundary(tmp_path, graph_weight, expected):
+def test_detector_threshold_boundary(tmp_path, graph_weight, expected):
     assert GRAPH_REPLAY_FRACTION_MAX == 0.10
     rows = [
         ("hipGraphLaunch->k (Synthetic Op)", graph_weight, graph_weight),
         ("aten::mm", 100.0 - graph_weight, 100.0 - graph_weight),
     ]
-    perf_dir = _make_perf_csv(tmp_path, rows)
-    verdict = check_graph_replay_coverage(perf_dir)
+    perf_csv = _make_perf_csv(tmp_path, rows)
+    verdict = check_graph_replay_coverage(perf_csv)
 
     assert verdict.graph_under_recorded is expected
     assert verdict.graph_replay_fraction == pytest.approx(graph_weight / 100.0)
 
 
 # ---------------------------------------------------------------------------
-# U5 — wrapper-strip + exact-name grouping
+# wrapper-strip + exact-name grouping
 # ---------------------------------------------------------------------------
-def test_u5_wrapper_strip_and_exact_name_grouping(tmp_path):
+def test_writer_strips_wrapper_and_groups_by_name(tmp_path):
     rows = [
         ("hipGraphLaunch->foo (Synthetic Op)", 10.0, 10.0),
         ("hipGraphLaunch->foo (Synthetic Op)", 30.0, 30.0),
         ("hipGraphLaunch->bar (Synthetic Op)", 20.0, 20.0),
     ]
-    perf_dir = _make_perf_csv(tmp_path, rows)
-    md = render_fallback_report(perf_dir, 0.95)
+    perf_csv = _make_perf_csv(tmp_path, rows)
+    md = render_fallback_report(perf_csv, 0.95)
 
     # Bare names recovered from the WRAPPER->K (Synthetic Op) form.
     headings = dict((int(rank), name) for rank, name in _HEADING_RE.findall(md))
@@ -404,13 +222,13 @@ def test_u5_wrapper_strip_and_exact_name_grouping(tmp_path):
     assert lows.count(bar_low) == 1
 
 
-def test_u5_tile_variants_stay_separate_groups(tmp_path):
+def test_writer_keeps_tile_variants_separate(tmp_path):
     rows = [
         ("hipGraphLaunch->f4gemm_192x128 (Synthetic Op)", 30.0, 30.0),
         ("hipGraphLaunch->f4gemm_32x128 (Synthetic Op)", 10.0, 10.0),
     ]
-    perf_dir = _make_perf_csv(tmp_path, rows)
-    md = render_fallback_report(perf_dir, 0.95)
+    perf_csv = _make_perf_csv(tmp_path, rows)
+    md = render_fallback_report(perf_csv, 0.95)
 
     names = {name for _, name in _HEADING_RE.findall(md)}
     assert names == {"f4gemm_192x128", "f4gemm_32x128"}
@@ -426,7 +244,7 @@ def test_u5_tile_variants_stay_separate_groups(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# U5c — plumbing behind a graph-replay wrapper is dropped from the writer output.
+# plumbing behind a graph-replay wrapper is dropped from the writer output.
 # Guards the leak where the wrapper prefix is graph-replay but the bare kernel
 # behind it is runtime plumbing (e.g. `hipGraphLaunch->__amd_rocclr_copyBuffer`).
 # ---------------------------------------------------------------------------
@@ -434,14 +252,14 @@ def test_u5_tile_variants_stay_separate_groups(tmp_path):
     "plumbing_kernel",
     ["__amd_rocclr_copyBuffer", "__amd_rocclr_fillBufferAligned", "MemcpyDtoD"],
 )
-def test_u5c_plumbing_behind_graph_replay_wrapper_dropped(tmp_path, plumbing_kernel):
+def test_writer_drops_plumbing_behind_graph_wrapper(tmp_path, plumbing_kernel):
     rows = [
         ("hipGraphLaunch->real_kernel (Synthetic Op)", 90.0, 90.0),
         (f"hipGraphLaunch->{plumbing_kernel} (Synthetic Op)", 10.0, 10.0),
         (f"Torch-Compiled Region: 0/0->{plumbing_kernel} (Synthetic Op)", 5.0, 5.0),
     ]
-    perf_dir = _make_perf_csv(tmp_path, rows)
-    md = render_fallback_report(perf_dir, 0.95)
+    perf_csv = _make_perf_csv(tmp_path, rows)
+    md = render_fallback_report(perf_csv, 0.95)
 
     names = {name for _, name in _HEADING_RE.findall(md)}
     assert names == {"real_kernel"}
@@ -449,16 +267,16 @@ def test_u5c_plumbing_behind_graph_replay_wrapper_dropped(tmp_path, plumbing_ker
 
 
 # ---------------------------------------------------------------------------
-# U6 — impact arithmetic (match the exact emitted string)
+# impact arithmetic (match the exact emitted string)
 # ---------------------------------------------------------------------------
-def test_u6_impact_arithmetic(tmp_path):
+def test_writer_impact_arithmetic(tmp_path):
     # Two equal-weight rows with distinct names -> each is its own group at 50%.
     rows = [
         ("hipGraphLaunch->foo (Synthetic Op)", 50.0, 50.0),
         ("hipGraphLaunch->bar (Synthetic Op)", 50.0, 50.0),
     ]
-    perf_dir = _make_perf_csv(tmp_path, rows)
-    md = render_fallback_report(perf_dir, 0.95)
+    perf_csv = _make_perf_csv(tmp_path, rows)
+    md = render_fallback_report(perf_csv, 0.95)
 
     # 50 * 0.15/0.30/0.45 = 7.5 / 15.0 / 22.5 (round(...,2) prints 15.0, not 15).
     assert (
@@ -467,72 +285,74 @@ def test_u6_impact_arithmetic(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# U7 — parse contract (LOAD-BEARING) against vendored regexes
+# producer structural contract: heading order, marker-before-heading, the
+# canonical 9-column header, and one em-dash data row per P-item.
 # ---------------------------------------------------------------------------
-def test_u7_parse_contract(tmp_path):
-    # Two DISTINCT graph-replay kernels with distinct bare names and weights.
-    # Higher weight sorts first -> P1; the full downstream parse must yield one
-    # candidate per data row, i.e. TWO. This whole test drives the REAL parse
-    # path (_parse_candidates), not just a heading count, so it catches the
-    # class of contract bug where the md renders but parses to ZERO candidates.
+def test_writer_structure_contract(tmp_path):
+    # Two distinct graph-replay kernels; higher weight sorts first -> P1.
     rows = [
         ("hipGraphLaunch->foo (Synthetic Op)", 60.0, 60.0),
         ("hipGraphLaunch->bar (Synthetic Op)", 40.0, 40.0),
     ]
-    perf_dir = _make_perf_csv(tmp_path, rows)
-    md = render_fallback_report(perf_dir, 0.95)
+    perf_csv = _make_perf_csv(tmp_path, rows)
+    md = render_fallback_report(perf_csv, 0.95)
 
-    candidates = _parse_candidates(md)
+    # Exactly two P-item headings, ranked by weight (foo=60 -> P1, bar=40 -> P2).
+    headings = _HEADING_RE.findall(md)
+    assert len(headings) == 2
+    assert {int(rank): title for rank, title in headings} == {1: "foo", 2: "bar"}
 
-    # (1) LOAD-BEARING: the full parse yields exactly two candidates. This is
-    #     the assertion that would have caught both prior contract bugs, each of
-    #     which rendered headings but collapsed to zero downstream candidates.
-    assert len(candidates) == 2
-
-    # (2) rank -> kernel mapping (P1 = highest weight) and category propagation.
-    by_rank = {c["rank"]: c for c in candidates}
-    assert by_rank[1]["kernel_name"] == "foo"
-    assert by_rank[2]["kernel_name"] == "bar"
-    for cand in candidates:
-        assert cand["category"] == "unknown"
-
-    # (3) name/time/%E2E populated in the row; Args cell is the em dash.
-    assert by_rank[1]["operation"] == "foo"
-    assert by_rank[1]["args"] == _EM_DASH  # Args intentionally unrecoverable
-    assert by_rank[1]["time_ms"] == "0.060"  # 60 us -> 0.060 ms
-    assert by_rank[1]["percent_e2e"] == "60.00"
-
-    # (4) NEGATIVE — ### regression guard: downgrading the headings to three
-    #     hashes makes every block vanish under _HEADING_RE -> zero candidates.
-    downgraded = md.replace("#### P", "### P")
-    assert len(_parse_candidates(downgraded)) == 0
-
-    # (5) NEGATIVE — **Data:** regression guard (catches C1): with the Data
-    #     marker deleted, _extract_data_table returns [] -> zero candidates.
-    no_data = "\n".join(line for line in md.splitlines() if line.strip() != "**Data:**")
-    assert len(_parse_candidates(no_data)) == 0
-
-    # (6) NEGATIVE — marker/heading ORDER guard (catches C2): moving each
-    #     heading BEFORE its reasoning-candidate marker breaks the block split
-    #     (the heading no longer falls in the marker's body slice), so the
-    #     candidate count is wrong (not two). The correct order is load-bearing.
-    reordered = re.sub(
-        r"(<!-- reasoning-candidate tier=compute rank=\d+ -->)\n(#### P\d+: [^\n]+)",
-        r"\2\n\1",
-        md,
-    )
-    assert len(_parse_candidates(reordered)) != 2
-    # And in the REAL md every marker precedes its matching heading.
+    # Each reasoning-candidate marker precedes its own #### PN heading.
     for rank in (1, 2):
         marker_idx = md.index(f"reasoning-candidate tier=compute rank={rank}")
         heading_idx = md.index(f"#### P{rank}:")
         assert marker_idx < heading_idx
 
+    # Each P-item carries a **Data:** line and a table header holding the 9
+    # canonical column tokens in order (Kernel Name may interleave).
+    assert md.count("**Data:**") == 2
+    for header_line in [
+        line for line in md.splitlines() if line.strip().startswith("| Operation |")
+    ]:
+        header_tokens = [c.strip().lower() for c in header_line.split("|")[1:-1]]
+        canonical = [t for t in header_tokens if t in _DATA_TABLE_HEADER_TOKENS]
+        assert canonical == list(_DATA_TABLE_HEADER_TOKENS)
+    assert (
+        len(
+            [
+                line
+                for line in md.splitlines()
+                if line.strip().startswith("| Operation |")
+            ]
+        )
+        == 2
+    )
+
+    # One data row per P-item: Operation cell is the em dash, Kernel Name is the
+    # raw symbol, with the expected time (µs -> ms) and %E2E.
+    for kernel, time_ms, pct in (("foo", "0.060", "60.00"), ("bar", "0.040", "40.00")):
+        cells = _data_row_cells(md, _EM_DASH)  # each row starts with the em dash
+        assert kernel in md
+        row = next(
+            [c.strip() for c in line.split("|")[1:-1]]
+            for line in md.splitlines()
+            if line.strip().startswith("| —") and f"| {kernel} |" in line
+        )
+        assert row[0] == _EM_DASH  # Operation cell
+        assert row[3] == kernel  # Kernel Name cell == raw symbol
+        assert row[4] == time_ms
+        assert row[5] == pct
+    assert cells is not None  # a data row exists
+
+    # NEGATIVE — downgrading #### P to ### P makes _HEADING_RE find no headings.
+    downgraded = md.replace("#### P", "### P")
+    assert len(_HEADING_RE.findall(downgraded)) == 0
+
 
 # ---------------------------------------------------------------------------
-# U8 — separate-row vs grouped invariant; plumbing dropped
+# separate-row vs grouped invariant; plumbing dropped
 # ---------------------------------------------------------------------------
-def test_u8_separate_rows_grouped_impact(tmp_path):
+def test_writer_separate_rows_grouped_impact(tmp_path):
     rows = [
         ("hipGraphLaunch->foo (Synthetic Op)", 30.0, 30.0),
         ("hipGraphLaunch->foo (Synthetic Op)", 10.0, 10.0),
@@ -540,8 +360,8 @@ def test_u8_separate_rows_grouped_impact(tmp_path):
         # Benign plumbing must be dropped from the candidate table entirely.
         ("hipMemcpyAsync->copy (Synthetic Op)", 5.0, 5.0),
     ]
-    perf_dir = _make_perf_csv(tmp_path, rows)
-    md = render_fallback_report(perf_dir, 0.95)
+    perf_csv = _make_perf_csv(tmp_path, rows)
+    md = render_fallback_report(perf_csv, 0.95)
 
     headings = _HEADING_RE.findall(md)
     # One card per SURVIVING CSV kernel row (3), plumbing row dropped.
@@ -561,16 +381,16 @@ def test_u8_separate_rows_grouped_impact(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# U9 — degraded banner present and inert to the parser
+# degraded banner present and structurally inert
 # ---------------------------------------------------------------------------
-def test_u9_degraded_banner(tmp_path):
+def test_writer_degraded_banner(tmp_path):
     rows = [
         ("hipGraphLaunch->foo (Synthetic Op)", 95.0, 95.0),
         ("aten::mm", 5.0, 5.0),
     ]
-    perf_dir = _make_perf_csv(tmp_path, rows)
+    perf_csv = _make_perf_csv(tmp_path, rows)
     frac = 0.95
-    md = render_fallback_report(perf_dir, frac)
+    md = render_fallback_report(perf_csv, frac)
 
     # Visible call-out with the fraction rendered as a percent.
     assert "> **⚠ Degraded (deterministic fallback) report.**" in md
@@ -656,8 +476,8 @@ def test_group_independence_raw_key_not_display(tmp_path):
         (f"hipGraphLaunch->{name_a} (Synthetic Op)", 60.0, 60.0),
         (f"hipGraphLaunch->{name_b} (Synthetic Op)", 40.0, 40.0),
     ]
-    perf_dir = _make_perf_csv(tmp_path, rows)
-    md = render_fallback_report(perf_dir, 0.95)
+    perf_csv = _make_perf_csv(tmp_path, rows)
+    md = render_fallback_report(perf_csv, 0.95)
 
     # Two P-items render even though their titles are byte-identical.
     headings = _HEADING_RE.findall(md)
@@ -681,8 +501,8 @@ def test_group_independence_raw_key_not_display(tmp_path):
 def test_n3_operation_em_dash_kernel_name_raw(tmp_path):
     raw = "void aiter::" + "x" * 100  # > cap -> display truncates, raw preserved
     rows = [(f"hipGraphLaunch->{raw} (Synthetic Op)", 100.0, 100.0)]
-    perf_dir = _make_perf_csv(tmp_path, rows)
-    md = render_fallback_report(perf_dir, 0.95)
+    perf_csv = _make_perf_csv(tmp_path, rows)
+    md = render_fallback_report(perf_csv, 0.95)
 
     display = _normalize_kernel_name(raw)
     assert display != raw
@@ -697,18 +517,17 @@ def test_n3_operation_em_dash_kernel_name_raw(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Em-dash-Operation contract — every row emits an em-dash Operation cell, and the
-# relaxed reader recovers a candidate per row via the device kernel symbol.
+# Em-dash Operation contract — every rendered data row's Operation cell is the
+# em dash (the op is never captured on a graph-collapsed trace).
 # ---------------------------------------------------------------------------
-def test_option_b_operation_is_em_dash_reader_substitutes_kernel_name(tmp_path):
+def test_data_row_operation_is_em_dash(tmp_path):
     rows = [
         ("hipGraphLaunch->foo (Synthetic Op)", 60.0, 60.0),
         ("hipGraphLaunch->bar (Synthetic Op)", 40.0, 40.0),
     ]
-    perf_dir = _make_perf_csv(tmp_path, rows)
-    md = render_fallback_report(perf_dir, 0.95)
+    perf_csv = _make_perf_csv(tmp_path, rows)
+    md = render_fallback_report(perf_csv, 0.95)
 
-    # Every rendered data row's Operation cell is the em dash (op never captured).
     data_rows = [
         line
         for line in md.splitlines()
@@ -716,19 +535,11 @@ def test_option_b_operation_is_em_dash_reader_substitutes_kernel_name(tmp_path):
     ]
     assert data_rows
     for line in data_rows:
-        first_cell = line.split("|")[1].strip()
-        assert first_cell == _EM_DASH
-
-    # The relaxed reader still yields one candidate per row, keyed on the symbol.
-    candidates = _parse_candidates(md)
-    assert len(candidates) == 2
-    assert {c["operation"] for c in candidates} == {"foo", "bar"}
-    for c in candidates:
-        assert c["operation"] == c["kernel_name"]
+        assert line.split("|")[1].strip() == _EM_DASH
 
 
 # ---------------------------------------------------------------------------
-# U10 — N4 %E2E floor + top-N cap + drop-logging.
+# N4 %E2E floor + top-N cap + drop-logging.
 # ---------------------------------------------------------------------------
 @pytest.mark.parametrize(
     "percent, expected_kept",
@@ -738,11 +549,11 @@ def test_option_b_operation_is_em_dash_reader_substitutes_kernel_name(tmp_path):
         (0.51, 1),  # above floor -> kept
     ],
 )
-def test_u10_floor_boundary(tmp_path, percent, expected_kept):
+def test_writer_pitem_floor_boundary(tmp_path, percent, expected_kept):
     assert MIN_PITEM_PERCENT_E2E == 0.5
     rows = [("hipGraphLaunch->k (Synthetic Op)", 100.0, percent)]
-    perf_dir = _make_perf_csv(tmp_path, rows)
-    md = render_fallback_report(perf_dir, 0.95)
+    perf_csv = _make_perf_csv(tmp_path, rows)
+    md = render_fallback_report(perf_csv, 0.95)
 
     assert len(_HEADING_RE.findall(md)) == expected_kept
     dropped = 1 - expected_kept
@@ -752,7 +563,7 @@ def test_u10_floor_boundary(tmp_path, percent, expected_kept):
         assert "Dropped " not in md
 
 
-def test_u10_top_n_cap_and_drop_logging(tmp_path):
+def test_writer_pitem_cap_and_drop_logging(tmp_path):
     # MAX_PITEM_COUNT + 5 distinct kernels, all above the floor, descending weight.
     n = MAX_PITEM_COUNT + 5
     weights = [float(100 - i) for i in range(n)]
@@ -760,8 +571,8 @@ def test_u10_top_n_cap_and_drop_logging(tmp_path):
         (f"hipGraphLaunch->k{i:02d} (Synthetic Op)", w, 4.0)
         for i, w in enumerate(weights)
     ]
-    perf_dir = _make_perf_csv(tmp_path, rows)
-    md = render_fallback_report(perf_dir, 0.95)
+    perf_csv = _make_perf_csv(tmp_path, rows)
+    md = render_fallback_report(perf_csv, 0.95)
 
     # Exactly MAX_PITEM_COUNT render; the rest dropped, logged in the banner.
     assert len(_HEADING_RE.findall(md)) == MAX_PITEM_COUNT
@@ -782,72 +593,47 @@ def test_u10_top_n_cap_and_drop_logging(tmp_path):
     assert expected_p1_low != round(top_n_pct * 0.15, 2)
 
 
-def test_u10_no_drop_note_when_nothing_dropped(tmp_path):
+def test_writer_no_drop_note_when_nothing_dropped(tmp_path):
     rows = [("hipGraphLaunch->k (Synthetic Op)", 100.0, 60.0)]
-    perf_dir = _make_perf_csv(tmp_path, rows)
-    md = render_fallback_report(perf_dir, 0.95)
+    perf_csv = _make_perf_csv(tmp_path, rows)
+    md = render_fallback_report(perf_csv, 0.95)
 
     assert "Dropped " not in md  # drop-note sentence suppressed at zero
 
 
-# ---------------------------------------------------------------------------
-# U9 extension — the banner drop-note stays inert to the parser.
-# ---------------------------------------------------------------------------
-def test_u9_drop_note_inert(tmp_path):
+def test_writer_drop_note_parser_inert(tmp_path):
     rows = [
         ("hipGraphLaunch->foo (Synthetic Op)", 60.0, 60.0),
         ("hipGraphLaunch->bar (Synthetic Op)", 40.0, 40.0),
     ]
-    perf_dir = _make_perf_csv(tmp_path, rows)
-    md = render_fallback_report(perf_dir, 0.95)
+    perf_csv = _make_perf_csv(tmp_path, rows)
+    md = render_fallback_report(perf_csv, 0.95)
 
-    # Stripping the banner does not change the parsed candidate count.
-    assert len(_parse_candidates(md)) == 2
-    assert len(_parse_candidates(_strip_banner(md))) == 2
-
-
-# ---------------------------------------------------------------------------
-# U7 re-run — the Operation cell is the em dash, but the relaxed
-# reader substitutes the device kernel symbol, so candidates still parse with a
-# non-empty operation identity and `####` headings.
-# ---------------------------------------------------------------------------
-def test_u7_rerun_after_normalization(tmp_path):
-    long_raw = "void aiter::" + "y" * 90
-    rows = [
-        (f"hipGraphLaunch->{long_raw} (Synthetic Op)", 60.0, 60.0),
-        ("hipGraphLaunch->_fwd_kernel (Synthetic Op)", 40.0, 40.0),
-    ]
-    perf_dir = _make_perf_csv(tmp_path, rows)
-    md = render_fallback_report(perf_dir, 0.95)
-
-    candidates = _parse_candidates(md)
-    assert len(candidates) == 2
-    for cand in candidates:
-        # Operation resolves to the device kernel symbol via reader substitution.
-        assert cand["operation"]
-        assert cand["operation"] not in ("", _EM_DASH)
-        assert cand["operation"] == cand["kernel_name"]
-    for line in md.splitlines():
-        if "P1:" in line or "P2:" in line:
-            assert line.startswith("####")
+    # Stripping the banner leaves heading and marker counts unchanged.
+    stripped = _strip_banner(md)
+    assert len(_HEADING_RE.findall(md)) == len(_HEADING_RE.findall(stripped))
+    assert len(_PITEM_MARKER_RE.findall(md)) == len(_PITEM_MARKER_RE.findall(stripped))
+    assert len(_REASONING_MARKER_RE.findall(md)) == len(
+        _REASONING_MARKER_RE.findall(stripped)
+    )
 
 
 # ---------------------------------------------------------------------------
-# U11 — field-size crash fix: a field larger than csv's 131072 default must not
+# field-size crash fix: a field larger than csv's 131072 default must not
 # raise in the detector or the loader/writer.
 # ---------------------------------------------------------------------------
-def test_u11_giant_field_does_not_crash(tmp_path):
+def test_detector_handles_giant_csv_field(tmp_path):
     giant = "hipGraphLaunch->" + ("k" * 200000) + " (Synthetic Op)"
     rows = [
         (giant, 90.0, 90.0),
         ("hipGraphLaunch->small (Synthetic Op)", 10.0, 10.0),
     ]
-    perf_dir = _make_perf_csv(tmp_path, rows)
+    perf_csv = _make_perf_csv(tmp_path, rows)
 
-    verdict = check_graph_replay_coverage(perf_dir)  # must not raise
+    verdict = check_graph_replay_coverage(perf_csv)  # must not raise
     assert verdict.graph_under_recorded is True
 
     md = render_fallback_report(
-        perf_dir, verdict.graph_replay_fraction
+        perf_csv, verdict.graph_replay_fraction
     )  # must not raise
     assert "#### P1:" in md

--- a/tests/test_analysis_agent_deterministic.py
+++ b/tests/test_analysis_agent_deterministic.py
@@ -27,6 +27,7 @@ from TraceLens.Agent.Analysis.utils.deterministic_fallback import (
     _PERCENT_COLUMN,
     _WEIGHT_COLUMN,
     check_graph_replay_coverage,
+    main,
     render_fallback_report,
 )
 
@@ -618,10 +619,6 @@ def test_writer_drop_note_parser_inert(tmp_path):
     )
 
 
-# ---------------------------------------------------------------------------
-# field-size crash fix: a field larger than csv's 131072 default must not
-# raise in the detector or the loader/writer.
-# ---------------------------------------------------------------------------
 def test_detector_handles_giant_csv_field(tmp_path):
     giant = "hipGraphLaunch->" + ("k" * 200000) + " (Synthetic Op)"
     rows = [
@@ -636,4 +633,56 @@ def test_detector_handles_giant_csv_field(tmp_path):
     md = render_fallback_report(
         perf_csv, verdict.graph_replay_fraction
     )  # must not raise
+    assert "#### P1:" in md
+
+
+def test_main_writes_analysis_md(tmp_path, monkeypatch):
+    rows = [
+        ("hipGraphLaunch->k (Synthetic Op)", 90.0, 90.0),
+        ("aten::mm", 10.0, 10.0),
+    ]
+    perf_csv = _make_perf_csv(tmp_path, rows)
+    out_dir = tmp_path / "out"
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "deterministic_fallback",
+            "--unified-perf-csv",
+            str(perf_csv),
+            "--output-dir",
+            str(out_dir),
+            "--graph-replay-fraction",
+            "0.9",
+        ],
+    )
+
+    main()
+
+    md = (out_dir / "analysis.md").read_text(encoding="utf-8")
+    assert "#### P1:" in md
+
+
+def test_main_derives_fraction_when_omitted(tmp_path, monkeypatch):
+    rows = [
+        ("hipGraphLaunch->k (Synthetic Op)", 90.0, 90.0),
+        ("aten::mm", 10.0, 10.0),
+    ]
+    perf_csv = _make_perf_csv(tmp_path, rows)
+    out_dir = tmp_path / "out"
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "deterministic_fallback",
+            "--unified-perf-csv",
+            str(perf_csv),
+            "--output-dir",
+            str(out_dir),
+        ],
+    )
+
+    main()
+
+    # 90% graph-replay fraction is recovered from the gate and rendered in the banner.
+    md = (out_dir / "analysis.md").read_text(encoding="utf-8")
+    assert "90%" in md
     assert "#### P1:" in md

--- a/tests/test_analysis_agent_deterministic.py
+++ b/tests/test_analysis_agent_deterministic.py
@@ -20,12 +20,10 @@ import pytest
 
 from TraceLens.Agent.Analysis.utils.deterministic_fallback import (
     GRAPH_REPLAY_FRACTION_MAX,
-    MAX_KERNEL_NAME_LEN,
     MAX_PITEM_COUNT,
     MIN_PITEM_PERCENT_E2E,
+    _KERNEL_NAME_TRUNC_LEN,
     _normalize_kernel_name,
-    _PERCENT_COLUMN,
-    _WEIGHT_COLUMN,
     check_graph_replay_coverage,
     main,
     render_fallback_report,
@@ -77,7 +75,7 @@ def _make_perf_csv(tmp_path, rows):
     csv_path = tmp_path / "unified_perf_summary.csv"
     with open(csv_path, "w", newline="", encoding="utf-8") as fh:
         writer = csv.writer(fh)
-        writer.writerow(["name", _WEIGHT_COLUMN, _PERCENT_COLUMN])
+        writer.writerow(["name", "Kernel Time (µs)_sum", "Percentage (%)"])
         for row in rows:
             name, weight = row[0], row[1]
             percent = row[2] if len(row) > 2 else 0.0
@@ -416,7 +414,7 @@ def test_normalizer_bare_triton_identity():
 def test_normalizer_clean_aiter_identity():
     # A real ~50-char aiter config passes through untouched (< the 75 cap).
     name = "aiter::f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128"
-    assert len(name) < MAX_KERNEL_NAME_LEN
+    assert len(name) < _KERNEL_NAME_TRUNC_LEN
     assert _normalize_kernel_name(name) == name
 
 
@@ -426,30 +424,30 @@ def test_normalizer_void_template_truncated_void_kept():
         "void at::native::elementwise_kernel<128, 2, "
         "at::native::gpu_kernel_impl<at::native::BinaryFunctor>>(int, char*)"
     )
-    assert len(raw) > MAX_KERNEL_NAME_LEN
+    assert len(raw) > _KERNEL_NAME_TRUNC_LEN
     out = _normalize_kernel_name(raw)
     assert out.startswith("void ")
-    assert out == raw[:MAX_KERNEL_NAME_LEN] + "..."
-    assert len(out) == MAX_KERNEL_NAME_LEN + 3
+    assert out == raw[:_KERNEL_NAME_TRUNC_LEN] + "..."
+    assert len(out) == _KERNEL_NAME_TRUNC_LEN + 3
 
 
 def test_normalizer_tensile_truncated():
     raw = "Cijk_Ailk_Bljk_HHS_BH_Bias_AS_MT128x160x16_MI16x16x16x1_SN_WG32_8_1_ABCD"
     raw = raw + "_extra_tokens_pushing_well_past_the_cap"
-    assert len(raw) > MAX_KERNEL_NAME_LEN
+    assert len(raw) > _KERNEL_NAME_TRUNC_LEN
     out = _normalize_kernel_name(raw)
-    assert out == raw[:MAX_KERNEL_NAME_LEN] + "..."
+    assert out == raw[:_KERNEL_NAME_TRUNC_LEN] + "..."
 
 
 def test_normalizer_mangled_zn_truncated_not_demangled():
     # Locks in the no-demangle decision: the symbol stays mangled, just shorter.
     raw = "_ZN5aiter24add_rmsnorm_quant_kernelIN3std10bfloat16_tES2_Li256ELb1EEEvPT_"
     raw = raw + "PKS1_iiffb"
-    assert len(raw) > MAX_KERNEL_NAME_LEN
+    assert len(raw) > _KERNEL_NAME_TRUNC_LEN
     out = _normalize_kernel_name(raw)
     assert out.startswith("_ZN")
     assert out.endswith("...")
-    assert out == raw[:MAX_KERNEL_NAME_LEN] + "..."
+    assert out == raw[:_KERNEL_NAME_TRUNC_LEN] + "..."
 
 
 def test_normalizer_never_returns_empty():
@@ -459,8 +457,8 @@ def test_normalizer_never_returns_empty():
 
 
 def test_normalizer_length_boundary():
-    at_cap = "a" * MAX_KERNEL_NAME_LEN
-    over_cap = "a" * (MAX_KERNEL_NAME_LEN + 1)
+    at_cap = "a" * _KERNEL_NAME_TRUNC_LEN
+    over_cap = "a" * (_KERNEL_NAME_TRUNC_LEN + 1)
     assert _normalize_kernel_name(at_cap) == at_cap  # len 75 -> identity
     assert _normalize_kernel_name(over_cap) == at_cap + "..."  # len 76 -> truncates
 


### PR DESCRIPTION
<!--
Copyright (c) 2025 - 2026 Advanced Micro Devices, Inc. All rights reserved.

See LICENSE for license information.
-->

# Deterministic (no-LLM) fallback for graph-collapsed traces

Some inference traces are **graph-under-recorded**: a GPU graph replay or a
compiled region collapses the whole workload behind a single launch, so the
profiler records device kernels but not the per-op decomposition (Python / aten
op, shapes, launcher path) the analysis pipeline needs. On these traces per-op
decomposition fails and the LLM analysis path cannot run.

This change adds a deterministic fallback that still emits a parser-compatible
`analysis.md`. It recovers the only three things a graph-collapsed trace carries
(**kernel name, time, and %E2E**) and marks every other field as unrecoverable
instead of guessing at it.

## Architecture

```
                    Step 1: perf report ──> perf_report_csvs/
                                                   │
                                                   ▼
                    Step 2: check_graph_replay_coverage()  ── graph_replay_fraction
                                                   │
                        ┌──────────────────────────┴──────────────────────────┐
              frac ≤ MAX │ (healthy)                          frac > MAX │ (graph-collapsed)
                         ▼                                                ▼
              Steps 3-6: prepare category data          render_fallback_report()
              Steps 7-8: analysis sub-agents                        │
              Step 12: analysis.md (full)          ┌────────────────┴──────────────┐
                         │                          │ _load_surviving_rows          │
                         │                          │  (drop plumbing wrappers)     │
                         │                          │ rank device kernels by %E2E   │
                         │                          │ apply %E2E floor + count cap  │
                         │                          │ unrecoverable cells = "—"     │
                         │                          │ Kernel Name  = raw symbol     │
                         │                          │ P-item heading = normalized   │
                         │                          └────────────────┬──────────────┘
                         ▼                                           ▼
                 analysis.md (full)                       analysis.md (degraded)
                         └────────────────────┬──────────────────────┘
                                              ▼
                        same contract: #### P{rank}: / reasoning-candidate /
                        impact-begin kind=p_item / 9-column **Data:** table
                                              │
                                              ▼
                               downstream analysis.md consumer
```

The fallback branch is a drop-in: it emits the **same** `analysis.md` marker and
table contract as the full analysis path, so a downstream consumer that parses
`analysis.md` needs no structural change.

## Design

- **Trace-quality gate (Step 2).** After perf-report generation,
  `check_graph_replay_coverage()` reads the already-written `perf_report_csvs/`,
  computes the fraction of device time hidden behind graph-replay / compiled-region
  launches, and trips when it exceeds `GRAPH_REPLAY_FRACTION_MAX`. Benign
  eager-launch and memcpy plumbing wrappers (present in healthy traces too) are
  excluded, so the signal isolates the pathology.
- **Deterministic report writer.** On a bad verdict, `render_fallback_report()`
  builds P-items from the surviving device-kernel rows, ranks them by %E2E, and
  writes the contract the pipeline already emits: `#### P{rank}:` headings, one
  `reasoning-candidate` marker and one `impact-begin kind=p_item` marker per P-item,
  and the 9-column `**Data:**` table. No LLM, no GPU, fully deterministic.
- **Honest unrecoverable cells.** Fields that a graph-collapsed trace never captured
  (Operation, Args, Kernel Path, Count, FLOPS/Byte, Efficiency, Bound) render a
  literal `—` instead of a fabricated or duplicated value. The raw device symbol is
  preserved verbatim in the `Kernel Name` cell so a downstream consumer can key on it,
  and the P-item heading shows a display-shortened form of that symbol.
- **P-item count control.** A `%E2E` floor (`MIN_PITEM_PERCENT_E2E`) plus a defensive
  count cap (`MAX_PITEM_COUNT`) collapse noisy traces to the significant few. The
  percentage denominator is built over **all** surviving rows before filtering, so
  dropping the tail never inflates the survivors. Drops are reported in the banner
  (never silent) when non-zero.
- **Display-only name normalization.** `_normalize_kernel_name()` shortens the P-item
  heading to a fixed length with a truncation marker. It never demangles and never
  strips qualifiers, so the symbol in `Kernel Name` and the impact-grouping key both
  stay raw. Two long GEMM variants that differ only past the truncation boundary
  collapse to the same heading but remain distinct P-items in the arithmetic.
- **Degraded banner.** A visible banner states the graph-replay fraction, what is
  recoverable (kernel, time, %E2E), and what was never captured (shapes, launcher
  path, quant operands, category, efficiency), so the report can never be mistaken for
  a full analysis.
- **CSV field-size hardening.** The gate reads every trace's CSVs, and traces with
  very large cells exceeded `csv`'s default field limit and aborted the gate before it
  could pass. A module-level `csv.field_size_limit(...)` is now raised once with a
  platform-safe clamp (start high, halve on `OverflowError`).
- **Pipeline step renumber.** Inserting the gate as Step 2 shifted the rest of the
  pipeline by one, so the orchestrator prep, the validation utility, and the
  orchestrator skill / reference / template prose were renumbered in lockstep. This is
  prose and print-label only, with no logic change.

## Validation

- **Unit tests (CI):** `tests/test_analysis_agent_deterministic.py` covers the gate
  (fraction math, plumbing-wrapper exclusion, field-size case), the writer contract
  (markers 1:1 with P-items, unrecoverable cells em-dashed, raw kernel name preserved,
  normalized heading), the normalizer matrix (identity / truncate / mangled-stays-raw
  / length boundary / never-empty), the floor/cap boundaries and drop reporting, and
  the consumer-side substitution of the kernel name when Operation is an em dash. No
  GPU, no LLM.
- **End-to-end:** exercised through the full orchestrator on several graph-collapsed
  inference traces spanning distinct workload shapes (dense and MoE decode, diffusion
  image generation, speculative decode). Each tripped the Step 2 gate and routed to
  the fallback, and every report preserved the marker contract
  (`reasoning-candidate` = `impact-begin` = data-tables = P-item count) with the floor
  and cap applied.
- **Coverage vs the full analysis path:** on traces where a non-fallback baseline
  exists, the fallback recovers the complete compute-heavy tail (every dominant GEMM,
  attention, quantization, sort, and norm kernel), and surfaces additional
  kernel-granular items the category-grouped path folds together. The only kernels it
  cannot recover are ones that live inside a fused region and are visible only when
  capture-enabled decomposition splits them apart. That is a genuine limit of a
  graph-collapsed trace, and the `—` cells reflect it honestly.
- **Healthy no-op:** on healthy traces the gate returns false and the writer never
  fires.

## Downstream / contract impact

The change is additive and parser-compatible. The 9-column table header, the
`#### P{rank}:` / `reasoning-candidate` / `impact-begin` markers, and their attribute
names are all unchanged. The one behavioral note for a downstream consumer is the `—`
`Operation` cell: a consumer that today drops rows with an empty Operation should
substitute the `Kernel Name` symbol for those rows (a backward-compatible reader
relaxation) so that fallback reports parse to the intended candidates.

## Test plan

- [x] `pytest tests/test_analysis_agent_deterministic.py`
- [x] `black --check` on all changed Python (clean)
- [x] Copyright headers valid on all changed files
- [x] End-to-end fallback on multiple graph-collapsed inference traces
- [x] Coverage compared against the full analysis path
- [x] Field-size fix verified on a large-cell trace
- [x] Healthy no-op returns false at the gate
