### PR TITLE
Adding v2 runner patches

### DIFF
--- a/examples/custom_workflows/inference_analysis/build_docker_vllm.sh
+++ b/examples/custom_workflows/inference_analysis/build_docker_vllm.sh
@@ -10,13 +10,19 @@ set -e
 usage() {
     echo "Usage: $0 <vllm-version> <path-to-TraceLens> [--base-image <image>] [docker build args...]"
     echo ""
-    echo "  vllm-version    One of: v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25 (shorthand for v0.14.0 ... v0.25.0)"
+    echo "  vllm-version    One of: v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28 (shorthand for v0.14.0 ... v0.28.0)"
     echo "  --base-image    Override the default base Docker image for the selected vllm version"
     echo ""
-    echo "  Each version applies the matching vllm_patches/config_vllm_*.patch, which adds the"
-    echo "  profiler_config.capture_torch_profiler and profiler_config.detailed_trace_annotation"
-    echo "  options. vLLM v0.26.0 and later ship both options upstream, so they need no image"
-    echo "  from this script - run a stock upstream image and analyse the traces on the host."
+    echo "  Each version applies the matching vllm_patches/config_vllm_*.patch."
+    echo ""
+    echo "  v14-v25 patches add the profiler_config.capture_torch_profiler and"
+    echo "  profiler_config.detailed_trace_annotation options, plus graph-capture tracing"
+    echo "  for the V1 model runner."
+    echo ""
+    echo "  v26+ ship both config options upstream, so those patches instead add the"
+    echo "  graph-capture tracing that upstream still lacks: the V2 model runner (decoder"
+    echo "  and speculator, plus the encoder from v0.28.0) and the V1 encoder. Traces are"
+    echo "  written per subsystem as graph_capture_rank_0[_encoder|_speculator].*."
     echo ""
     echo "Examples:"
     echo "  $0 v14 /home/user/TraceLens -t tracelens-vllm"
@@ -81,12 +87,26 @@ case "${VLLM_VERSION}" in
         BASE_IMAGE="vllm/vllm-openai-rocm:v0.25.0"
         PATCH_FILE="config_vllm_v0.25.0.patch"
         ;;
+    v26)
+        BASE_IMAGE="vllm/vllm-openai-rocm:v0.26.0"
+        PATCH_FILE="config_vllm_v0.26.0.patch"
+        ;;
+    v27)
+        BASE_IMAGE="vllm/vllm-openai-rocm:v0.27.0"
+        PATCH_FILE="config_vllm_v0.27.0.patch"
+        ;;
+    v28)
+        BASE_IMAGE="vllm/vllm-openai-rocm:v0.28.0"
+        PATCH_FILE="config_vllm_v0.28.0.patch"
+        ;;
     *)
         echo "Error: unsupported vllm version '${VLLM_VERSION}'"
-        echo "Supported versions: v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25"
+        echo "Supported versions: v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28"
         echo ""
         echo "vLLM v0.26.0 and later ship capture_torch_profiler and detailed_trace_annotation"
-        echo "upstream, so no patched image is needed: run a stock upstream image."
+        echo "upstream, so the v26+ patches only add graph-capture tracing to the paths"
+        echo "upstream still leaves untraced: the V2 model runner and the V1 encoder. A stock"
+        echo "image is enough if you only need V1 decoder capture traces."
         exit 1
         ;;
 esac

