### PR TITLE
Codex Support

### DIFF
--- a/TraceLens/Agent/Analysis/README.md
+++ b/TraceLens/Agent/Analysis/README.md
@@ -71,9 +71,7 @@ Roofline analysis compares each measured kernel against your GPU's max-achievabl
 
 ## Quick Start - How to Use
 
-> **Note**: The orchestrator skills are portable and work with agentic runners that support skill-file discovery.
-
-> **Skill paths in the package:** The orchestrator and its subagent prompts live under `TraceLens/Agent/Analysis/skills/analysis-orchestrator/` (`SKILL.md`, `reference.md`, and `agents/*.md`).
+> **Note**: The orchestrator skills are portable and work with agentic runners that support skill-file discovery (for example, Claude Code, Cursor, or Codex). The orchestrator and its subagent prompts live under `TraceLens/Agent/Analysis/skills/analysis-orchestrator/` (`SKILL.md`, `reference.md`, and `agents/*.md`).
 
 ### To run manually:
 

--- a/TraceLens/Agent/Analysis/skills/analysis-orchestrator/SKILL.md
+++ b/TraceLens/Agent/Analysis/skills/analysis-orchestrator/SKILL.md
@@ -42,7 +42,7 @@ Follow **[reference.md](reference.md)** for every step (user prompts, `<prefix>`
 
 ## Rules
 
-- **Subagents:** Use the Task tool **only** where reference.md says “subagent” (Steps **7**, **8**, **10**). The orchestrator runs everything else, including Step 8.5, using the command prefix from `<output_dir>/cache/cmd_prefix.txt` (`{CMD}` substitution).
+- **Subagents:** Use your runner's subagent primitive (the Task tool in Claude Code or Cursor, `spawn_agent` under Codex) **only** where reference.md says “subagent” (Steps **7**, **8**, **10**). The orchestrator runs everything else, including Step 8.5, using the command prefix from `<output_dir>/cache/cmd_prefix.txt` (`{CMD}` substitution).
 - **Language:** Prefer vendor-agnostic terms (GPU kernels, collective communication, vendor GEMM library, DNN primitives, GPU graph). When quoting trace data, real kernel names are fine.
 - **Subagent prompts:** Point each subagent at the checked-in agent file under `TraceLens/Agent/Analysis/skills/analysis-orchestrator/agents/<name>.md` (see reference.md for exact paths and prompt shells).
 

--- a/docs/how-to/agent.md
+++ b/docs/how-to/agent.md
@@ -92,7 +92,7 @@ expects.
 Invoke the agent from any chat session with a capable model using one of the following prompts.
 
 ```{note}
-The orchestrator skills are portable and work with agentic runners that support skill-file discovery.
+The orchestrator skills are portable and work with agentic runners that support skill-file discovery (for example, Claude Code, Cursor, or Codex).
 ```
 
 In a chat with a capable model, invoke one of:


### PR DESCRIPTION
<!--
Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.

See LICENSE for license information.
-->

## Summary

Documents Codex as a supported agent runner for the TraceLens Analysis Agent, now that it has been verified end-to-end against the orchestrator. The two user-facing "supported runners" notes now name Claude Code, Cursor, and Codex, and the orchestrator's subagent rule no longer assumes the Claude-only "Task tool" primitive. Docs-only: 3 files changed, +3 / -5.

## Why

The orchestrator skill and its docs described a portable, runner-agnostic workflow but only ever named runners implicitly, and the one operational rule that mattered for portability — how to spawn subagents — was written as "use the Task tool", which is Claude Code / Cursor terminology. A Codex user following the skill hit a primitive that does not exist under their runner (`spawn_agent`) with no translation. These edits close that gap without changing any workflow behavior.

## What changed

### Docs (3 files)

| File | Change |
|---|---|
| `TraceLens/Agent/Analysis/README.md` | Quick Start portability note now names Claude Code, Cursor, or Codex as example runners; merged the adjacent skill-paths note into the same block. |
| `docs/how-to/agent.md` | Published how-to "Run the agent from a chat" note mirrors the README wording, naming the three runners. |
| `TraceLens/Agent/Analysis/skills/analysis-orchestrator/SKILL.md` | Subagents rule reworded from "Use the Task tool" to "Use your runner's subagent primitive (the Task tool in Claude Code or Cursor, `spawn_agent` under Codex)". |

## Net diff

```
3 files changed, 3 insertions(+), 5 deletions(-)
```
