### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,16 +51,6 @@ To try out TraceLens without collecting your own trace, use the [demo traces](te
 
 ### 3. Analyze your Workload
 
-## Supported Profile Formats
-
-| Format | Tool | Documentation |
-|--------|------|---------------|
-| **PyTorch** | `torch.profiler` | [docs/generate_perf_report.md](docs/generate_perf_report.md) |
-| **JAX** | XPlane protobuf | [docs/jax_analyses.md](docs/jax_analyses.md) |
-| **rocprofv3 JSON** | AMD ROCm rocprofiler-sdk | [docs/generate_perf_report_rocprof.md](docs/generate_perf_report_rocprof.md) |
-| **rocprofv3 pftrace** | Perfetto-style | [docs/generate_perf_report_rocprof_pftrace.md](docs/generate_perf_report_rocprof_pftrace.md) |
-| **Genesis / Taichi** | rocprofv3 + pftrace | [docs/generate_perf_report_genesis.md](docs/generate_perf_report_genesis.md) |
-
 Generate a performance analysis report from an eager execution PyTorch trace with a single command:
 
 ```bash
@@ -117,6 +107,7 @@ Analyze a workload autonomously using an agentic system that automates performan
 | **JAX**               | XPlane protobuf          | [docs/how-to/generate-perf-report-jax.md](docs/how-to/generate-perf-report-jax.md)                             |
 | **rocprofv3 JSON**    | AMD ROCm rocprofiler-sdk | [docs/how-to/generate-perf-report-rocprof.md](docs/how-to/generate-perf-report-rocprof.md)                     |
 | **rocprofv3 pftrace** | Perfetto-style           | [docs/how-to/generate-perf-report-rocprof.md](docs/how-to/generate-perf-report-rocprof.md)                     |
+| **Genesis / Taichi**  | rocprofv3 + pftrace      | [docs/how-to/generate-perf-report-genesis.md](docs/how-to/generate-perf-report-genesis.md)                     |
 
 Each format's linked doc covers its full CLI reference. For PyTorch report comparison and multi-rank collective analysis, see the corresponding docs in the [Documentation](#documentation) table.
 
@@ -127,12 +118,12 @@ Each format's linked doc covers its full CLI reference. For PyTorch report compa
 | Module                       | Doc                                                                                                                              |
 | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
 | Trace2Tree                   | [docs/conceptual/trace2tree.md](docs/conceptual/trace2tree.md)                                                                   |
-| TreePerf                     | [docs/how-to/tree-perf-analysis.md](docs/how-to/tree-perf-analysis.md)                                                           |
+| TreePerf                     | [docs/how-to/sdk-analysis.md](docs/how-to/sdk-analysis.md)                                                                       |
 | NCCL Analyser                | [docs/how-to/nccl-analysis.md](docs/how-to/nccl-analysis.md)                                                                     |
 | TraceDiff                    | [docs/how-to/compare-traces.md](docs/how-to/compare-traces.md)                                                                   |
 | Event Replay                 | [docs/how-to/event-replay.md](docs/how-to/event-replay.md)                                                                       |
 | TraceFusion                  | [docs/how-to/trace-fusion.md](docs/how-to/trace-fusion.md)                                                                       |
-| GPU Event Analyser           | [docs/how-to/gpu-event-analysis.md](docs/how-to/gpu-event-analysis.md)                                                           |
+| GPU Event Analyser           | [docs/how-to/sdk-analysis.md](docs/how-to/sdk-analysis.md)                                                                       |
 | JAX Analyses                 | [docs/how-to/generate-perf-report-jax.md](docs/how-to/generate-perf-report-jax.md)                                               |
 | pftrace Reports              | [docs/how-to/generate-perf-report-rocprof.md](docs/how-to/generate-perf-report-rocprof.md)                                       |
 | Compare PyTorch Reports      | [docs/how-to/compare-perf-reports.md](docs/how-to/compare-perf-reports.md)                                                       |


### PR DESCRIPTION
## Summary

The root `README.md` had several documentation links pointing at pages that
either no longer exist or describe something other than what the link text
claims. All fixes are contained in `README.md`; the other ten module READMEs
across the repo were audited and are clean.

## What was wrong

1. **Stale duplicate "Supported Profile Formats" table.** The README carried
   two `## Supported Profile Formats` sections. The first used pre-reorg flat
   paths (`docs/generate_perf_report.md`, `docs/jax_analyses.md`,
   `docs/generate_perf_report_rocprof.md`,
   `docs/generate_perf_report_rocprof_pftrace.md`,
   `docs/generate_perf_report_genesis.md`) — none of which exist after the docs
   were reorganized under `docs/how-to/`. The `#supported-profile-formats`
   in-page anchors landed on this broken copy. The second table (further down)
   was already correct.

2. **Documentation table rows pointing at never-created docs.** The TreePerf
   row pointed at `docs/how-to/tree-perf-analysis.md` and the GPU Event Analyser
   row at `docs/how-to/gpu-event-analysis.md`; neither file exists. Both
   features are actually documented in `docs/how-to/sdk-analysis.md` (the
   `TreePerfAnalyzer` / `GPUEventAnalyser` SDK reference).

## Changes

- Removed the stale duplicate "Supported Profile Formats" table so there is one
  authoritative section and a clean anchor target.
- Preserved that table's unique **Genesis / Taichi** row by porting it into the
  canonical table, repointed to `docs/how-to/generate-perf-report-genesis.md`.
- Repointed the **TreePerf** and **GPU Event Analyser** rows in the
  Documentation table to `docs/how-to/sdk-analysis.md`.

Net effect: every relative link in the README now both resolves and points at a
doc whose subject matches the link text.