--- a/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.26.0.patch
+++ b/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.26.0.patch
@@ -1,0 +1,279 @@
+diff --git a/vllm/profiler/graph_capture.py b/vllm/profiler/graph_capture.py
+new file mode 100644
+index 0000000000..e9c6e67176
+--- /dev/null
++++ b/vllm/profiler/graph_capture.py
+@@ -0,0 +1,127 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++"""Torch profiler helpers for CUDA/HIP graph capture tracing.
++
++Graph capture is driven by three subsystems (encoder, decoder and speculator)
++that reach the same handful of capture loops by different routes.
++``graph_capture_profiler`` binds one profiler around a subsystem's capture,
++and ``graph_capture_step`` picks that binding up inside whichever capture loop
++ends up running. Capture loops therefore carry no profiler plumbing, and a new
++speculator built on an existing capture loop is traced without further changes.
++"""
++
++from __future__ import annotations
++
++import contextvars
++from collections.abc import Iterator
++from contextlib import AbstractContextManager, contextmanager, nullcontext
++from dataclasses import dataclass
++from typing import Any
++
++import torch
++
++from vllm.config import VllmConfig
++from vllm.distributed.parallel_state import get_world_group
++from vllm.logger import init_logger
++
++logger = init_logger(__name__)
++
++
++@dataclass(frozen=True)
++class _CaptureBinding:
++    profiler: AbstractContextManager[Any]
++    label_prefix: str | None
++
++
++_active_binding: contextvars.ContextVar[_CaptureBinding | None] = (
++    contextvars.ContextVar("vllm_graph_capture_binding", default=None)
++)
++
++
++def _make_profiler(
++    vllm_config: VllmConfig,
++    subsystem: str | None,
++) -> AbstractContextManager[Any]:
++    profiler_config = vllm_config.profiler_config
++    local_rank = get_world_group().local_rank
++    if local_rank != 0 or not profiler_config.capture_torch_profiler:
++        logger.info_once(
++            "Rank %d: Torch profiler disabled for CUDA graph capture", local_rank
++        )
++        return nullcontext()
++
++    trace_dir = profiler_config.torch_profiler_dir + "/capture_traces"
++    worker_name = f"graph_capture_rank_{local_rank}"
++    if subsystem:
++        worker_name += f"_{subsystem}"
++    logger.info_once(
++        "Rank %d: Torch profiler enabled for %s CUDA graph capture, "
++        "traces will be saved to: %s",
++        local_rank,
++        subsystem or "decoder",
++        trace_dir,
++    )
++    return torch.profiler.profile(
++        activities=[
++            torch.profiler.ProfilerActivity.CPU,
++            torch.profiler.ProfilerActivity.CUDA,
++        ],
++        record_shapes=True,
++        profile_memory=True,
++        with_stack=True,
++        on_trace_ready=torch.profiler.tensorboard_trace_handler(
++            trace_dir,
++            worker_name=worker_name,
++            use_gzip=True,
++        ),
++    )
++
++
++@contextmanager
++def graph_capture_profiler(
++    vllm_config: VllmConfig,
++    subsystem: str | None = None,
++    label_prefix: str | None = None,
++) -> Iterator[None]:
++    """Bind a graph-capture profiler for one subsystem's capture.
++
++    Args:
++        subsystem: Suffix for the trace file name. ``"encoder"`` writes
++            ``graph_capture_rank_0_encoder.<timestamp>.pt.trace.json.gz``;
++            the main decoder passes ``None`` and keeps the unsuffixed name.
++        label_prefix: Inserted into every annotation recorded inside the
++            block, so that e.g. speculator graphs are labelled
++            ``capture_32_draft_FULL`` rather than reusing the decoder's
++            ``capture_32_FULL``.
++    """
++    binding = _CaptureBinding(
++        profiler=_make_profiler(vllm_config, subsystem),
++        label_prefix=label_prefix,
++    )
++    token = _active_binding.set(binding)
++    try:
++        yield
++    finally:
++        _active_binding.reset(token)
++
++
++@contextmanager
++def graph_capture_step(num_tokens: int, mode: str) -> Iterator[None]:
++    """Profile the capture of a single graph shape.
++
++    Records a ``capture_{num_tokens}_{mode}`` annotation, or
++    ``capture_{num_tokens}_{label_prefix}_{mode}`` when the active binding
++    sets a prefix. Does nothing outside a ``graph_capture_profiler`` block, so
++    capture loops can call this unconditionally.
++    """
++    binding = _active_binding.get()
++    if binding is None:
++        yield
++        return
++
++    if binding.label_prefix:
++        label = f"capture_{num_tokens}_{binding.label_prefix}_{mode}"
++    else:
++        label = f"capture_{num_tokens}_{mode}"
++    with binding.profiler, torch.profiler.record_function(label):
++        yield
+diff --git a/vllm/v1/worker/encoder_cudagraph.py b/vllm/v1/worker/encoder_cudagraph.py
+index d3c5481289..ab3919cac0 100644
+--- a/vllm/v1/worker/encoder_cudagraph.py
++++ b/vllm/v1/worker/encoder_cudagraph.py
+@@ -19,6 +19,7 @@ from vllm.model_executor.models.interfaces import (
+ )
+ from vllm.model_executor.models.utils import scatter_output_slices
+ from vllm.model_executor.models.vision import get_load_balance_assignment
++from vllm.profiler.graph_capture import graph_capture_step
+ from vllm.v1.worker.encoder_cudagraph_defs import (
+     EncoderCudaGraphConfig,
+     EncoderItemSpec,
+@@ -277,7 +278,11 @@ class EncoderCudaGraphManager:
+             output_buffer = torch.empty_like(output)
+ 
+         graph = torch.cuda.CUDAGraph()
+-        with torch.inference_mode(), torch.cuda.graph(graph, pool=self.graph_pool):
++        with (
++            graph_capture_step(token_budget, path),
++            torch.inference_mode(),
++            torch.cuda.graph(graph, pool=self.graph_pool),
++        ):
+             output = self.model.encoder_cudagraph_forward({**values}, path=path)
+             output_buffer.copy_(output)
+ 
+diff --git a/vllm/v1/worker/gpu/cudagraph_utils.py b/vllm/v1/worker/gpu/cudagraph_utils.py
+index 27fd554725..9831f0a757 100644
+--- a/vllm/v1/worker/gpu/cudagraph_utils.py
++++ b/vllm/v1/worker/gpu/cudagraph_utils.py
+@@ -26,6 +26,7 @@ from vllm.forward_context import BatchDescriptor, set_forward_context
+ from vllm.logger import init_logger
+ from vllm.model_executor.offloader.base import get_offloader
+ from vllm.platforms import current_platform
++from vllm.profiler.graph_capture import graph_capture_step
+ from vllm.sequence import IntermediateTensors
+ from vllm.utils.math_utils import round_up
+ from vllm.v1.kv_cache_interface import KVCacheConfig
+@@ -332,12 +333,16 @@ class CudaGraphManager:
+                         desc.cg_mode == CUDAGraphMode.PIECEWISE
+                         and not self.use_breakable_cg
+                     ):
+-                        forward_fn(CUDAGraphMode.PIECEWISE)
++                        with graph_capture_step(desc.num_tokens, desc.cg_mode.name):
++                            forward_fn(CUDAGraphMode.PIECEWISE)
+                     else:
+                         # Capture with fresh attention state.
+                         forward_fn = create_forward_fn(desc, warmup=False)
+                         if desc.cg_mode == CUDAGraphMode.PIECEWISE:
+-                            forward_fn(CUDAGraphMode.PIECEWISE)
++                            with graph_capture_step(
++                                desc.num_tokens, desc.cg_mode.name
++                            ):
++                                forward_fn(CUDAGraphMode.PIECEWISE)
+                             continue
+                         assert desc not in self.graphs, (
+                             f"Graph already captured for {desc}"
+@@ -346,7 +351,10 @@ class CudaGraphManager:
+                         # Sync offloader's copy stream before capture.
+                         # Ensure any pre-capture prefetches from offloader are complete.
+                         get_offloader().sync_prev_onload()
+-                        with torch.cuda.graph(graph, self.pool):
++                        with (
++                            graph_capture_step(desc.num_tokens, desc.cg_mode.name),
++                            torch.cuda.graph(graph, self.pool),
++                        ):
+                             forward_fn(CUDAGraphMode.NONE)
+                             # Join offloader's copy stream after forward to avoid
+                             # unjoined stream error. The last layer's start_prefetch
+diff --git a/vllm/v1/worker/gpu/model_runner.py b/vllm/v1/worker/gpu/model_runner.py
+index 293b06ff97..b43fc71933 100644
+--- a/vllm/v1/worker/gpu/model_runner.py
++++ b/vllm/v1/worker/gpu/model_runner.py
+@@ -43,6 +43,7 @@ from vllm.model_executor.layers.mamba.ops.ssu_dispatch import (
+ )
+ from vllm.model_executor.model_loader import get_model_loader
+ from vllm.multimodal import MULTIMODAL_REGISTRY
++from vllm.profiler.graph_capture import graph_capture_profiler
+ from vllm.sequence import IntermediateTensors
+ from vllm.tasks import SupportedTask
+ from vllm.utils.math_utils import cdiv
+@@ -724,20 +725,26 @@ class GPUModelRunner(LoRAModelRunnerMixin):
+         start_free_gpu_memory = torch.accelerator.get_memory_info()[0]
+ 
+         with self.maybe_setup_dummy_loras(self.lora_config):
+-            self.cudagraph_manager.capture(
+-                self.model,
+-                self.model_state,
+-                self.input_buffers,
+-                self.intermediate_tensors,
+-                self.block_tables,
+-                self.attn_groups,
+-                self.kv_cache_config,
+-                has_lora=self.lora_config is not None,
+-                use_aux_hidden_state_outputs=self.use_aux_hidden_state_outputs,
+-                lora_capture_hook=create_lora_capture_hook(self.lora_config, self),
+-            )
++            with graph_capture_profiler(self.vllm_config):
++                self.cudagraph_manager.capture(
++                    self.model,
++                    self.model_state,
++                    self.input_buffers,
++                    self.intermediate_tensors,
++                    self.block_tables,
++                    self.attn_groups,
++                    self.kv_cache_config,
++                    has_lora=self.lora_config is not None,
++                    use_aux_hidden_state_outputs=self.use_aux_hidden_state_outputs,
++                    lora_capture_hook=create_lora_capture_hook(
++                        self.lora_config, self
++                    ),
++                )
+             if self.speculator is not None:
+-                self.speculator.capture()
++                with graph_capture_profiler(
++                    self.vllm_config, subsystem="speculator", label_prefix="draft"
++                ):
++                    self.speculator.capture()
+ 
+         end_time = time.perf_counter()
+         end_free_gpu_memory = torch.accelerator.get_memory_info()[0]
+diff --git a/vllm/v1/worker/gpu_model_runner.py b/vllm/v1/worker/gpu_model_runner.py
+index f3f0afb130..81ab7ff387 100644
+--- a/vllm/v1/worker/gpu_model_runner.py
++++ b/vllm/v1/worker/gpu_model_runner.py
+@@ -113,6 +113,7 @@ from vllm.multimodal.utils import (
+ )
+ from vllm.platforms import current_platform
+ from vllm.pooling_params import PoolingParams
++from vllm.profiler.graph_capture import graph_capture_profiler
+ from vllm.sampling_params import SamplingType
+ from vllm.sequence import IntermediateTensors
+ from vllm.tasks import GenerationTask, PoolingTask, SupportedTask
+@@ -6818,7 +6819,12 @@ class GPUModelRunner(
+             # Capture encoder CUDA graphs if enabled
+             if self.encoder_cudagraph_manager is not None:
+                 encoder_graph_pool = current_platform.graph_pool_handle()
+-                self.encoder_cudagraph_manager.capture(graph_pool=encoder_graph_pool)
++                with graph_capture_profiler(
++                    self.vllm_config, subsystem="encoder", label_prefix="encoder"
++                ):
++                    self.encoder_cudagraph_manager.capture(
++                        graph_pool=encoder_graph_pool
++                    )
+ 
+             torch.accelerator.synchronize()
+             end_free_gpu_memory = torch.accelerator.get_memory_info()[0]

--- a/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.27.0.patch
+++ b/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.27.0.patch
@@ -1,0 +1,279 @@
+diff --git a/vllm/profiler/graph_capture.py b/vllm/profiler/graph_capture.py
+new file mode 100644
+index 0000000000..e9c6e67176
+--- /dev/null
++++ b/vllm/profiler/graph_capture.py
+@@ -0,0 +1,127 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++"""Torch profiler helpers for CUDA/HIP graph capture tracing.
++
++Graph capture is driven by three subsystems (encoder, decoder and speculator)
++that reach the same handful of capture loops by different routes.
++``graph_capture_profiler`` binds one profiler around a subsystem's capture,
++and ``graph_capture_step`` picks that binding up inside whichever capture loop
++ends up running. Capture loops therefore carry no profiler plumbing, and a new
++speculator built on an existing capture loop is traced without further changes.
++"""
++
++from __future__ import annotations
++
++import contextvars
++from collections.abc import Iterator
++from contextlib import AbstractContextManager, contextmanager, nullcontext
++from dataclasses import dataclass
++from typing import Any
++
++import torch
++
++from vllm.config import VllmConfig
++from vllm.distributed.parallel_state import get_world_group
++from vllm.logger import init_logger
++
++logger = init_logger(__name__)
++
++
++@dataclass(frozen=True)
++class _CaptureBinding:
++    profiler: AbstractContextManager[Any]
++    label_prefix: str | None
++
++
++_active_binding: contextvars.ContextVar[_CaptureBinding | None] = (
++    contextvars.ContextVar("vllm_graph_capture_binding", default=None)
++)
++
++
++def _make_profiler(
++    vllm_config: VllmConfig,
++    subsystem: str | None,
++) -> AbstractContextManager[Any]:
++    profiler_config = vllm_config.profiler_config
++    local_rank = get_world_group().local_rank
++    if local_rank != 0 or not profiler_config.capture_torch_profiler:
++        logger.info_once(
++            "Rank %d: Torch profiler disabled for CUDA graph capture", local_rank
++        )
++        return nullcontext()
++
++    trace_dir = profiler_config.torch_profiler_dir + "/capture_traces"
++    worker_name = f"graph_capture_rank_{local_rank}"
++    if subsystem:
++        worker_name += f"_{subsystem}"
++    logger.info_once(
++        "Rank %d: Torch profiler enabled for %s CUDA graph capture, "
++        "traces will be saved to: %s",
++        local_rank,
++        subsystem or "decoder",
++        trace_dir,
++    )
++    return torch.profiler.profile(
++        activities=[
++            torch.profiler.ProfilerActivity.CPU,
++            torch.profiler.ProfilerActivity.CUDA,
++        ],
++        record_shapes=True,
++        profile_memory=True,
++        with_stack=True,
++        on_trace_ready=torch.profiler.tensorboard_trace_handler(
++            trace_dir,
++            worker_name=worker_name,
++            use_gzip=True,
++        ),
++    )
++
++
++@contextmanager
++def graph_capture_profiler(
++    vllm_config: VllmConfig,
++    subsystem: str | None = None,
++    label_prefix: str | None = None,
++) -> Iterator[None]:
++    """Bind a graph-capture profiler for one subsystem's capture.
++
++    Args:
++        subsystem: Suffix for the trace file name. ``"encoder"`` writes
++            ``graph_capture_rank_0_encoder.<timestamp>.pt.trace.json.gz``;
++            the main decoder passes ``None`` and keeps the unsuffixed name.
++        label_prefix: Inserted into every annotation recorded inside the
++            block, so that e.g. speculator graphs are labelled
++            ``capture_32_draft_FULL`` rather than reusing the decoder's
++            ``capture_32_FULL``.
++    """
++    binding = _CaptureBinding(
++        profiler=_make_profiler(vllm_config, subsystem),
++        label_prefix=label_prefix,
++    )
++    token = _active_binding.set(binding)
++    try:
++        yield
++    finally:
++        _active_binding.reset(token)
++
++
++@contextmanager
++def graph_capture_step(num_tokens: int, mode: str) -> Iterator[None]:
++    """Profile the capture of a single graph shape.
++
++    Records a ``capture_{num_tokens}_{mode}`` annotation, or
++    ``capture_{num_tokens}_{label_prefix}_{mode}`` when the active binding
++    sets a prefix. Does nothing outside a ``graph_capture_profiler`` block, so
++    capture loops can call this unconditionally.
++    """
++    binding = _active_binding.get()
++    if binding is None:
++        yield
++        return
++
++    if binding.label_prefix:
++        label = f"capture_{num_tokens}_{binding.label_prefix}_{mode}"
++    else:
++        label = f"capture_{num_tokens}_{mode}"
++    with binding.profiler, torch.profiler.record_function(label):
++        yield
+diff --git a/vllm/v1/worker/encoder_cudagraph.py b/vllm/v1/worker/encoder_cudagraph.py
+index 0b3543da1e..8e49bf259a 100644
+--- a/vllm/v1/worker/encoder_cudagraph.py
++++ b/vllm/v1/worker/encoder_cudagraph.py
+@@ -19,6 +19,7 @@ from vllm.model_executor.models.interfaces import (
+ )
+ from vllm.model_executor.models.utils import scatter_output_slices
+ from vllm.model_executor.models.vision import get_load_balance_assignment
++from vllm.profiler.graph_capture import graph_capture_step
+ from vllm.v1.worker.encoder_cudagraph_defs import (
+     EncoderCudaGraphConfig,
+     EncoderItemSpec,
+@@ -265,7 +266,11 @@ class EncoderCudaGraphManager:
+             output_buffer = torch.empty_like(output)
+ 
+         graph = torch.cuda.CUDAGraph()
+-        with torch.inference_mode(), torch.cuda.graph(graph, pool=self.graph_pool):
++        with (
++            graph_capture_step(token_budget, path),
++            torch.inference_mode(),
++            torch.cuda.graph(graph, pool=self.graph_pool),
++        ):
+             output = self.model.encoder_cudagraph_forward({**values}, path=path)
+             output_buffer.copy_(output)
+ 
+diff --git a/vllm/v1/worker/gpu/cudagraph_utils.py b/vllm/v1/worker/gpu/cudagraph_utils.py
+index 3a174cba80..21213f6c0e 100644
+--- a/vllm/v1/worker/gpu/cudagraph_utils.py
++++ b/vllm/v1/worker/gpu/cudagraph_utils.py
+@@ -27,6 +27,7 @@ from vllm.forward_context import BatchDescriptor, set_forward_context
+ from vllm.logger import init_logger
+ from vllm.model_executor.offloader.base import get_offloader
+ from vllm.platforms import current_platform
++from vllm.profiler.graph_capture import graph_capture_step
+ from vllm.sequence import IntermediateTensors
+ from vllm.utils.math_utils import round_up
+ from vllm.v1.kv_cache_interface import KVCacheConfig
+@@ -333,12 +334,16 @@ class CudaGraphManager:
+                         desc.cg_mode == CUDAGraphMode.PIECEWISE
+                         and not self.use_breakable_cg
+                     ):
+-                        forward_fn(CUDAGraphMode.PIECEWISE)
++                        with graph_capture_step(desc.num_tokens, desc.cg_mode.name):
++                            forward_fn(CUDAGraphMode.PIECEWISE)
+                     else:
+                         # Capture with fresh attention state.
+                         forward_fn = create_forward_fn(desc, warmup=False)
+                         if desc.cg_mode == CUDAGraphMode.PIECEWISE:
+-                            forward_fn(CUDAGraphMode.PIECEWISE)
++                            with graph_capture_step(
++                                desc.num_tokens, desc.cg_mode.name
++                            ):
++                                forward_fn(CUDAGraphMode.PIECEWISE)
+                             continue
+                         assert desc not in self.graphs, (
+                             f"Graph already captured for {desc}"
+@@ -351,7 +356,10 @@ class CudaGraphManager:
+                             set_graph_pool_id(self.pool)
+                         else:
+                             set_graph_pool_id(current_platform.graph_pool_handle())
+-                        with torch.cuda.graph(graph, self.pool):
++                        with (
++                            graph_capture_step(desc.num_tokens, desc.cg_mode.name),
++                            torch.cuda.graph(graph, self.pool),
++                        ):
+                             forward_fn(CUDAGraphMode.NONE)
+                             # Join offloader's copy stream after forward to avoid
+                             # unjoined stream error. The last layer's start_prefetch
+diff --git a/vllm/v1/worker/gpu/model_runner.py b/vllm/v1/worker/gpu/model_runner.py
+index cea735c0e8..cfe9e936dc 100644
+--- a/vllm/v1/worker/gpu/model_runner.py
++++ b/vllm/v1/worker/gpu/model_runner.py
+@@ -48,6 +48,7 @@ from vllm.multimodal.encoder_budget import (
+     MultiModalBudget,
+     get_dummy_encoder_profile_inputs,
+ )
++from vllm.profiler.graph_capture import graph_capture_profiler
+ from vllm.sequence import IntermediateTensors
+ from vllm.tasks import SupportedTask
+ from vllm.utils.math_utils import cdiv
+@@ -768,20 +769,26 @@ class GPUModelRunner(LoRAModelRunnerMixin):
+         start_free_gpu_memory = torch.accelerator.get_memory_info()[0]
+ 
+         with self.maybe_setup_dummy_loras(self.lora_config):
+-            self.cudagraph_manager.capture(
+-                self.model,
+-                self.model_state,
+-                self.input_buffers,
+-                self.intermediate_tensors,
+-                self.block_tables,
+-                self.attn_groups,
+-                self.kv_cache_config,
+-                has_lora=self.lora_config is not None,
+-                use_aux_hidden_state_outputs=self.use_aux_hidden_state_outputs,
+-                lora_capture_hook=create_lora_capture_hook(self.lora_config, self),
+-            )
++            with graph_capture_profiler(self.vllm_config):
++                self.cudagraph_manager.capture(
++                    self.model,
++                    self.model_state,
++                    self.input_buffers,
++                    self.intermediate_tensors,
++                    self.block_tables,
++                    self.attn_groups,
++                    self.kv_cache_config,
++                    has_lora=self.lora_config is not None,
++                    use_aux_hidden_state_outputs=self.use_aux_hidden_state_outputs,
++                    lora_capture_hook=create_lora_capture_hook(
++                        self.lora_config, self
++                    ),
++                )
+             if self.speculator is not None:
+-                self.speculator.capture()
++                with graph_capture_profiler(
++                    self.vllm_config, subsystem="speculator", label_prefix="draft"
++                ):
++                    self.speculator.capture()
+ 
+         end_time = time.perf_counter()
+         end_free_gpu_memory = torch.accelerator.get_memory_info()[0]
+diff --git a/vllm/v1/worker/gpu_model_runner.py b/vllm/v1/worker/gpu_model_runner.py
+index 859cec2781..2d7feb35c4 100644
+--- a/vllm/v1/worker/gpu_model_runner.py
++++ b/vllm/v1/worker/gpu_model_runner.py
+@@ -115,6 +115,7 @@ from vllm.multimodal.utils import (
+ )
+ from vllm.platforms import current_platform
+ from vllm.pooling_params import PoolingParams
++from vllm.profiler.graph_capture import graph_capture_profiler
+ from vllm.sampling_params import SamplingType
+ from vllm.sequence import IntermediateTensors
+ from vllm.tasks import GenerationTask, PoolingTask, SupportedTask
+@@ -6887,7 +6888,12 @@ class GPUModelRunner(
+             # Capture encoder CUDA graphs if enabled
+             if self.encoder_cudagraph_manager is not None:
+                 encoder_graph_pool = current_platform.graph_pool_handle()
+-                self.encoder_cudagraph_manager.capture(graph_pool=encoder_graph_pool)
++                with graph_capture_profiler(
++                    self.vllm_config, subsystem="encoder", label_prefix="encoder"
++                ):
++                    self.encoder_cudagraph_manager.capture(
++                        graph_pool=encoder_graph_pool
++                    )
+ 
+             torch.accelerator.synchronize()
+             end_free_gpu_memory = torch.accelerator.get_memory_info()[0]

--- a/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.28.0.patch
+++ b/examples/custom_workflows/inference_analysis/vllm_patches/config_vllm_v0.28.0.patch
@@ -1,0 +1,290 @@
+diff --git a/vllm/profiler/graph_capture.py b/vllm/profiler/graph_capture.py
+new file mode 100644
+index 0000000000..e9c6e67176
+--- /dev/null
++++ b/vllm/profiler/graph_capture.py
+@@ -0,0 +1,127 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++"""Torch profiler helpers for CUDA/HIP graph capture tracing.
++
++Graph capture is driven by three subsystems (encoder, decoder and speculator)
++that reach the same handful of capture loops by different routes.
++``graph_capture_profiler`` binds one profiler around a subsystem's capture,
++and ``graph_capture_step`` picks that binding up inside whichever capture loop
++ends up running. Capture loops therefore carry no profiler plumbing, and a new
++speculator built on an existing capture loop is traced without further changes.
++"""
++
++from __future__ import annotations
++
++import contextvars
++from collections.abc import Iterator
++from contextlib import AbstractContextManager, contextmanager, nullcontext
++from dataclasses import dataclass
++from typing import Any
++
++import torch
++
++from vllm.config import VllmConfig
++from vllm.distributed.parallel_state import get_world_group
++from vllm.logger import init_logger
++
++logger = init_logger(__name__)
++
++
++@dataclass(frozen=True)
++class _CaptureBinding:
++    profiler: AbstractContextManager[Any]
++    label_prefix: str | None
++
++
++_active_binding: contextvars.ContextVar[_CaptureBinding | None] = (
++    contextvars.ContextVar("vllm_graph_capture_binding", default=None)
++)
++
++
++def _make_profiler(
++    vllm_config: VllmConfig,
++    subsystem: str | None,
++) -> AbstractContextManager[Any]:
++    profiler_config = vllm_config.profiler_config
++    local_rank = get_world_group().local_rank
++    if local_rank != 0 or not profiler_config.capture_torch_profiler:
++        logger.info_once(
++            "Rank %d: Torch profiler disabled for CUDA graph capture", local_rank
++        )
++        return nullcontext()
++
++    trace_dir = profiler_config.torch_profiler_dir + "/capture_traces"
++    worker_name = f"graph_capture_rank_{local_rank}"
++    if subsystem:
++        worker_name += f"_{subsystem}"
++    logger.info_once(
++        "Rank %d: Torch profiler enabled for %s CUDA graph capture, "
++        "traces will be saved to: %s",
++        local_rank,
++        subsystem or "decoder",
++        trace_dir,
++    )
++    return torch.profiler.profile(
++        activities=[
++            torch.profiler.ProfilerActivity.CPU,
++            torch.profiler.ProfilerActivity.CUDA,
++        ],
++        record_shapes=True,
++        profile_memory=True,
++        with_stack=True,
++        on_trace_ready=torch.profiler.tensorboard_trace_handler(
++            trace_dir,
++            worker_name=worker_name,
++            use_gzip=True,
++        ),
++    )
++
++
++@contextmanager
++def graph_capture_profiler(
++    vllm_config: VllmConfig,
++    subsystem: str | None = None,
++    label_prefix: str | None = None,
++) -> Iterator[None]:
++    """Bind a graph-capture profiler for one subsystem's capture.
++
++    Args:
++        subsystem: Suffix for the trace file name. ``"encoder"`` writes
++            ``graph_capture_rank_0_encoder.<timestamp>.pt.trace.json.gz``;
++            the main decoder passes ``None`` and keeps the unsuffixed name.
++        label_prefix: Inserted into every annotation recorded inside the
++            block, so that e.g. speculator graphs are labelled
++            ``capture_32_draft_FULL`` rather than reusing the decoder's
++            ``capture_32_FULL``.
++    """
++    binding = _CaptureBinding(
++        profiler=_make_profiler(vllm_config, subsystem),
++        label_prefix=label_prefix,
++    )
++    token = _active_binding.set(binding)
++    try:
++        yield
++    finally:
++        _active_binding.reset(token)
++
++
++@contextmanager
++def graph_capture_step(num_tokens: int, mode: str) -> Iterator[None]:
++    """Profile the capture of a single graph shape.
++
++    Records a ``capture_{num_tokens}_{mode}`` annotation, or
++    ``capture_{num_tokens}_{label_prefix}_{mode}`` when the active binding
++    sets a prefix. Does nothing outside a ``graph_capture_profiler`` block, so
++    capture loops can call this unconditionally.
++    """
++    binding = _active_binding.get()
++    if binding is None:
++        yield
++        return
++
++    if binding.label_prefix:
++        label = f"capture_{num_tokens}_{binding.label_prefix}_{mode}"
++    else:
++        label = f"capture_{num_tokens}_{mode}"
++    with binding.profiler, torch.profiler.record_function(label):
++        yield
+diff --git a/vllm/v1/worker/encoder_cudagraph.py b/vllm/v1/worker/encoder_cudagraph.py
+index 04a54a39a0..79e33f83df 100644
+--- a/vllm/v1/worker/encoder_cudagraph.py
++++ b/vllm/v1/worker/encoder_cudagraph.py
+@@ -19,6 +19,7 @@ from vllm.model_executor.models.interfaces import (
+ )
+ from vllm.model_executor.models.utils import scatter_output_slices
+ from vllm.model_executor.models.vision import get_load_balance_assignment
++from vllm.profiler.graph_capture import graph_capture_step
+ from vllm.utils.gpu_sync_debug import gpu_sync_allowed
+ from vllm.v1.worker.encoder_cudagraph_defs import (
+     EncoderCudaGraphConfig,
+@@ -270,7 +271,11 @@ class EncoderCudaGraphManager:
+             output_buffer = torch.empty_like(output)
+ 
+         graph = torch.cuda.CUDAGraph()
+-        with torch.inference_mode(), torch.cuda.graph(graph, pool=self.graph_pool):
++        with (
++            graph_capture_step(token_budget, path),
++            torch.inference_mode(),
++            torch.cuda.graph(graph, pool=self.graph_pool),
++        ):
+             output = self.model.encoder_cudagraph_forward({**values}, path=path)
+             output_buffer.copy_(output)
+ 
+diff --git a/vllm/v1/worker/gpu/cudagraph_utils.py b/vllm/v1/worker/gpu/cudagraph_utils.py
+index 8e24a0ee02..4b3ae0fdeb 100644
+--- a/vllm/v1/worker/gpu/cudagraph_utils.py
++++ b/vllm/v1/worker/gpu/cudagraph_utils.py
+@@ -27,6 +27,7 @@ from vllm.forward_context import BatchDescriptor, set_forward_context
+ from vllm.logger import init_logger
+ from vllm.model_executor.offloader.base import get_offloader
+ from vllm.platforms import current_platform
++from vllm.profiler.graph_capture import graph_capture_step
+ from vllm.sequence import IntermediateTensors
+ from vllm.utils.math_utils import round_up
+ from vllm.v1.kv_cache_interface import KVCacheConfig
+@@ -344,12 +345,16 @@ class CudaGraphManager:
+                         desc.cg_mode == CUDAGraphMode.PIECEWISE
+                         and not self.use_breakable_cg
+                     ):
+-                        forward_fn(CUDAGraphMode.PIECEWISE)
++                        with graph_capture_step(desc.num_tokens, desc.cg_mode.name):
++                            forward_fn(CUDAGraphMode.PIECEWISE)
+                     else:
+                         # Capture with fresh attention state.
+                         forward_fn = create_forward_fn(desc, warmup=False)
+                         if desc.cg_mode == CUDAGraphMode.PIECEWISE:
+-                            forward_fn(CUDAGraphMode.PIECEWISE)
++                            with graph_capture_step(
++                                desc.num_tokens, desc.cg_mode.name
++                            ):
++                                forward_fn(CUDAGraphMode.PIECEWISE)
+                             continue
+                         assert desc not in self.graphs, (
+                             f"Graph already captured for {desc}"
+@@ -362,7 +367,10 @@ class CudaGraphManager:
+                             set_graph_pool_id(self.pool)
+                         else:
+                             set_graph_pool_id(current_platform.graph_pool_handle())
+-                        with torch.cuda.graph(graph, self.pool):
++                        with (
++                            graph_capture_step(desc.num_tokens, desc.cg_mode.name),
++                            torch.cuda.graph(graph, self.pool),
++                        ):
+                             forward_fn(CUDAGraphMode.NONE)
+                             # Join offloader's copy stream after forward to avoid
+                             # unjoined stream error. The last layer's start_prefetch
+diff --git a/vllm/v1/worker/gpu/model_runner.py b/vllm/v1/worker/gpu/model_runner.py
+index d68666cf4a..b96db1f4db 100644
+--- a/vllm/v1/worker/gpu/model_runner.py
++++ b/vllm/v1/worker/gpu/model_runner.py
+@@ -56,6 +56,7 @@ from vllm.multimodal.encoder_budget import (
+     MultiModalBudget,
+     get_dummy_encoder_profile_inputs,
+ )
++from vllm.profiler.graph_capture import graph_capture_profiler
+ from vllm.sequence import IntermediateTensors
+ from vllm.tasks import SupportedTask
+ from vllm.utils.math_utils import cdiv
+@@ -872,23 +873,36 @@ class GPUModelRunner(LoRAModelRunnerMixin):
+ 
+         with self.maybe_setup_dummy_loras(self.lora_config):
+             if capture_encoder:
+-                self.model_state.encoder_runner.capture()
++                with graph_capture_profiler(
++                    self.vllm_config, subsystem="encoder", label_prefix="encoder"
++                ):
++                    self.model_state.encoder_runner.capture()
+ 
+             if capture_decoder:
+-                self.cudagraph_manager.capture(
+-                    self.model,
+-                    self.model_state,
+-                    self.input_buffers,
+-                    self.intermediate_tensors,
+-                    self.block_tables,
+-                    self.attn_groups,
+-                    self.kv_cache_config,
+-                    has_lora=self.lora_config is not None,
+-                    use_aux_hidden_state_outputs=self.use_aux_hidden_state_outputs,
+-                    lora_capture_hook=create_lora_capture_hook(self.lora_config, self),
+-                )
++                with graph_capture_profiler(self.vllm_config):
++                    self.cudagraph_manager.capture(
++                        self.model,
++                        self.model_state,
++                        self.input_buffers,
++                        self.intermediate_tensors,
++                        self.block_tables,
++                        self.attn_groups,
++                        self.kv_cache_config,
++                        has_lora=self.lora_config is not None,
++                        use_aux_hidden_state_outputs=self.use_aux_hidden_state_outputs,
++                        lora_capture_hook=create_lora_capture_hook(
++                            self.lora_config, self
++                        ),
++                    )
+                 if self.speculator is not None:
+-                    with use_workspace_lane(self._draft_workspace_lane):
++                    with (
++                        use_workspace_lane(self._draft_workspace_lane),
++                        graph_capture_profiler(
++                            self.vllm_config,
++                            subsystem="speculator",
++                            label_prefix="draft",
++                        ),
++                    ):
+                         self.speculator.capture()
+                 if self.adaptive_verification is not None:
+                     with self.step_timing.collect() as timings:
+diff --git a/vllm/v1/worker/gpu_model_runner.py b/vllm/v1/worker/gpu_model_runner.py
+index 9087f87854..a086452543 100644
+--- a/vllm/v1/worker/gpu_model_runner.py
++++ b/vllm/v1/worker/gpu_model_runner.py
+@@ -115,6 +115,7 @@ from vllm.multimodal.utils import (
+ )
+ from vllm.platforms import current_platform
+ from vllm.pooling_params import PoolingParams
++from vllm.profiler.graph_capture import graph_capture_profiler
+ from vllm.sampling_params import SamplingType
+ from vllm.sequence import IntermediateTensors
+ from vllm.tasks import GenerationTask, PoolingTask, SupportedTask
+@@ -7022,7 +7023,12 @@ class GPUModelRunner(
+             # Capture encoder CUDA graphs if enabled
+             if self.encoder_cudagraph_manager is not None:
+                 encoder_graph_pool = current_platform.graph_pool_handle()
+-                self.encoder_cudagraph_manager.capture(graph_pool=encoder_graph_pool)
++                with graph_capture_profiler(
++                    self.vllm_config, subsystem="encoder", label_prefix="encoder"
++                ):
++                    self.encoder_cudagraph_manager.capture(
++                        graph_pool=encoder_graph_pool
++                    )
+ 
+             torch.accelerator.synchronize()
+             end_free_gpu_memory = torch.accelerator.get_memory_info()[0]


### PR DESCRIPTION
This pull request extends the `build_docker_vllm.sh` script and adds new patches to support vLLM versions v0.26.0 through v0.28.0. It introduces improved graph-capture tracing for CUDA/HIP profiling in these newer versions, ensuring that all relevant subsystems (decoder, speculator, encoder) are properly traced. The main changes are grouped as follows:

**Script and Versioning Updates:**

* Updated `build_docker_vllm.sh` to support vLLM versions v26, v27, and v28, including their corresponding patch files and improved documentation for tracing behavior in these versions. [[1]](diffhunk://#diff-e87f62fd28a41719f1735a23b6aacd929284e4f592d3311e5f5ffc13fa24aa26L13-R25) [[2]](diffhunk://#diff-e87f62fd28a41719f1735a23b6aacd929284e4f592d3311e5f5ffc13fa24aa26R90-R109)

**Graph-Capture Tracing Enhancements (v0.26.0+):**

* Added a new patch (`config_vllm_v0.26.0.patch`) that introduces `vllm/profiler/graph_capture.py`, providing context-managed helpers to bind and annotate torch profiler traces during CUDA graph capture for encoder, decoder, and speculator subsystems.
* Integrated `graph_capture_profiler` and `graph_capture_step` into key vLLM worker modules to ensure that graph-capture tracing is performed per subsystem, and trace files are written with subsystem-specific names.
* Updated tracing logic so that for v0.26.0 and later, the patches focus on adding graph-capture tracing to areas that upstream vLLM does not yet cover, rather than duplicating config options now present upstream. [[1]](diffhunk://#diff-e87f62fd28a41719f1735a23b6aacd929284e4f592d3311e5f5ffc13fa24aa26L13-R25) [[2]](diffhunk://#diff-e87f62fd28a41719f1735a23b6aacd929284e4f592d3311e5f5ffc13fa24aa26R90-R109)
## Test Result

**Environment:** 1× MI355X (gfx950), TP=1, ROCm 7.2.3, PyTorch 2.11.0, ROCm base images for
vLLM v0.26.0 / v0.27.0 / v0.28.0 with this change applied. Traces collected with
`--profiler-config.capture_torch_profiler True --profiler-config.detailed_trace_annotation True`.

### 1. The gap this closes (v0.26.0, Qwen3-8B + `AngelSlim/Qwen3-8B_eagle3`, 3 draft tokens)

`capture_torch_profiler` was accepted but silently produced nothing on the V2 runner, because only
the legacy `GPUModelRunner.capture_model()` path was instrumented:

| Build | Model runner | Graph-capture shards emitted |
|---|---|---|
| stock v0.26.0 | V2 (default for this model) | **0** — no `capture_traces/` directory created |
| stock v0.26.0 | V1 (`VLLM_USE_V2_MODEL_RUNNER=0`) | 98 |
| **patched** | V2 (default) | **251** (100 decoder + 151 speculator) |

### 2. Coverage matrix (all runs completed, all shards non-empty and loadable)

| vLLM | Workload | Shards (decoder + subsystem) |
|---|---|---|
| v0.26.0 | Qwen3-8B + EAGLE3, V2 runner | 100 + 151 speculator | 
| v0.27.0 | Qwen3-8B + EAGLE3, V2 runner | 100 + 151 speculator | 
| v0.28.0 | Qwen3-8B + EAGLE3, V2 runner | 100 + 151 speculator | 
| v0.28.0 | Qwen2-VL-2B-Instruct, encoder cudagraphs (budgets `[256,512]`) | 102 + 2 encoder | 
| v0.26.0 | gpt-oss-20b MXFP4 (MoE → legacy V1 runner) | 166 | 

The gpt-oss-20b run confirms the legacy V1 path still behaves as before this change: 166 shards for
83 capture sizes × {PIECEWISE, FULL}.

### 3. Subsystem separation and annotation naming

Each subsystem writes its own trace-file group, so shards from concurrent capture invocations no
longer share a filename prefix, and every shard carries a `record_function` annotation identifying
the shape and cudagraph mode:

- `graph_capture_rank_0.*` — `capture_104_FULL`, `capture_104_PIECEWISE`, … (100 distinct
  annotations across 100 shards)
- `graph_capture_rank_0_speculator.*` — `capture_104_draft_FULL`, `capture_104_draft_PIECEWISE`, …
  (151 shards, 102 distinct annotations; the 49 `*_draft_FULL` shapes captured by both drafter
  capture invocations appear once per invocation, each in its own shard file)
- `graph_capture_rank_0_encoder.*` — `capture_256_encoder_default`, `capture_512_encoder_default`

<!--
Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.

See LICENSE for license information.
-->

